### PR TITLE
Fail if the computed matrix is empty.

### DIFF
--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -67,7 +67,7 @@ jobs:
 
           echo "MATRIX=$(
             yq -n -o json 'env(MATRIX)' | \
-            jq -c '${{ inputs.matrix_filter }} | {include: .}' \
+            jq -c '${{ inputs.matrix_filter }} | {include: .} | if .include != [] then . else halt_error(1) end' \
           )" | tee --append "${GITHUB_OUTPUT}"
   build:
     needs: compute-matrix

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -67,7 +67,7 @@ jobs:
 
           echo "MATRIX=$(
             yq -n -o json 'env(MATRIX)' | \
-            jq -c '${{ inputs.matrix_filter }} | {include: .} | if .include != [] then . else halt_error(1) end' \
+            jq -c '${{ inputs.matrix_filter }} | if (. | length) > 0 then {include: .} else "Error: Empty matrix\n" | halt_error(1) end' \
           )" | tee --append "${GITHUB_OUTPUT}"
   build:
     needs: compute-matrix

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -65,10 +65,12 @@ jobs:
           - { ARCH: 'arm64', PY_VER: '3.10', CUDA_VER: '12.2.2', LINUX_VER: 'ubuntu22.04' }
           "
 
-          echo "MATRIX=$(
+          MATRIX="$(
             yq -n -o json 'env(MATRIX)' | \
-            jq -c '${{ inputs.matrix_filter }} | if (. | length) > 0 then {include: .} else "Error: Empty matrix\n" | halt_error(1) end' \
-          )" | tee --append "${GITHUB_OUTPUT}"
+            jq -c '${{ inputs.matrix_filter }} | if (. | length) > 0 then {include: .} else "Error: Empty matrix\n" | halt_error(1) end'
+          )"
+
+          echo "MATRIX=${MATRIX}" | tee --append "${GITHUB_OUTPUT}"
   build:
     needs: compute-matrix
     timeout-minutes: 480

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -89,10 +89,12 @@ jobs:
           TEST_MATRIX=$(yq -n 'env(MATRICES) | .[strenv(BUILD_TYPE)]')
           export TEST_MATRIX
 
-          echo "MATRIX=$(
+          MATRIX="$(
             yq -n -o json 'env(TEST_MATRIX)' | \
-            jq -c '${{ inputs.matrix_filter }} | if (. | length) > 0 then {include: .} else "Error: Empty matrix\n" | halt_error(1) end' \
-          )" | tee --append "${GITHUB_OUTPUT}"
+            jq -c '${{ inputs.matrix_filter }} | if (. | length) > 0 then {include: .} else "Error: Empty matrix\n" | halt_error(1) end'
+          )"
+
+          echo "MATRIX=${MATRIX}" | tee --append "${GITHUB_OUTPUT}"
   tests:
     needs: compute-matrix
     strategy:

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -91,7 +91,7 @@ jobs:
 
           echo "MATRIX=$(
             yq -n -o json 'env(TEST_MATRIX)' | \
-            jq -c '${{ inputs.matrix_filter }} | {include: .}' \
+            jq -c '${{ inputs.matrix_filter }} | {include: .} | if .include != [] then . else halt_error(1) end' \
           )" | tee --append "${GITHUB_OUTPUT}"
   tests:
     needs: compute-matrix

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -91,7 +91,7 @@ jobs:
 
           echo "MATRIX=$(
             yq -n -o json 'env(TEST_MATRIX)' | \
-            jq -c '${{ inputs.matrix_filter }} | {include: .} | if .include != [] then . else halt_error(1) end' \
+            jq -c '${{ inputs.matrix_filter }} | if (. | length) > 0 then {include: .} else "Error: Empty matrix\n" | halt_error(1) end' \
           )" | tee --append "${GITHUB_OUTPUT}"
   tests:
     needs: compute-matrix

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -73,10 +73,12 @@ jobs:
           - { ARCH: 'arm64', PY_VER: '3.11', CUDA_VER: '12.2.2', LINUX_VER: 'ubuntu22.04' }
           "
 
