### PR TITLE
run wheels-publish jobs in Python 3.11 image

### DIFF
--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -41,8 +41,8 @@ jobs:
     name: wheels publish
     runs-on: linux-amd64-cpu4
     container:
-      # ctk version of the container is irrelevant in the publish step
-      # it's simply a launcher for twine
+      # CUDA toolkit version of the container is irrelevant in the publish step.
+      # This just uploads already-built wheels to remote storage.
       image: "rapidsai/ci-wheel:cuda12.2.2-centos7-py3.11"
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -43,7 +43,7 @@ jobs:
     container:
       # CUDA toolkit version of the container is irrelevant in the publish step.
       # This just uploads already-built wheels to remote storage.
-      image: "rapidsai/ci-wheel:cuda12.2.2-centos7-py3.11"
+      image: "rapidsai/ci-wheel:cuda12.0.1-centos7-py3.11"
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -43,7 +43,7 @@ jobs:
     container:
       # ctk version of the container is irrelevant in the publish step
       # it's simply a launcher for twine
-      image: "rapidsai/ci-wheel:cuda12.0.1-centos7-py3.10"
+      image: "rapidsai/ci-wheel:cuda12.2.2-centos7-py3.11"
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/7.

Split off from #166.

This proposes upgrading the image used in the `wheels-publish` workflow to a newer Python version (`3.10 -> 3.11`).

### Benefits of this change

Delays similar updates further into the future (e.g. `aws` and `anaconda-client` will drop Python 3.10 support before they drop Python 3.11 support).

### How I tested this

This workflow just runs this script: https://github.com/rapidsai/gha-tools/blob/main/tools/rapids-wheels-anaconda.

So just checked that the things that script needs are in the image.

```shell
docker run --rm -it rapidsai/ci-wheel:cuda12.0.1-centos7-py3.11 bash

which rapids-wheels-anaconda
# /usr/local/bin/rapids-wheels-anaconda

aws --version
# aws-cli/2.15.7 Python/3.11.6 Linux/5.4.0-148-generic docker/x86_64.centos.7 prompt/off

twine --version
# twine version 4.0.2
# (importlib-metadata: 7.0.1, keyring: 24.3.0, pkginfo: 1.9.6, requests: 2.31.0, requests-toolbelt:
# 1.0.0, urllib3: 2.1.0)

anaconda --version
# anaconda Command line client (version 1.12.2)
```

I think that's probably sufficient. It'd be easy to revert this if it breaks something... less effort and lower-risk than trying to test on another repo where this `wheels-publish` only runs on merges to `main`.