### PR TITLE
Temporarily use cpu32 by default for accelerating CCCL 2.2.0 migration.

### DIFF
--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -7,7 +7,7 @@ on:
         type: string
       node_type:
         type: string
-        default: "cpu8"
+        default: "cpu32"
       build_command:
         type: string
         required: true

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -14,7 +14,7 @@ on:
         type: string
       node_type:
         type: string
-        default: "cpu8"
+        default: "cpu32"
       build_script:
         type: string
         default: "ci/build_cpp.sh"


### PR DESCRIPTION
The RAPIDS update to CCCL 2.2.0 requires rebuilding all of RAPIDS. This PR temporarily bumps the default CPU node from 8 cores to 32 cores.

xref: https://github.com/rapidsai/rapids-cmake/issues/502