### PR TITLE
Revert "Add codecov organization token"

### DIFF
--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -146,15 +146,11 @@ jobs:
         if: always()
       - name: Run codecov
         if: inputs.run_codecov
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
           codecov \
-            upload-process \
-            -v \
             -s \
-            -C ${{ github.sha }} \
             "${RAPIDS_COVERAGE_DIR}" \
+            -v
       - name: Upload additional artifacts
         if: "!cancelled()"
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}


### PR DESCRIPTION
Reverts rapidsai/shared-workflows#212

Reason explained [here](https://github.com/rapidsai/ci-imgs/pull/142#issue-2328451536).

This PR depends on rapidsai/ci-imgs/pull/142