### PR TITLE
Use `configFile` option, support an additional repo deploy key

### DIFF
--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -97,14 +97,14 @@ jobs:
 
             rapids-make-${PYTHON_PACKAGE_MANAGER}-env;
 
-            if test -n "${{ inputs.extra-repo-deploy-key }}" \
-            || test -n "${{ inputs.extra-repo-deploy-key-2 }}"; then
+            if test -n '${{ inputs.extra-repo-deploy-key }}' \
+            || test -n '${{ inputs.extra-repo-deploy-key-2 }}'; then
               if ! pgrep ssh-agent >/dev/null 2>&1; then eval "$(ssh-agent -s)"; fi;
-              if test -n "${{ inputs.extra-repo-deploy-key }}"; then
-                ssh-add - <<< "${{ secrets[inputs.extra-repo-deploy-key] }}";
+              if test -n '${{ inputs.extra-repo-deploy-key }}'; then
+                ssh-add - <<< '${{ secrets[inputs.extra-repo-deploy-key] }}';
               fi
-              if test -n "${{ inputs.extra-repo-deploy-key-2 }}"; then
-                ssh-add - <<< "${{ secrets[inputs.extra-repo-deploy-key-2] }}";
+              if test -n '${{ inputs.extra-repo-deploy-key-2 }}'; then
+                ssh-add - <<< '${{ secrets[inputs.extra-repo-deploy-key-2] }}';
               fi
               devcontainer-utils-init-ssh-deploy-keys || true;
             fi

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -56,6 +56,7 @@ jobs:
           fetch-depth: 0
       - name: Check if repo has devcontainer
         run: |
+          echo "REPOSITORY=$(basename $(pwd))" | tee -a "${GITHUB_ENV}";
           if test -f .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json; then
             echo "HAS_DEVCONTAINER=true" >> "${GITHUB_ENV}";
           else
@@ -79,14 +80,13 @@ jobs:
           push: never
           configFile: .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json
           env: |
+            REPOSITORY=${{ env.REPOSITORY }}
             GH_TOKEN=${{ secrets[inputs.gh_token] }}
             SCCACHE_REGION=${{ vars.AWS_REGION }}
             AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }}
             AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }}
             AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}
           runCmd: |
-            set -e;
-
             mkdir -p ~/.config/pip/;
             cat <<EOF >> ~/.config/pip/pip.conf
             [global]
@@ -101,4 +101,5 @@ jobs:
               devcontainer-utils-init-ssh-deploy-keys || true;
             fi
 
+            cd ~/"${REPOSITORY}";
             ${{ inputs.build_command }}

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -3,6 +3,12 @@ on:
     inputs:
       sha:
         type: string
+      arch:
+        type: string
+        default: '["amd64"]'
+      cuda:
+        type: string
+        default: '["12.0"]'
       repo:
         type: string
       node_type:
@@ -42,8 +48,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: ["amd64"]
-        cuda: ["12.0"]
+        arch: ${{ fromJSON(inputs.arch) }}
+        cuda: ${{ fromJSON(inputs.cuda) }}
         pkgr: ["conda", "pip"]
     runs-on: "linux-${{ matrix.arch }}-${{ inputs.node_type }}"
     steps:

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -92,9 +92,14 @@ jobs:
 
             rapids-make-${PYTHON_PACKAGE_MANAGER}-env;
 
-            if ! grep -qE "^$" <<< "${{ inputs.extra-repo-deploy-key }}"; then
+            # Load private repo deploy keys
+            if ! grep -qE "^$" <<< "${{ inputs.extra-repo-deploy-key }}" \
+            || ! grep -qE "^$" <<< "${{ inputs.extra-repo-deploy-key-2 }}"; then
               if ! pgrep ssh-agent >/dev/null 2>&1; then eval "$(ssh-agent -s)"; fi;
-              ssh-add - <<< "${{ secrets[inputs.extra-repo-deploy-key] }}";
+              ssh-add - << "__EOF"
+            ${{ secrets[inputs.extra-repo-deploy-key] }}
+            ${{ secrets[inputs.extra-repo-deploy-key-2] }}
+            __EOF
               devcontainer-utils-init-ssh-deploy-keys || true;
             fi
 

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -5,6 +5,9 @@ on:
         type: string
       repo:
         type: string
+      gh_token:
+        type: string
+        required: false
       node_type:
         type: string
         default: "cpu8"
@@ -80,6 +83,7 @@ jobs:
             AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }}
             AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }}
             AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}
