### PR TITLE
Forward-merge branch-23.12 to branch-24.02

### DIFF
--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -82,3 +82,5 @@ jobs:
           echo "RAPIDS_SHA=$(git rev-parse HEAD)" >> "${GITHUB_ENV}"
       - name: Run script
         run: ${{ inputs.run_script }}
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -133,7 +133,7 @@ jobs:
     - name: Run tests
       run: ${{ inputs.script }}
       env:
-          GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ github.token }}
 
     - name: Upload additional artifacts
       if: "!cancelled()"


### PR DESCRIPTION
Forward-merge triggered by push to `branch-23.12` that creates a PR to keep `branch-24.02` up-to-date. If this PR is unable to be immediately merged due to conflicts, it will remain open for the team to manually merge.