### PR TITLE
Remove `build_script` & `test_script`

### DIFF
--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -15,8 +15,6 @@ on:
       node_type:
         type: string
         default: "cpu8"
-      build_script:
-        type: string
       script:
         type: string
         default: "ci/build_cpp.sh"
@@ -110,7 +108,7 @@ jobs:
           echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
       - name: C++ build
-        run: ${{ inputs.build_script || inputs.script }}
+        run: ${{ inputs.script }}
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Upload additional artifacts

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -12,8 +12,6 @@ on:
         type: string
       repo:
         type: string
-      test_script:
-        type: string
       script:
         type: string
         default: "ci/test_cpp.sh"
@@ -135,7 +133,7 @@ jobs:
           echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
       - name: C++ tests
-        run: ${{ inputs.test_script || inputs.script }}
+        run: ${{ inputs.script }}
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Generate test report

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -15,8 +15,6 @@ on:
       node_type:
         type: string
         default: "cpu8"
-      build_script:
-        type: string
       script:
         type: string
         default: "ci/build_python.sh"
@@ -116,7 +114,7 @@ jobs:
           echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
       - name: Python build
-        run: ${{ inputs.build_script || inputs.script }}
+        run: ${{ inputs.script }}
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Upload additional artifacts

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -12,8 +12,6 @@ on:
         type: string
       repo:
         type: string
-      test_script:
-        type: string
       script:
         type: string
         default: "ci/test_python.sh"
@@ -139,7 +137,7 @@ jobs:
           echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
       - name: Python tests
-        run: ${{ inputs.test_script || inputs.script }}
+        run: ${{ inputs.script }}
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Generate test report


### PR DESCRIPTION
Removes all `build_script` and `test_script` input references.

See https://github.com/rapidsai/shared-workflows/pull/191#issue-2184593787

Depends on these PRs:

- https://github.com/rapidsai/cudf/pull/15301
- https://github.com/rapidsai/wholegraph/pull/147
- https://github.com/rapidsai/cugraph-ops/pull/615
- https://github.com/rapidsai/cuml/pull/5802
- https://github.com/rapidsai/ucxx/pull/208
- https://github.com/rapidsai/integration/pull/705
- https://github.com/rapidsai/legate-cuml/pull/11
- https://github.com/rapidsai/cudf-private/pull/172
- https://github.com/rapidsai/pynvjitlink/pull/67
- https://github.com/rapidsai/cudf-pandas-integration/pull/101
- https://github.com/rapidsai/gputreeshap/pull/44
