### PR TITLE
Forward-merge branch-23.10 to branch-23.12

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Get PR Info
         id: get-pr-info
-        uses: rapidsai/shared-action-workflows/get-pr-info@branch-23.10
+        uses: rapidsai/shared-workflows/get-pr-info@branch-23.10
       - name: Run rapids-size-checker
         if: ${{ inputs.enable_check_size }}
         run: rapids-size-checker
@@ -63,7 +63,7 @@ jobs:
           fetch-depth: 0
       - name: Get PR Info
         id: get-pr-info
-        uses: rapidsai/shared-action-workflows/get-pr-info@branch-23.10
+        uses: rapidsai/shared-workflows/get-pr-info@branch-23.10
       - uses: actions/cache@v3
         with:
           path: ~/.cache/pre-commit

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Get PR Info
         if: startsWith(github.ref_name, 'pull-request/')
         id: get-pr-info
-        uses: rapidsai/shared-action-workflows/get-pr-info@branch-23.10
+        uses: rapidsai/shared-workflows/get-pr-info@branch-23.10
       - name: Add PR Info
         if: startsWith(github.ref_name, 'pull-request/')
         run: |

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -120,7 +120,7 @@ jobs:
           persist-credentials: false
 
       - name: Standardize repository information
-        uses: rapidsai/shared-action-workflows/rapids-github-info@branch-23.10
+        uses: rapidsai/shared-workflows/rapids-github-info@branch-23.10
         with:
           repo: ${{ inputs.repo }}
           branch: ${{ inputs.branch }}

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -64,7 +64,7 @@ jobs:
         persist-credentials: false
 
     - name: Standardize repository information
-      uses: rapidsai/shared-action-workflows/rapids-github-info@branch-23.08
+      uses: rapidsai/shared-workflows/rapids-github-info@branch-23.08
       with:
         repo: ${{ inputs.repo }}
         branch: ${{ inputs.branch }}

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -127,7 +127,7 @@ jobs:
         persist-credentials: false
 
     - name: Standardize repository information
-      uses: rapidsai/shared-action-workflows/rapids-github-info@branch-23.08
+      uses: rapidsai/shared-workflows/rapids-github-info@branch-23.08
       with:
         repo: ${{ inputs.repo }}
         branch: ${{ inputs.branch }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# shared-action-workflows
+# shared-workflows
 
 ## Introduction
 

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Copyright (c) 2019-2023, NVIDIA CORPORATION.
 ###########################################
-# shared-action-workflows Version Updater #
+# shared-workflows Version Updater #
 ###########################################
 
 ## Usage
@@ -23,5 +23,5 @@ function sed_runner() {
 }
 
 for FILE in .github/workflows/*.yaml; do
-  sed_runner "/rapidsai\/shared-action-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"
+  sed_runner "/rapidsai\/shared-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"
 done

--- a/get-pr-info/README.md
+++ b/get-pr-info/README.md
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: get-pr-info
-        uses: rapidsai/shared-action-workflows/get-pr-info@main
+        uses: rapidsai/shared-workflows/get-pr-info@main
       - run: echo "${RAPIDS_BASE_BRANCH}"
         env:
           RAPIDS_BASE_BRANCH: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.10` that creates a PR to keep `branch-23.12` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.