### PR TITLE
Enable publishing C++ wheels

### DIFF
--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -20,6 +20,10 @@ on:
       package-name:
         required: true
         type: string
+      package-type:
+        required: false
+        default: python
+        type: string
 
 permissions:
   actions: read
@@ -73,6 +77,6 @@ jobs:
         sha: ${{ inputs.sha }}
 
     - name: Download wheels from downloads.rapids.ai and publish to anaconda repository
-      run: rapids-wheels-anaconda "${{ inputs.package-name }}"
+      run: rapids-wheels-anaconda "${{ inputs.package-name }}" "${{ inputs.package-type }}"
       env:
         RAPIDS_CONDA_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}


### PR DESCRIPTION
This adapts the shared workflow for publishing for the support for cpp wheels added in https://github.com/rapidsai/gha-tools/pull/105. 