### PR TITLE
make Python 3.11 jobs required

### DIFF
--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -112,18 +112,9 @@ jobs:
           echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
       - name: Python build
-        # TODO: remove 'continue-on-error' before closing https://github.com/rapidsai/build-planning/issues/3
-        continue-on-error: ${{ matrix.PY_VER == '3.11' }}
         run: ${{ inputs.build_script }}
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Upload additional artifacts
-        # TODO: remove 'continue-on-error' before closing https://github.com/rapidsai/build-planning/issues/3
-        continue-on-error: ${{ matrix.PY_VER == '3.11' }}
         if: "!cancelled()"
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
-      # TODO: remove before closing https://github.com/rapidsai/build-planning/issues/3
-      - name: mark Python 3.11 jobs successful
-        if: ${{ matrix.PY_VER == '3.11' }}
-        run: |
-          exit 0

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -137,34 +137,20 @@ jobs:
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
       - name: Python tests
         run: ${{ inputs.test_script }}
-        # TODO: remove 'continue-on-error' before closing https://github.com/rapidsai/build-planning/issues/3
-        continue-on-error: ${{ matrix.PY_VER == '3.11' }}
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Generate test report
         uses: test-summary/action@v2.2
-        # TODO: remove 'continue-on-error' before closing https://github.com/rapidsai/build-planning/issues/3
-        continue-on-error: ${{ matrix.PY_VER == '3.11' }}
         with:
           paths: "${{ env.RAPIDS_TESTS_DIR }}/*.xml"
         if: always()
       - name: Run codecov
         if: inputs.run_codecov && runner.arch == 'X64'
-        # TODO: remove 'continue-on-error' before closing https://github.com/rapidsai/build-planning/issues/3
-        continue-on-error: ${{ matrix.PY_VER == '3.11' }}
         run: |
           codecov \
             -s \
             "${RAPIDS_COVERAGE_DIR}" \
             -v
       - name: Upload additional artifacts
-        # TODO: remove 'continue-on-error' before closing https://github.com/rapidsai/build-planning/issues/3
-        continue-on-error: ${{ matrix.PY_VER == '3.11' }}
         if: "!cancelled()"
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
-
-      # TODO: remove before closing https://github.com/rapidsai/build-planning/issues/3
-      - name: mark Python 3.11 jobs successful
-        if: ${{ matrix.PY_VER == '3.11' }}
-        run: |
-          exit 0

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -183,8 +183,6 @@ jobs:
           persist-credentials: false
 
       - name: Build and repair the wheel
-        # TODO: remove 'continue-on-error' before closing https://github.com/rapidsai/build-planning/issues/3
-        continue-on-error: ${{ matrix.PY_VER == '3.11' }}
         run: |
           ${{ inputs.script }}
         env:
@@ -192,12 +190,5 @@ jobs:
         # Use a shell that loads the rc file so that we get the compiler settings
         shell: bash -leo pipefail {0}
       - name: Upload additional artifacts
-        # TODO: remove 'continue-on-error' before closing https://github.com/rapidsai/build-planning/issues/3
-        continue-on-error: ${{ matrix.PY_VER == '3.11' }}
         if: "!cancelled()"
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
-      # TODO: remove before closing https://github.com/rapidsai/build-planning/issues/3
-      - name: mark Python 3.11 jobs successful
-        if: ${{ matrix.PY_VER == '3.11' }}
-        run: |
-          exit 0

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -147,15 +147,11 @@ jobs:
         sha: ${{ inputs.sha }}
 
     - name: Run tests
-      # TODO: remove 'continue-on-error' before closing https://github.com/rapidsai/build-planning/issues/3
-      continue-on-error: ${{ matrix.PY_VER == '3.11' }}
       run: ${{ inputs.script }}
       env:
         GH_TOKEN: ${{ github.token }}
 
     - name: Generate test report
-      # TODO: remove 'continue-on-error' before closing https://github.com/rapidsai/build-planning/issues/3
-      continue-on-error: ${{ matrix.PY_VER == '3.11' }}
       uses: test-summary/action@v2.2
       with:
         paths: "${{ env.RAPIDS_TESTS_DIR }}/*.xml"
@@ -163,13 +159,5 @@ jobs:
       if: always()
 
     - name: Upload additional artifacts
-      # TODO: remove 'continue-on-error' before closing https://github.com/rapidsai/build-planning/issues/3
-      continue-on-error: ${{ matrix.PY_VER == '3.11' }}
       if: "!cancelled()"
       run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
-
-    # TODO: remove before closing https://github.com/rapidsai/build-planning/issues/3
-    - name: mark Python 3.11 jobs successful
-      if: ${{ matrix.PY_VER == '3.11' }}
-      run: |
-        exit 0


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/3.

Reverts #182.

Proposes making the Python 3.11 CI jobs required. As of this PR:

* if those jobs fail, they'll be marked as `failed` in CI
* merging will be blocked until they're passing