### PR TITLE
Revert "Add back wheels test job for Python 3.11, amd64, CUDA 12."

### DIFF
--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -76,7 +76,6 @@ jobs:
             pull-request:
               # amd64
               - { ARCH: 'amd64', PY_VER: '3.9',  CUDA_VER: '12.2.2', LINUX_VER: 'ubuntu22.04', gpu: 'v100', driver: 'latest' }
-              - { ARCH: 'amd64', PY_VER: '3.11', CUDA_VER: '12.2.2', LINUX_VER: 'ubuntu22.04', gpu: 'v100', driver: 'latest' }
               # arm64
               - { ARCH: 'arm64', PY_VER: '3.11', CUDA_VER: '11.8.0', LINUX_VER: 'ubuntu20.04', gpu: 'a100', driver: 'latest' }
             nightly:


### PR DESCRIPTION
Reverts rapidsai/shared-workflows#188

To keep things running smoothly, we're going to wait to merge this until 24.06 since it relies on fixes elsewhere in RAPIDS and we want to give ourselves a bit of time to get everything sorted out.