-          echo "MATRIX=$(
+          MATRIX="$(
             yq -n -o json 'env(MATRIX)' | \
-            jq -c '${{ inputs.matrix_filter }} | if (. | length) > 0 then {include: .} else "Error: Empty matrix\n" | halt_error(1) end' \
-          )" | tee --append "${GITHUB_OUTPUT}"
+            jq -c '${{ inputs.matrix_filter }} | if (. | length) > 0 then {include: .} else "Error: Empty matrix\n" | halt_error(1) end'
+          )"
+
+          echo "MATRIX=${MATRIX}" | tee --append "${GITHUB_OUTPUT}"
   build:
     needs: compute-matrix
     strategy:

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -75,7 +75,7 @@ jobs:
 
           echo "MATRIX=$(
             yq -n -o json 'env(MATRIX)' | \
-            jq -c '${{ inputs.matrix_filter }} | {include: .}' \
+            jq -c '${{ inputs.matrix_filter }} | {include: .} | if .include != [] then . else halt_error(1) end' \
           )" | tee --append "${GITHUB_OUTPUT}"
   build:
     needs: compute-matrix

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -75,7 +75,7 @@ jobs:
 
           echo "MATRIX=$(
             yq -n -o json 'env(MATRIX)' | \
-            jq -c '${{ inputs.matrix_filter }} | {include: .} | if .include != [] then . else halt_error(1) end' \
+            jq -c '${{ inputs.matrix_filter }} | if (. | length) > 0 then {include: .} else "Error: Empty matrix\n" | halt_error(1) end' \
           )" | tee --append "${GITHUB_OUTPUT}"
   build:
     needs: compute-matrix

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -94,7 +94,7 @@ jobs:
 
           echo "MATRIX=$(
             yq -n -o json 'env(TEST_MATRIX)' | \
-            jq -c '${{ inputs.matrix_filter }} | {include: .} | if .include != [] then . else halt_error(1) end' \
+            jq -c '${{ inputs.matrix_filter }} | if (. | length) > 0 then {include: .} else "Error: Empty matrix\n" | halt_error(1) end' \
           )" | tee --append "${GITHUB_OUTPUT}"
   tests:
     needs: compute-matrix

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -92,10 +92,12 @@ jobs:
           TEST_MATRIX=$(yq -n 'env(MATRICES) | .[strenv(BUILD_TYPE)]')
           export TEST_MATRIX
 
-          echo "MATRIX=$(
+          MATRIX="$(
             yq -n -o json 'env(TEST_MATRIX)' | \
-            jq -c '${{ inputs.matrix_filter }} | if (. | length) > 0 then {include: .} else "Error: Empty matrix\n" | halt_error(1) end' \
-          )" | tee --append "${GITHUB_OUTPUT}"
+            jq -c '${{ inputs.matrix_filter }} | if (. | length) > 0 then {include: .} else "Error: Empty matrix\n" | halt_error(1) end'
+          )"
+
+          echo "MATRIX=${MATRIX}" | tee --append "${GITHUB_OUTPUT}"
   tests:
     needs: compute-matrix
     strategy:

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -94,7 +94,7 @@ jobs:
 
           echo "MATRIX=$(
             yq -n -o json 'env(TEST_MATRIX)' | \
-            jq -c '${{ inputs.matrix_filter }} | {include: .}' \
+            jq -c '${{ inputs.matrix_filter }} | {include: .} | if .include != [] then . else halt_error(1) end' \
           )" | tee --append "${GITHUB_OUTPUT}"
   tests:
     needs: compute-matrix

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -117,11 +117,12 @@ jobs:
               export MATRIX+=${NEW_MANYLINUX_MATRIX}
           fi
 
-          echo "MATRIX=$(
+          MATRIX="$(
             yq -n -o json 'env(MATRIX)' | \
