### PR TITLE
Remove input for build-2_28-wheels.

### DIFF
--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -45,12 +45,6 @@ on:
         type: string
         default: ''
 
-      # Build manylinux 2.28 wheels in addition to 2.17 wheels
-      build-2_28-wheels:
-        required: false
-        type: string
-        default: 'false'
-
 defaults:
   run:
     shell: bash


### PR DESCRIPTION
Cleans up an extra option that was needed to support building both `manylinux_2_28` and `manylinux_2_17` wheels for cudf.

Depends on https://github.com/rapidsai/cudf/pull/15323.
