### PR TITLE
Remove verbosity added in #164

### DIFF
--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -59,10 +59,6 @@ jobs:
     runs-on: "linux-${{ matrix.arch }}-${{ inputs.node_type }}"
     steps:
       - uses: actions/checkout@v4
-        env:
-          GIT_TRACE_PACKET: 1
-          GIT_TRACE: 1
-          GIT_CURL_VERBOSE: 1
         with:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -46,10 +46,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        env:
-          GIT_TRACE_PACKET: 1
-          GIT_TRACE: 1
-          GIT_CURL_VERBOSE: 1
       - name: Get PR Info
         id: get-pr-info
         uses: rapidsai/shared-actions/get-pr-info@main
@@ -71,10 +67,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        env:
-          GIT_TRACE_PACKET: 1
-          GIT_TRACE: 1
-          GIT_CURL_VERBOSE: 1
         with:
           fetch-depth: 0
       - name: Get PR Info

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -92,10 +92,6 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           role-duration-seconds: 43200 # 12h
       - uses: actions/checkout@v4
-        env:
-          GIT_TRACE_PACKET: 1
-          GIT_TRACE: 1
-          GIT_CURL_VERBOSE: 1
         with:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}

--- a/.github/workflows/conda-cpp-post-build-checks.yaml
+++ b/.github/workflows/conda-cpp-post-build-checks.yaml
@@ -53,10 +53,6 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           role-duration-seconds: 43200 # 12h
       - uses: actions/checkout@v4
-        env:
-          GIT_TRACE_PACKET: 1
-          GIT_TRACE: 1
-          GIT_CURL_VERBOSE: 1
         with:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}
@@ -75,10 +71,6 @@ jobs:
           echo "RAPIDS_EXTRACTED_DIR=${EXTRACTED_DIR}" >> "${GITHUB_ENV}"
       - name: Get weak detection tool
         uses: actions/checkout@v4
-        env:
-          GIT_TRACE_PACKET: 1
-          GIT_TRACE: 1
-          GIT_CURL_VERBOSE: 1
         with:
           repository: rapidsai/detect-weak-linking
           ref: refs/heads/main

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -117,10 +117,6 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           role-duration-seconds: 43200 # 12h
       - uses: actions/checkout@v4
-        env:
-          GIT_TRACE_PACKET: 1
-          GIT_TRACE: 1
-          GIT_CURL_VERBOSE: 1
         with:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -98,10 +98,6 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           role-duration-seconds: 43200 # 12h
       - uses: actions/checkout@v4
-        env:
-          GIT_TRACE_PACKET: 1
-          GIT_TRACE: 1
-          GIT_CURL_VERBOSE: 1
         with:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -121,10 +121,6 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           role-duration-seconds: 43200 # 12h
       - uses: actions/checkout@v4
-        env:
-          GIT_TRACE_PACKET: 1
-          GIT_TRACE: 1
-          GIT_CURL_VERBOSE: 1
         with:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -52,10 +52,6 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           role-duration-seconds: 43200 # 12h
       - uses: actions/checkout@v4
-        env:
-          GIT_TRACE_PACKET: 1
-          GIT_TRACE: 1
-          GIT_CURL_VERBOSE: 1
         with:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -61,10 +61,6 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           role-duration-seconds: 43200 # 12h
       - uses: actions/checkout@v4
-        env:
-          GIT_TRACE_PACKET: 1
-          GIT_TRACE: 1
-          GIT_CURL_VERBOSE: 1
         with:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -124,10 +124,6 @@ jobs:
           role-duration-seconds: 43200 # 12h
       - name: checkout code repo
         uses: actions/checkout@v4
-        env:
-          GIT_TRACE_PACKET: 1
-          GIT_TRACE: 1
-          GIT_CURL_VERBOSE: 1
         with:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}
@@ -152,10 +148,6 @@ jobs:
       - name: checkout extra repos
         uses: actions/checkout@v4
         if: ${{ inputs.extra-repo != '' }}
-        env:
-          GIT_TRACE_PACKET: 1
-          GIT_TRACE: 1
-          GIT_CURL_VERBOSE: 1
         with:
           repository: ${{ inputs.extra-repo }}
           ref: ${{ inputs.extra-repo-sha }}

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -58,10 +58,6 @@ jobs:
         role-duration-seconds: 43200 # 12h
     - name: checkout code repo
       uses: actions/checkout@v4
-      env:
-        GIT_TRACE_PACKET: 1
-        GIT_TRACE: 1
-        GIT_CURL_VERBOSE: 1
       with:
         repository: ${{ inputs.repo }}
         ref: ${{ inputs.sha }}

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -134,10 +134,6 @@ jobs:
 
     - name: checkout code repo
       uses: actions/checkout@v4
-      env:
-        GIT_TRACE_PACKET: 1
-        GIT_TRACE: 1
-        GIT_CURL_VERBOSE: 1
       with:
         repository: ${{ inputs.repo }}
         ref: ${{ inputs.sha }}


### PR DESCRIPTION
This PR removes the verbosity that was added in #164. It was originally added for debugging purposes. It can be removed now. It causes our GitHub Actions logs to be really verbose.