### PR TITLE
Fix typo in centos7

### DIFF
--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -59,7 +59,7 @@ jobs:
 
           export MATRICES="
             pull-request:
-              - { CUDA_VER: '11.4.3', LINUX_VER: 'centos', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'latest' }
+              - { CUDA_VER: '11.4.3', LINUX_VER: 'centos7', ARCH: 'amd64', PY_VER: '3.9', GPU: 'v100', DRIVER: 'latest' }
               - { CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }
               - { CUDA_VER: '12.0.1', LINUX_VER: 'ubuntu22.04', ARCH: 'amd64', PY_VER: '3.10', GPU: 'v100', DRIVER: 'latest' }
               - { CUDA_VER: '12.0.1', LINUX_VER: 'ubuntu22.04', ARCH: 'arm64', PY_VER: '3.10', GPU: 'a100', DRIVER: 'latest' }


### PR DESCRIPTION
Just fixes a small typo in `centos7` from #136 