### PR TITLE
Add back wheels test job for Python 3.11, amd64, CUDA 12.

### DIFF
--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -76,6 +76,7 @@ jobs:
             pull-request:
               # amd64
               - { ARCH: 'amd64', PY_VER: '3.9',  CUDA_VER: '12.2.2', LINUX_VER: 'ubuntu22.04', gpu: 'v100', driver: 'latest' }
+              - { ARCH: 'amd64', PY_VER: '3.11', CUDA_VER: '12.2.2', LINUX_VER: 'ubuntu22.04', gpu: 'v100', driver: 'latest' }
               # arm64
               - { ARCH: 'arm64', PY_VER: '3.11', CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu20.04', gpu: 'a100', driver: 'latest' }
             nightly:


### PR DESCRIPTION
This reverts part of #184. We found that wheel tests were failing due to a lack of proper support for "pure" Python wheels (independent of Python version and arch). Adding back the Python 3.11, amd64, CUDA 12 job will temporarily fix this (by making the "latest Python/CUDA" matrix filter used for wheel tests match the same configuration as the wheel build jobs).

We will need to change the `gha-tools` scripts to better handle pure Python wheels that should not have a Python version in their tarball names for upload/download.

#187 will fix an underlying cause of this issue (we didn't notice that the `compute-matrix` job had an empty matrix because it passed in #184).