+            GH_TOKEN=${{ inputs.gh_token || secrets.GITHUB_TOKEN }}
           runCmd: |
             set -e;
 

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -97,14 +97,15 @@ jobs:
 
             rapids-make-${PYTHON_PACKAGE_MANAGER}-env;
 
-            # Load private repo deploy keys
-            if ! grep -qE "^$" <<< "${{ inputs.extra-repo-deploy-key }}" \
-            || ! grep -qE "^$" <<< "${{ inputs.extra-repo-deploy-key-2 }}"; then
+            if test -n "${{ inputs.extra-repo-deploy-key }}" \
+            || test -n "${{ inputs.extra-repo-deploy-key-2 }}"; then
               if ! pgrep ssh-agent >/dev/null 2>&1; then eval "$(ssh-agent -s)"; fi;
-              ssh-add - << "__EOF"
-            ${{ secrets[inputs.extra-repo-deploy-key] }}
-            ${{ secrets[inputs.extra-repo-deploy-key-2] }}
-            __EOF
+              if test -n "${{ inputs.extra-repo-deploy-key }}"; then
+                ssh-add - <<< "${{ secrets[inputs.extra-repo-deploy-key] }}";
+              fi
+              if test -n "${{ inputs.extra-repo-deploy-key-2 }}"; then
+                ssh-add - <<< "${{ secrets[inputs.extra-repo-deploy-key-2] }}";
+              fi
               devcontainer-utils-init-ssh-deploy-keys || true;
             fi
 

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -74,6 +74,7 @@ jobs:
         uses: devcontainers/ci@v0.3
         with:
           push: never
+          subFolder: .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}
           configFile: .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json
           env: |
             REPOSITORY=${{ env.REPOSITORY }}

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -74,7 +74,6 @@ jobs:
         uses: devcontainers/ci@v0.3
         with:
           push: never
-          subFolder: .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}
           configFile: .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json
           env: |
             REPOSITORY="${{ inputs.repo }}"

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -97,14 +97,14 @@ jobs:
 
             rapids-make-${PYTHON_PACKAGE_MANAGER}-env;
 
-            if test -n "${{ inputs.extra-repo-deploy-key }}" \
-            || test -n "${{ inputs.extra-repo-deploy-key-2 }}"; then
+            if ! grep -qE "^$" <<< '${{ secrets[inputs.extra-repo-deploy-key] }}' \
+            || ! grep -qE "^$" <<< '${{ secrets[inputs.extra-repo-deploy-key-2] }}'; then
               if ! pgrep ssh-agent >/dev/null 2>&1; then eval "$(ssh-agent -s)"; fi;
-              if test -n "${{ inputs.extra-repo-deploy-key }}"; then
-                ssh-add - <<< "${{ secrets[inputs.extra-repo-deploy-key] }}";
+              if ! grep -qE "^$" <<< '${{ secrets[inputs.extra-repo-deploy-key] }}'; then
+                ssh-add - <<< '${{ secrets[inputs.extra-repo-deploy-key] }}';
               fi
-              if test -n "${{ inputs.extra-repo-deploy-key-2 }}"; then
-                ssh-add - <<< "${{ secrets[inputs.extra-repo-deploy-key-2] }}";
+              if ! grep -qE "^$" <<< '${{ secrets[inputs.extra-repo-deploy-key-2] }}'; then
+                ssh-add - <<< '${{ secrets[inputs.extra-repo-deploy-key-2] }}';
               fi
               devcontainer-utils-init-ssh-deploy-keys || true;
             fi

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -70,16 +70,11 @@ jobs:
         with:
           node-version: '16'
       - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
-        name: Copy devcontainer.json file up one level
-        run: |
-          echo "REPOSITORY=$(basename $(pwd))" | tee -a "${GITHUB_ENV}";
-          cp .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json \
-             .devcontainer/devcontainer.json;
-      - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
         name: Run build in devcontainer
         uses: devcontainers/ci@v0.3
         with:
           push: never
+          configFile: .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json
           env: |
             REPOSITORY=${{ env.REPOSITORY }}
             SCCACHE_REGION=${{ vars.AWS_REGION }}

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -5,9 +5,6 @@ on:
         type: string
       repo:
         type: string
-      gh_token:
-        type: string
-        default: "GITHUB_TOKEN"
       node_type:
         type: string
         default: "cpu8"
@@ -81,7 +78,6 @@ jobs:
           configFile: .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json
           env: |
             REPOSITORY=${{ env.REPOSITORY }}
