### PR TITLE
Remove `PARALLEL_LEVEL` env variable from workflows

### DIFF
--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -85,7 +85,6 @@ jobs:
       image: rapidsai/ci-conda:cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
-        PARALLEL_LEVEL: ${{ env.PARALLEL_LEVEL }}
     steps:
       - uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -109,7 +109,6 @@ jobs:
       options: ${{ inputs.container-options }}
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
-        PARALLEL_LEVEL: ${{ env.PARALLEL_LEVEL }}
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
     steps:
       - uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -91,7 +91,6 @@ jobs:
       image: rapidsai/ci-conda:cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
-        PARALLEL_LEVEL: ${{ env.PARALLEL_LEVEL }}
     steps:
       - uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -113,7 +113,6 @@ jobs:
       options: ${{ inputs.container-options }}
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
-        PARALLEL_LEVEL: ${{ env.PARALLEL_LEVEL }}
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
     steps:
       - uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -53,7 +53,6 @@ jobs:
       image: ${{ inputs.container_image }}
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
-        PARALLEL_LEVEL: ${{ env.PARALLEL_LEVEL }}
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
     steps:
       - uses: aws-actions/configure-aws-credentials@v4


### PR DESCRIPTION
Now that https://github.com/rapidsai/gha-tools/pull/108 is merged, we can remove the `PARALLEL_LEVEL` from our workflows. 

Also, workflows can't access env variables defined at the runner level using the `env` context ([doc](https://docs.github.com/en/actions/learn-github-actions/contexts#env-context)), so these lines never worked as expected.