### PR TITLE
always mark Python 3.11 jobs as successful

### DIFF
--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -83,8 +83,6 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
     runs-on: "linux-${{ matrix.ARCH }}-${{ inputs.node_type }}"
-    # TODO: remove 'continue-on-error' before closing https://github.com/rapidsai/build-planning/issues/3
-    continue-on-error: ${{ matrix.PY_VER == '3.11' }}
     env:
       RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
     container:
@@ -114,9 +112,18 @@ jobs:
           echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
       - name: Python build
+        # TODO: remove 'continue-on-error' before closing https://github.com/rapidsai/build-planning/issues/3
+        continue-on-error: ${{ matrix.PY_VER == '3.11' }}
         run: ${{ inputs.build_script }}
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Upload additional artifacts
+        # TODO: remove 'continue-on-error' before closing https://github.com/rapidsai/build-planning/issues/3
+        continue-on-error: ${{ matrix.PY_VER == '3.11' }}
         if: "!cancelled()"
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
+      # TODO: remove before closing https://github.com/rapidsai/build-planning/issues/3
+      - name: mark Python 3.11 jobs successful
+        if: ${{ matrix.PY_VER == '3.11' }}
+        run: |
+          exit 0

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -103,8 +103,6 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
     runs-on: "linux-${{ matrix.ARCH }}-gpu-${{ matrix.GPU }}-${{ matrix.DRIVER }}-1"
-    # TODO: remove 'continue-on-error' before closing https://github.com/rapidsai/build-planning/issues/3
-    continue-on-error: ${{ matrix.PY_VER == '3.11' }}
     env:
       RAPIDS_COVERAGE_DIR: ${{ github.workspace }}/coverage-results
       RAPIDS_TESTS_DIR: ${{ github.workspace }}/test-results
@@ -139,20 +137,34 @@ jobs:
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
       - name: Python tests
         run: ${{ inputs.test_script }}
+        # TODO: remove 'continue-on-error' before closing https://github.com/rapidsai/build-planning/issues/3
+        continue-on-error: ${{ matrix.PY_VER == '3.11' }}
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Generate test report
         uses: test-summary/action@v2.2
+        # TODO: remove 'continue-on-error' before closing https://github.com/rapidsai/build-planning/issues/3
+        continue-on-error: ${{ matrix.PY_VER == '3.11' }}
         with:
           paths: "${{ env.RAPIDS_TESTS_DIR }}/*.xml"
         if: always()
       - name: Run codecov
         if: inputs.run_codecov && runner.arch == 'X64'
+        # TODO: remove 'continue-on-error' before closing https://github.com/rapidsai/build-planning/issues/3
+        continue-on-error: ${{ matrix.PY_VER == '3.11' }}
         run: |
           codecov \
             -s \
             "${RAPIDS_COVERAGE_DIR}" \
             -v
       - name: Upload additional artifacts
+        # TODO: remove 'continue-on-error' before closing https://github.com/rapidsai/build-planning/issues/3
+        continue-on-error: ${{ matrix.PY_VER == '3.11' }}
         if: "!cancelled()"
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
+
+      # TODO: remove before closing https://github.com/rapidsai/build-planning/issues/3
+      - name: mark Python 3.11 jobs successful
+        if: ${{ matrix.PY_VER == '3.11' }}
+        run: |
+          exit 0

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -128,8 +128,6 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
     runs-on: "linux-${{ matrix.ARCH }}-${{ inputs.node_type }}"
-    # TODO: remove 'continue-on-error' before closing https://github.com/rapidsai/build-planning/issues/3
-    continue-on-error: ${{ matrix.PY_VER == '3.11' }}
     env:
       RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
     container:
@@ -185,6 +183,8 @@ jobs:
           persist-credentials: false
 
       - name: Build and repair the wheel
+        # TODO: remove 'continue-on-error' before closing https://github.com/rapidsai/build-planning/issues/3
+        continue-on-error: ${{ matrix.PY_VER == '3.11' }}
         run: |
           ${{ inputs.script }}
         env:
