### PR TITLE
Add `RAPIDS_AUX_SECRET_1` to select workflows

### DIFF
--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -27,6 +27,11 @@ on:
         required: false
         type: string
         default: ''
+    # the use of secrets in shared-workflows is discouraged, especially for public repositories.
+    # these values were added for situations where the use of secrets is unavoidable.
+    secrets:
+      RAPIDS_AUX_SECRET_1:
+        required: false
 
 permissions:
   actions: read
@@ -93,6 +98,7 @@ jobs:
             AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }}
             AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }}
             AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}
+            RAPIDS_AUX_SECRET_1=${{ secrets.RAPIDS_AUX_SECRET_1 }}
           runCmd: |
             set -e;
             mkdir -p ~/.config/pip/;

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -29,6 +29,11 @@ on:
         required: false
         type: string
         default: "fail"
+    # the use of secrets in shared-workflows is discouraged, especially for public repositories.
+    # these values were added for situations where the use of secrets is unavoidable.
+    secrets:
+      RAPIDS_AUX_SECRET_1:
+        required: false
 
 defaults:
   run:
@@ -151,6 +156,7 @@ jobs:
       run: ${{ inputs.script }}
       env:
         GH_TOKEN: ${{ github.token }}
+        RAPIDS_AUX_SECRET_1: ${{ secrets.RAPIDS_AUX_SECRET_1 }}
 
     - name: Generate test report
       uses: test-summary/action@v2.3


### PR DESCRIPTION
There is a need to inject a secret into these shared-workflows by one of our repositories.

This PR adds an optional secret, `RAPIDS_AUX_SECRET_1`, to the necessary shared workflows.

I intentionally didn't add this secret to the other workflows, because its use is strongly discouraged. Therefore, we should only add it to workflows as needed.

This secret can be used by calling workflows like this:

```yaml
jobs:
  wheels-test:
    uses: rapidsai/shared-workflows/.github/workflows/wheels-test.yaml@branch-24.06
    secrets:
      RAPIDS_AUX_SECRET_1: ${{ secrets.REPO_SPECIFIC_SECRET }}
```