### PR TITLE
Increase sleep timer for the get project ID workflow

### DIFF
--- a/.github/workflows/project-get-item-id.yaml
+++ b/.github/workflows/project-get-item-id.yaml
@@ -32,10 +32,10 @@ jobs:
       ITEM_PROJECT_ID: ${{ steps.get_item_id.outputs.ITEM_PROJECT_ID }}
 
     steps:
-      - name: Sleep 1s
+      - name: Sleep 10s
         id: sleep_1s
         run: |
-          sleep 1 # Ensure the PR is added to the project before we query its ID
+          sleep 10 # Ensure the PR is added to the project before we query its ID
 
       - name: Get Item Project ID
         id: get_item_id

--- a/.github/workflows/project-get-item-id.yaml
+++ b/.github/workflows/project-get-item-id.yaml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Sleep 10s
-        id: sleep_1s
+        id: sleep
         run: |
           sleep 10 # Ensure the PR is added to the project before we query its ID
 


### PR DESCRIPTION
Right now we sleep for 1s prior to getting the project ID, but in cuDF sometimes new PRs still aren't being added in time. This PR increases the duration to 10s to resolve this.