### PR TITLE
Remove default exclusions from symbol_exclusions

### DIFF
--- a/.github/workflows/conda-cpp-post-build-checks.yaml
+++ b/.github/workflows/conda-cpp-post-build-checks.yaml
@@ -85,9 +85,11 @@ jobs:
           path: "./tool/"
           fetch-depth: 0
       - name: Verify CUDA libraries have no public kernel entry points
+        env:
+          SYMBOL_EXCLUSIONS: ${{ inputs.symbol_exclusions }}
         run: |
-          if ${{ inputs.symbol_exclusions }}; then
-            python ./tool/detect.py ${RAPIDS_EXTRACTED_DIR}/lib -e "${{ inputs.symbol_exclusions }}"
+          if [ -n "${SYMBOL_EXCLUSIONS}" ]; then
+            python ./tool/detect.py ${RAPIDS_EXTRACTED_DIR}/lib -e "${SYMBOL_EXCLUSIONS}"
           else
             python ./tool/detect.py ${RAPIDS_EXTRACTED_DIR}/lib
           fi

--- a/.github/workflows/conda-cpp-post-build-checks.yaml
+++ b/.github/workflows/conda-cpp-post-build-checks.yaml
@@ -18,7 +18,6 @@ on:
         required: false
       symbol_exclusions:
         type: string
-        default: ""
 
 defaults:
   run:
@@ -87,7 +86,7 @@ jobs:
           fetch-depth: 0
       - name: Verify CUDA libraries have no public kernel entry points
         run: |
-          if ${{ inputs.symbol_exclusions == "" }}
+          if ${{ inputs.symbol_exclusions }}
             python ./tool/detect.py ${RAPIDS_EXTRACTED_DIR}/lib
           else
             python ./tool/detect.py ${RAPIDS_EXTRACTED_DIR}/lib -e "${{ inputs.symbol_exclusions }}"

--- a/.github/workflows/conda-cpp-post-build-checks.yaml
+++ b/.github/workflows/conda-cpp-post-build-checks.yaml
@@ -87,7 +87,7 @@ jobs:
       - name: Verify CUDA libraries have no public kernel entry points
         run: |
           if ${{ inputs.symbol_exclusions }}
-            python ./tool/detect.py ${RAPIDS_EXTRACTED_DIR}/lib
-          else
             python ./tool/detect.py ${RAPIDS_EXTRACTED_DIR}/lib -e "${{ inputs.symbol_exclusions }}"
+          else
+            python ./tool/detect.py ${RAPIDS_EXTRACTED_DIR}/lib
           fi

--- a/.github/workflows/conda-cpp-post-build-checks.yaml
+++ b/.github/workflows/conda-cpp-post-build-checks.yaml
@@ -18,7 +18,7 @@ on:
         required: false
       symbol_exclusions:
         type: string
-        default: "void (cub::|thrust::)"
+        default: ""
 
 defaults:
   run:
@@ -86,4 +86,9 @@ jobs:
           path: "./tool/"
           fetch-depth: 0
       - name: Verify CUDA libraries have no public kernel entry points
-        run: python ./tool/detect.py ${RAPIDS_EXTRACTED_DIR}/lib -e "${{ inputs.symbol_exclusions }}"
+        run: |
+          if ${{ inputs.symbol_exclusions == "" }}
+            python ./tool/detect.py ${RAPIDS_EXTRACTED_DIR}/lib
+          else
+            python ./tool/detect.py ${RAPIDS_EXTRACTED_DIR}/lib -e "${{ inputs.symbol_exclusions }}"
+          fi

--- a/.github/workflows/conda-cpp-post-build-checks.yaml
+++ b/.github/workflows/conda-cpp-post-build-checks.yaml
@@ -86,7 +86,7 @@ jobs:
           fetch-depth: 0
       - name: Verify CUDA libraries have no public kernel entry points
         run: |
-          if ${{ inputs.symbol_exclusions }}
+          if ${{ inputs.symbol_exclusions }}; then
             python ./tool/detect.py ${RAPIDS_EXTRACTED_DIR}/lib -e "${{ inputs.symbol_exclusions }}"
           else
             python ./tool/detect.py ${RAPIDS_EXTRACTED_DIR}/lib


### PR DESCRIPTION
Needed as we know have patches for CCCL ( cub, thrust, libcudacxx ) which hide all symbols. So projects should be able to run without any exclusions at all.