### PR TITLE
Forward-merge branch-23.12 to branch-24.02

### DIFF
--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -121,6 +121,8 @@ jobs:
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
       - name: C++ tests
         run: ${{ inputs.test_script }}
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Generate test report
         uses: test-summary/action@v2
         with:

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -125,6 +125,8 @@ jobs:
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
       - name: Python tests
         run: ${{ inputs.test_script }}
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Generate test report
         uses: test-summary/action@v2
         with:

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -132,6 +132,8 @@ jobs:
 
     - name: Run tests
       run: ${{ inputs.script }}
+      env:
+          GH_TOKEN: ${{ github.token }}
 
     - name: Upload additional artifacts
       if: "!cancelled()"


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.12` that creates a PR to keep `branch-24.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.