@@ -192,5 +192,12 @@ jobs:
         # Use a shell that loads the rc file so that we get the compiler settings
         shell: bash -leo pipefail {0}
       - name: Upload additional artifacts
+        # TODO: remove 'continue-on-error' before closing https://github.com/rapidsai/build-planning/issues/3
+        continue-on-error: ${{ matrix.PY_VER == '3.11' }}
         if: "!cancelled()"
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
+      # TODO: remove before closing https://github.com/rapidsai/build-planning/issues/3
+      - name: mark Python 3.11 jobs successful
+        if: ${{ matrix.PY_VER == '3.11' }}
+        run: |
+          exit 0

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -149,11 +149,15 @@ jobs:
         sha: ${{ inputs.sha }}
 
     - name: Run tests
+      # TODO: remove 'continue-on-error' before closing https://github.com/rapidsai/build-planning/issues/3
+      continue-on-error: ${{ matrix.PY_VER == '3.11' }}
       run: ${{ inputs.script }}
       env:
         GH_TOKEN: ${{ github.token }}
 
     - name: Generate test report
+      # TODO: remove 'continue-on-error' before closing https://github.com/rapidsai/build-planning/issues/3
+      continue-on-error: ${{ matrix.PY_VER == '3.11' }}
       uses: test-summary/action@v2.2
       with:
         paths: "${{ env.RAPIDS_TESTS_DIR }}/*.xml"
@@ -161,5 +165,13 @@ jobs:
       if: always()
 
     - name: Upload additional artifacts
+      # TODO: remove 'continue-on-error' before closing https://github.com/rapidsai/build-planning/issues/3
+      continue-on-error: ${{ matrix.PY_VER == '3.11' }}
       if: "!cancelled()"
       run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
+
+    # TODO: remove before closing https://github.com/rapidsai/build-planning/issues/3
+    - name: mark Python 3.11 jobs successful
+      if: ${{ matrix.PY_VER == '3.11' }}
+      run: |
+        exit 0

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -111,8 +111,6 @@ jobs:
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
     runs-on: "linux-${{ matrix.ARCH }}-gpu-${{ matrix.gpu }}-${{ matrix.driver }}-1"
-    # TODO: remove 'continue-on-error' before closing https://github.com/rapidsai/build-planning/issues/3
-    continue-on-error: ${{ matrix.PY_VER == '3.11' }}
     container:
       image: "rapidsai/citestwheel:cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
       options: ${{ inputs.container-options }}


### PR DESCRIPTION
Follow-up to #176.

#176 added Python 3.11 build and test jobs. It tried to make those optional by using  GitHub Actions' `jobs.<job_id>.continue_on_error` mechanism ([docs on that](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error)).

Unfortunately, it seems that that mechanism doesn't play nicely with RAPIDS branch protections, which use one more job that runs at the end of the `pr` workflow and declares all other sets of jobs in a `needs:` block.

`cudf` example: https://github.com/rapidsai/cudf/blob/8526e6d5b21361465d1c72ecbea64d3d2d9bf849/.github/workflows/pr.yaml#L13-L34.

As a result, the Python 3.11 jobs **were actually blocking CI** in repos where they were failing.

This proposes the following changes:

* removing that job-level `continue-on-error`
* ensuring that Python 3.11 jobs are always marked successful, even when individual steps in them fail

### How I tested this

Opened https://github.com/rapidsai/cudf/pull/15172 to test.

On the first run, I saw all Python 3.11 marked as successful, even though their logs clearly indicated that they failed.

<img width="1683" alt="Screenshot 2024-02-28 at 10 56 20 AM" src="https://github.com/rapidsai/shared-workflows/assets/7608904/34c6a20e-d03d-42c8-8c81-90153942a966">

([build link](https://github.com/rapidsai/cudf/actions/runs/8083300129/job/22086966999?pr=15172))

~TODO: once that completes, I'll do one more build that breaks the tests and shows that the non-Python-3.11 jobs are marked as failed.~

Proposing that we merge this without waiting on that test, to unblock CI for `cudf` (and maybe other projects).