### PR TITLE
Fix incorrect secret name in project automation

### DIFF
--- a/.github/workflows/project-get-item-id.yaml
+++ b/.github/workflows/project-get-item-id.yaml
@@ -16,7 +16,7 @@ on:
         required: true
 
     secrets:
-      PROJECT_MANAGEMENT_SECRET:
+      ADD_TO_PROJECT_GITHUB_TOKEN:
         description: "Project Access Token"
         required: true
 
@@ -40,7 +40,7 @@ jobs:
       - name: Get Item Project ID
         id: get_item_id
         env:
-          GH_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_SECRET }}
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_GITHUB_TOKEN }}
         run: |
             # Query up to 10 projects for the PR
             # There's no graphQL filter configured to query by a specific project

--- a/.github/workflows/project-get-set-iteration-field.yaml
+++ b/.github/workflows/project-get-set-iteration-field.yaml
@@ -42,7 +42,7 @@ on:
         type: boolean
 
     secrets:
-      PROJECT_MANAGEMENT_SECRET:
+      ADD_TO_PROJECT_GITHUB_TOKEN:
         description: "Project Access Token"
         required: true
 
@@ -63,7 +63,7 @@ jobs:
       - name: Get Iteration Option ID
         id: get_iteration_option_id
         env:
-          GH_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_SECRET }}
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_GITHUB_TOKEN }}
         run: |
             # Get current iteration iteration id
             # The current iteration is always the first element in the returned list
@@ -93,7 +93,7 @@ jobs:
         id: update_item_iteration_field
         if: ${{ inputs.UPDATE_ITEM == true }}
         env:
-          GH_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_SECRET }}
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_GITHUB_TOKEN }}
         run: |
             # Set the iteration based on the query above
             # This overwrites whatever was in it before, we may want to make an "OVERWRITE" option

--- a/.github/workflows/project-get-set-single-select-field.yaml
+++ b/.github/workflows/project-get-set-single-select-field.yaml
@@ -47,7 +47,7 @@ on:
         type: boolean
 
     secrets:
-      PROJECT_MANAGEMENT_SECRET:
+      ADD_TO_PROJECT_GITHUB_TOKEN:
         description: "Project Access Token"
         required: true
 
@@ -68,7 +68,7 @@ jobs:
       - name: Get single_select Option ID
         id: get_single_select_option_id
         env:
-          GH_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_SECRET }}
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_GITHUB_TOKEN }}
         run: |
             # Get single_select option id
             gh api graphql -f query='
@@ -92,7 +92,7 @@ jobs:
         id: update_item_single_select_field
         if: ${{ inputs.UPDATE_ITEM == true }}
         env:
-          GH_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_SECRET }}
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_GITHUB_TOKEN }}
         run: |
             # Set the single_select based on the query above
             # This overwrites whatever was in it before, we may want to make an "OVERWRITE" option

--- a/.github/workflows/project-set-text-date-numeric-field.yaml
+++ b/.github/workflows/project-set-text-date-numeric-field.yaml
@@ -43,7 +43,7 @@ on:
         type: boolean
 
     secrets:
-      PROJECT_MANAGEMENT_SECRET:
+      ADD_TO_PROJECT_GITHUB_TOKEN:
         description: "Project Access Token"
         required: true
 
@@ -57,7 +57,7 @@ jobs:
       - name: Update item text/date/numeric field
         id: update_item_text_date_numeric_field
         env:
-          GH_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_SECRET }}
+          GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_GITHUB_TOKEN }}
         run: |
             # Set the field based on the inputted desired value
             # This overwrites whatever was in it before, we may want to make an "OVERWRITE" option

--- a/.github/workflows/project-update-linked-issues.yaml
+++ b/.github/workflows/project-update-linked-issues.yaml
@@ -38,7 +38,7 @@ on:
         required: true
 
     secrets:
-      PROJECT_MANAGEMENT_SECRET:
+      ADD_TO_PROJECT_GITHUB_TOKEN:
         description: "Project Access Token"
         required: true
 
@@ -53,7 +53,7 @@ jobs:
         - name: Sync Linked Issues
           id: sync_linked_issues
           env:
-            GITHUB_TOKEN: ${{ secrets.PROJECT_MANAGEMENT_SECRET }}
+            GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_GITHUB_TOKEN }}
           run: |
             # Find the linked issues to the PR
             # If an issue is passed in, the json will return null and the for loop won't trigger


### PR DESCRIPTION
#168 had a note at the bottom to do before merge that I failed to catch:

> ### TODO BEFORE MERGE
> 
> Currently all of the reusable workflows have the secret set to PROJECT_MANAGEMENT_SECRET, this needs to be changed to ADD_TO_PROJECT_GITHUB_TOKEN which is a token scoped specifically for project-related tasks.

These actions are set to be used in cuDF so opening this to fix the above secret issue.