### PR TITLE
Add option for additional build jobs

### DIFF
--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -104,7 +104,7 @@ jobs:
           - { CUDA_VER: '12.0.1', ARCH: 'arm64', PY_VER: '3.10', LINUX_VER: 'rockylinux8' }
           "
 
-          if [[ ${{ inputs.debug_mode == 'true' }} ]]; then
+          if [[ ${{ inputs.build-2_28-wheels == 'true' }} ]]; then
               export MATRIX+=${NEW_MANYLINUX_MATRIX}
           fi
 

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -45,6 +45,12 @@ on:
         type: string
         default: ''
 
+      # Build manylinux 2.28 wheels in addition to 2.17 wheels
+      build-2_28-wheels:
+        required: false
+        type: string
+        default: 'false'
+
 defaults:
   run:
     shell: bash
@@ -86,6 +92,21 @@ jobs:
           - { CUDA_VER: '12.0.1', ARCH: 'arm64', PY_VER: '3.9', LINUX_VER: 'ubuntu20.04' }
           - { CUDA_VER: '12.0.1', ARCH: 'arm64', PY_VER: '3.10', LINUX_VER: 'ubuntu20.04' }
           "
+
+          export NEW_MANYLINUX_MATRIX="
+          - { CUDA_VER: '11.8.0', ARCH: 'amd64', PY_VER: '3.9', LINUX_VER: 'rockylinux8' }
+          - { CUDA_VER: '11.8.0', ARCH: 'amd64', PY_VER: '3.10', LINUX_VER: 'rockylinux8' }
+          - { CUDA_VER: '11.8.0', ARCH: 'arm64', PY_VER: '3.9',  LINUX_VER: 'rockylinux8' }
+          - { CUDA_VER: '11.8.0', ARCH: 'arm64', PY_VER: '3.10', LINUX_VER: 'rockylinux8' }
+          - { CUDA_VER: '12.0.1', ARCH: 'amd64', PY_VER: '3.9',  LINUX_VER: 'rockylinux8' }
+          - { CUDA_VER: '12.0.1', ARCH: 'amd64', PY_VER: '3.10',  LINUX_VER: 'rockylinux8' }
+          - { CUDA_VER: '12.0.1', ARCH: 'arm64', PY_VER: '3.9', LINUX_VER: 'rockylinux8' }
+          - { CUDA_VER: '12.0.1', ARCH: 'arm64', PY_VER: '3.10', LINUX_VER: 'rockylinux8' }
+          "
+
+          if [[ ${{ inputs.debug_mode == 'true' }} ]]; then
+              export MATRIX+=${NEW_MANYLINUX_MATRIX}
+          fi
 
           echo "MATRIX=$(
             yq -n -o json 'env(MATRIX)' | \

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -67,7 +67,7 @@ jobs:
           export MATRICES="
             pull-request:
               - { ARCH: 'amd64', PY_VER: '3.9', CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu18.04', gpu: 'v100', driver: 'latest' }
-              - { ARCH: 'amd64', PY_VER: '3.10', CUDA_VER: '12.0.1', LINUX_VER: 'ubuntu18.04', gpu: 'v100', driver: 'latest' }
+              - { ARCH: 'amd64', PY_VER: '3.10', CUDA_VER: '12.0.1', LINUX_VER: 'ubuntu20.04', gpu: 'v100', driver: 'latest' }
               - { ARCH: 'arm64', PY_VER: '3.9', CUDA_VER: '12.0.1', LINUX_VER: 'ubuntu20.04', gpu: 'a100', driver: 'latest' }
             nightly:
               - { ARCH: 'amd64', PY_VER: '3.9', CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu18.04', gpu: 'v100', driver: 'latest' }


### PR DESCRIPTION
This PR adds an option for including additional build jobs in the matrix. These are built on new the rockylinux8 ci-wheel images added in https://github.com/rapidsai/ci-imgs/pull/87.

I'm not sure what we want to do for tests; the current test matrix means that some of the 2.28 wheels could easily be tested by just changing the download logic since they have new enough OSes to prefer the new wheels, but now it'll be an even smaller subset of the total builds. Also the nightly run won't test everything anymore. If we want to be thorough we'll have to double the number of jobs in nightlies to run on both old and new glibc citestwheel images.