### PR TITLE
Backport test-summary pinning to v2.2.

### DIFF
--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -128,7 +128,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Generate test report
-        uses: test-summary/action@v2
+        uses: test-summary/action@v2.2
         with:
           paths: "${{ env.RAPIDS_TESTS_DIR }}/*.xml"
         if: always()

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -132,7 +132,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Generate test report
-        uses: test-summary/action@v2
+        uses: test-summary/action@v2.2
         with:
           paths: "${{ env.RAPIDS_TESTS_DIR }}/*.xml"
         if: always()


### PR DESCRIPTION
Backports #178 to `branch-24.02`. Needed for 24.02 hotfixes and cuOpt.