### PR TITLE
Fix devcontainers workflows to support new GHA runners

### DIFF
--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -85,7 +85,7 @@ jobs:
           runCmd: |
             set -e;
 
-            mkdir -p ~/.config/pip/;
+            mkdir -m 0775 -p ~/.config/pip/;
             cat <<EOF >> ~/.config/pip/pip.conf
             [global]
             extra-index-url = https://cibuildwheel:${{ secrets.RAPIDSAI_PYPI_CI_PASSWORD }}@pypi.k8s.rapids.ai/simple

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -71,6 +71,11 @@ jobs:
           echo "REPOSITORY=$(basename $(pwd))" | tee -a "${GITHUB_ENV}";
           cp .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json \
              .devcontainer/devcontainer.json;
+      - if: env.HAS_DEVCONTAINER == 'true' && contains(runner.name, 'rapidsai-') == false
+        name: Patch devcontainer.json for CI
+        run: |
+          jq '.updateRemoteUserUID |= false' .devcontainer/devcontainer.json > /tmp/devcontainer.json
+          mv /tmp/devcontainer.json .devcontainer/devcontainer.json
       - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
         name: Run build in devcontainer
         uses: devcontainers/ci@v0.3


### PR DESCRIPTION
As the new runners are running using `dockerd` rootless, we need to fix some perms issues. This PR is addressing this