### PR TITLE
Backport codecov changes to 24.06

### DIFF
--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -147,6 +147,8 @@ jobs:
         if: always()
       - name: Run codecov
         if: inputs.run_codecov
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: |
           codecovcli \
             -v \

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -148,10 +148,12 @@ jobs:
       - name: Run codecov
         if: inputs.run_codecov
         run: |
-          codecov \
-            -s \
-            "${RAPIDS_COVERAGE_DIR}" \
-            -v
+          codecovcli \
+            -v \
+            upload-process \
+            -C ${{ github.sha }} \
+            -s "${RAPIDS_COVERAGE_DIR}" \
+            --handle-no-reports-found
       - name: Upload additional artifacts
         if: "!cancelled()"
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}


### PR DESCRIPTION
Backport of the codecov changes to `branch-24.06` so that the `cudf` hotfix can proceed.
