### PR TITLE
fix outdated docs about composite actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ## Introduction
 
-This repository contains [reusable GitHub Action workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows) and [composite actions](https://docs.github.com/en/actions/creating-actions/creating-a-composite-action).
+This repository contains [reusable GitHub Action workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows).
+
+Reusable composite actions can be found in https://github.com/rapidsai/shared-actions.
 
 See the articles below for a comparison between these two types of reusable GitHub Action components:
 
@@ -15,7 +17,3 @@ Reusable workflows must be placed in the `.github/workflows` directory as mentio
 
 - https://github.com/community/community/discussions/10773
 - https://github.com/community/community/discussions/9050
-
-Composite actions can be placed in any arbitrary repository location. The convention adopted for this repository is to place composite actions in the root of this repository.
-
-For more information on any particular composite action, see the `README.md` file in its respective folder.


### PR DESCRIPTION
As of #144, this repo no longer contains composite actions.

Those are now at https://github.com/rapidsai/shared-actions

This PR proposes updating the README to reflect that.