### PR TITLE
Fail if the computed matrix is empty.

### DIFF
--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -67,7 +67,7 @@ jobs:
 
           echo "MATRIX=$(
             yq -n -o json 'env(MATRIX)' | \
-            jq -c '${{ inputs.matrix_filter }} | {include: .}' \
+            jq -c '${{ inputs.matrix_filter }} | {include: .} | if .include != [] then . else halt_error(1) end' \
           )" | tee --append "${GITHUB_OUTPUT}"
   build:
     needs: compute-matrix

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -91,7 +91,7 @@ jobs:
 
           echo "MATRIX=$(
             yq -n -o json 'env(TEST_MATRIX)' | \
-            jq -c '${{ inputs.matrix_filter }} | {include: .}' \
+            jq -c '${{ inputs.matrix_filter }} | {include: .} | if .include != [] then . else halt_error(1) end' \
           )" | tee --append "${GITHUB_OUTPUT}"
   tests:
     needs: compute-matrix

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -75,7 +75,7 @@ jobs:
 
           echo "MATRIX=$(
             yq -n -o json 'env(MATRIX)' | \
-            jq -c '${{ inputs.matrix_filter }} | {include: .}' \
+            jq -c '${{ inputs.matrix_filter }} | {include: .} | if .include != [] then . else halt_error(1) end' \
           )" | tee --append "${GITHUB_OUTPUT}"
   build:
     needs: compute-matrix

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -94,7 +94,7 @@ jobs:
 
           echo "MATRIX=$(
             yq -n -o json 'env(TEST_MATRIX)' | \
-            jq -c '${{ inputs.matrix_filter }} | {include: .}' \
+            jq -c '${{ inputs.matrix_filter }} | {include: .} | if .include != [] then . else halt_error(1) end' \
           )" | tee --append "${GITHUB_OUTPUT}"
   tests:
     needs: compute-matrix

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -119,11 +119,11 @@ jobs:
 
           echo "MATRIX=$(
             yq -n -o json 'env(MATRIX)' | \
-            jq -c '${{ inputs.matrix_filter }} | {include: .}' \
+            jq -c '${{ inputs.matrix_filter }} | {include: .} | if .include != [] then . else halt_error(1) end' \
           )" | tee --append "${GITHUB_OUTPUT}"
 
   build:
-    name:  ${{ matrix.CUDA_VER }}, ${{ matrix.PY_VER }}, ${{ matrix.ARCH }}, ${{ matrix.LINUX_VER }} 
+    name:  ${{ matrix.CUDA_VER }}, ${{ matrix.PY_VER }}, ${{ matrix.ARCH }}, ${{ matrix.LINUX_VER }}
     needs: [compute-matrix]
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}


### PR DESCRIPTION
Currently the `compute-matrix` job passes even if the computed matrix is empty. Empty matrices raise an error (as shown below) so this should not be permitted.

![image](https://github.com/rapidsai/shared-workflows/assets/3943761/4d17b16f-c385-4634-960b-606fe087ed32)

This needs to be tested downstream with a cudf PR.