### PR TITLE
Upload wheels to public anaconda index

### DIFF
--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -93,7 +93,7 @@ jobs:
             mkdir -m 0775 -p ~/.config/pip/;
             cat <<EOF >> ~/.config/pip/pip.conf
             [global]
-            extra-index-url = https://cibuildwheel:${{ secrets.RAPIDSAI_PYPI_CI_PASSWORD }}@pypi.k8s.rapids.ai/simple
+            extra-index-url = https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
             EOF
 
             rapids-make-${PYTHON_PACKAGE_MANAGER}-env || true;

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -71,5 +71,7 @@ jobs:
         date: ${{ inputs.date }}
         sha: ${{ inputs.sha }}
 
-    - name: Download wheels from downloads.rapids.ai and publish to internal PyPI
-      run: rapids-twine "${{ inputs.package-name }}"
+    - name: Download wheels from downloads.rapids.ai and publish to anaconda repository
+      run: rapids-wheels-anaconda "${{ inputs.package-name }}"
+      env:
+        RAPIDS_CONDA_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}


### PR DESCRIPTION
PR updates the wheels-publish step to upload wheels to anaconda instead of the existing internal PyPI.

Cross-references:
- https://github.com/rapidsai/ci-imgs/pull/92
- https://github.com/rapidsai/gha-tools/pull/86