-            jq -c '${{ inputs.matrix_filter }} | if (. | length) > 0 then {include: .} else "Error: Empty matrix\n" | halt_error(1) end' \
-          )" | tee --append "${GITHUB_OUTPUT}"
+            jq -c '${{ inputs.matrix_filter }} | if (. | length) > 0 then {include: .} else "Error: Empty matrix\n" | halt_error(1) end'
+          )"
 
+          echo "MATRIX=${MATRIX}" | tee --append "${GITHUB_OUTPUT}"
   build:
     name:  ${{ matrix.CUDA_VER }}, ${{ matrix.PY_VER }}, ${{ matrix.ARCH }}, ${{ matrix.LINUX_VER }}
     needs: [compute-matrix]

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -119,11 +119,11 @@ jobs:
 
           echo "MATRIX=$(
             yq -n -o json 'env(MATRIX)' | \
-            jq -c '${{ inputs.matrix_filter }} | {include: .}' \
+            jq -c '${{ inputs.matrix_filter }} | {include: .} | if .include != [] then . else halt_error(1) end' \
           )" | tee --append "${GITHUB_OUTPUT}"
 
   build:
-    name:  ${{ matrix.CUDA_VER }}, ${{ matrix.PY_VER }}, ${{ matrix.ARCH }}, ${{ matrix.LINUX_VER }} 
+    name:  ${{ matrix.CUDA_VER }}, ${{ matrix.PY_VER }}, ${{ matrix.ARCH }}, ${{ matrix.LINUX_VER }}
     needs: [compute-matrix]
     strategy:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -119,7 +119,7 @@ jobs:
 
           echo "MATRIX=$(
             yq -n -o json 'env(MATRIX)' | \
-            jq -c '${{ inputs.matrix_filter }} | {include: .} | if .include != [] then . else halt_error(1) end' \
+            jq -c '${{ inputs.matrix_filter }} | if (. | length) > 0 then {include: .} else "Error: Empty matrix\n" | halt_error(1) end' \
           )" | tee --append "${GITHUB_OUTPUT}"
 
   build:

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -98,7 +98,7 @@ jobs:
 
           echo "MATRIX=$(
             yq -n -o json 'env(TEST_MATRIX)' | \
-            jq -c '${{ inputs.matrix_filter }} | {include: .}' \
+            jq -c '${{ inputs.matrix_filter }} | if (. | length) > 0 then {include: .} else "Error: Empty matrix\n" | halt_error(1) end' \
           )" | tee --append "${GITHUB_OUTPUT}"
 
   test:

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -96,11 +96,12 @@ jobs:
           TEST_MATRIX=$(yq -n 'env(MATRICES) | .[strenv(BUILD_TYPE)]')
           export TEST_MATRIX
 
-          echo "MATRIX=$(
+          MATRIX="$(
             yq -n -o json 'env(TEST_MATRIX)' | \
-            jq -c '${{ inputs.matrix_filter }} | if (. | length) > 0 then {include: .} else "Error: Empty matrix\n" | halt_error(1) end' \
-          )" | tee --append "${GITHUB_OUTPUT}"
+            jq -c '${{ inputs.matrix_filter }} | if (. | length) > 0 then {include: .} else "Error: Empty matrix\n" | halt_error(1) end'
+          )"
 
+          echo "MATRIX=${MATRIX}" | tee --append "${GITHUB_OUTPUT}"
   test:
     name: ${{ matrix.CUDA_VER }}, ${{ matrix.PY_VER }}, ${{ matrix.ARCH }}, ${{ matrix.LINUX_VER }}, ${{ matrix.gpu }}
     needs: compute-matrix


### PR DESCRIPTION
Currently the `compute-matrix` job passes even if the computed matrix is empty. Empty matrices raise an error (as shown below) so this should not be permitted.

![image](https://github.com/rapidsai/shared-workflows/assets/3943761/4d17b16f-c385-4634-960b-606fe087ed32)

This is tested in https://github.com/rapidsai/cudf/pull/15221.