### PR TITLE
Revert changes to use cpu32 by default.

### DIFF
--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -7,7 +7,7 @@ on:
         type: string
       node_type:
         type: string
-        default: "cpu32"
+        default: "cpu8"
       build_command:
         type: string
         required: true

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -14,7 +14,7 @@ on:
         type: string
       node_type:
         type: string
-        default: "cpu32"
+        default: "cpu8"
       build_script:
         type: string
         default: "ci/build_cpp.sh"


### PR DESCRIPTION
Reverts #165 now that the CCCL 2.2.0 migration is complete.