-            GH_TOKEN=${{ secrets[inputs.gh_token] }}
             SCCACHE_REGION=${{ vars.AWS_REGION }}
             AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }}
             AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }}

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -77,7 +77,7 @@ jobs:
           subFolder: .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}
           configFile: .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json
           env: |
-            REPOSITORY=${{ env.REPOSITORY }}
+            REPOSITORY="${{ inputs.repo }}"
             SCCACHE_REGION=${{ vars.AWS_REGION }}
             AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }}
             AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }}

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -87,13 +87,14 @@ jobs:
             AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }}
             AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}
           runCmd: |
+            set -e;
             mkdir -p ~/.config/pip/;
             cat <<EOF >> ~/.config/pip/pip.conf
             [global]
             extra-index-url = https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
             EOF
 
-            rapids-make-${PYTHON_PACKAGE_MANAGER}-env || true;
+            rapids-make-${PYTHON_PACKAGE_MANAGER}-env;
 
             if ! grep -qE "^$" <<< "${{ inputs.extra-repo-deploy-key }}"; then
               if ! pgrep ssh-agent >/dev/null 2>&1; then eval "$(ssh-agent -s)"; fi;

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -97,14 +97,14 @@ jobs:
 
             rapids-make-${PYTHON_PACKAGE_MANAGER}-env;
 
-            if ! grep -qE "^$" <<< '${{ secrets[inputs.extra-repo-deploy-key] }}' \
-            || ! grep -qE "^$" <<< '${{ secrets[inputs.extra-repo-deploy-key-2] }}'; then
+            if test -n "${{ inputs.extra-repo-deploy-key }}" \
+            || test -n "${{ inputs.extra-repo-deploy-key-2 }}"; then
               if ! pgrep ssh-agent >/dev/null 2>&1; then eval "$(ssh-agent -s)"; fi;
-              if ! grep -qE "^$" <<< '${{ secrets[inputs.extra-repo-deploy-key] }}'; then
-                ssh-add - <<< '${{ secrets[inputs.extra-repo-deploy-key] }}';
+              if test -n "${{ inputs.extra-repo-deploy-key }}"; then
+                ssh-add - <<< "${{ secrets[inputs.extra-repo-deploy-key] }}";
               fi
-              if ! grep -qE "^$" <<< '${{ secrets[inputs.extra-repo-deploy-key-2] }}'; then
-                ssh-add - <<< '${{ secrets[inputs.extra-repo-deploy-key-2] }}';
+              if test -n "${{ inputs.extra-repo-deploy-key-2 }}"; then
+                ssh-add - <<< "${{ secrets[inputs.extra-repo-deploy-key-2] }}";
               fi
               devcontainer-utils-init-ssh-deploy-keys || true;
             fi

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -76,7 +76,6 @@ jobs:
           push: never
           configFile: .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json
           env: |
-            REPOSITORY="${{ inputs.repo }}"
             SCCACHE_REGION=${{ vars.AWS_REGION }}
             AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }}
             AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }}
@@ -98,5 +97,4 @@ jobs:
               devcontainer-utils-init-ssh-deploy-keys || true;
             fi
 
-            cd ~/"${REPOSITORY}";
             ${{ inputs.build_command }}

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -16,6 +16,11 @@ on:
         required: false
         type: string
         default: ''
+      # Note that this is the _name_ of a secret containing the key, not the key itself.
+      extra-repo-deploy-key-2:
+        required: false
+        type: string
+        default: ''
 
 permissions:
   actions: read

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -7,7 +7,7 @@ on:
         type: string
       gh_token:
         type: string
-        required: false
+        default: "GITHUB_TOKEN"
       node_type:
         type: string
         default: "cpu8"
@@ -79,11 +79,11 @@ jobs:
           push: never
           configFile: .devcontainer/cuda${{ matrix.cuda }}-${{ matrix.pkgr }}/devcontainer.json
           env: |
+            GH_TOKEN=${{ secrets[inputs.gh_token] }}
             SCCACHE_REGION=${{ vars.AWS_REGION }}
             AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }}
             AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }}
             AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}
-            GH_TOKEN=${{ inputs.gh_token || secrets.GITHUB_TOKEN }}
           runCmd: |
             set -e;
 


### PR DESCRIPTION
* Make `build-in-devcontainer` action use the new [`configFile` option](https://github.com/devcontainers/ci/pull/269)
* Support an additional `extra-repo-deploy-key` in `build-in-devcontainer` action

Both of these changes are necessary to [build all the RAPIDS projects](https://github.com/rapidsai/devcontainers/pull/210) in `rapidsai/devcontainers` CI jobs.