### PR TITLE
Pin test-summary action to v2.2 to avoid the Node 20 requirement until RAPIDS drops CentOS 7 support.

### DIFF
--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -136,7 +136,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Generate test report
-        uses: test-summary/action@v2
+        uses: test-summary/action@v2.2
         with:
           paths: "${{ env.RAPIDS_TESTS_DIR }}/*.xml"
         if: always()

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -140,7 +140,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Generate test report
-        uses: test-summary/action@v2
+        uses: test-summary/action@v2.2
         with:
           paths: "${{ env.RAPIDS_TESTS_DIR }}/*.xml"
         if: always()

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -152,7 +152,7 @@ jobs:
         GH_TOKEN: ${{ github.token }}
 
     - name: Generate test report
-      uses: test-summary/action@v2
+      uses: test-summary/action@v2.2
       with:
         paths: "${{ env.RAPIDS_TESTS_DIR }}/*.xml"
         show: ${{ inputs.test_summary_show }}


### PR DESCRIPTION
The `test-summary` GitHub Action was updated to require Node 20, which doesn't work with CentOS 7. (Version 2.3, released 6 hours ago)
https://github.com/test-summary/action/releases/tag/v2.3

We'll have to pin to `test-summary/action@v2.2` in shared-workflows so that they remain compatible with CentOS 7.

Generally, most GitHub Actions are moving to require Node 20, and we're unable to support that on CentOS 7 runners. We'll be dropping CentOS 7 support in RAPIDS 24.06, but we'll have to pin GitHub Actions to compatible (Node 16) versions until then. https://docs.rapids.ai/notices/rsn0037/