### PR TITLE
Allow codecov on arm64 machines

### DIFF
--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -146,7 +146,7 @@ jobs:
           paths: "${{ env.RAPIDS_TESTS_DIR }}/*.xml"
         if: always()
       - name: Run codecov
-        if: inputs.run_codecov && runner.arch == 'X64'
+        if: inputs.run_codecov
         run: |
           codecov \
             -s \


### PR DESCRIPTION
`codecov` is now supported for `arm` architectures as of https://github.com/codecov/uploader/issues/523

Should only merge after:
- https://github.com/rapidsai/ci-imgs/pull/126