### PR TITLE
Set up optional release publishing to pypi

### DIFF
--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -24,6 +24,10 @@ on:
         required: false
         default: python
         type: string
+      publish_to_pypi:
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   actions: read
@@ -76,3 +80,21 @@ jobs:
       run: rapids-wheels-anaconda "${{ inputs.package-name }}" "${{ inputs.package-type }}"
       env:
         RAPIDS_CONDA_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
+
+    - name: Check if build is release
+      id: check_if_release
+      shell: bash
+      if: ${{ inputs.publish_to_pypi }}
+      run: |
+        if rapids-is-release-build; then
+          echo "is_release_build=true" | tee -a ${GITHUB_OUTPUT}
+        else
+          echo "is_release_build=false" | tee -a ${GITHUB_OUTPUT}
+        fi
+
+    - name: Publish the downloaded wheels to PyPI
+      if: ${{ inputs.publish_to_pypi && steps.check_if_release.outputs.is_release_build == 'true' }}
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}
+        repository-url: https://pypi.org/legacy/

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -96,5 +96,5 @@ jobs:
       if: ${{ inputs.publish_to_pypi && steps.check_if_release.outputs.is_release_build == 'true' }}
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        password: ${{ secrets.PYPI_API_TOKEN }}
+        password: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
         repository-url: https://pypi.org/legacy/


### PR DESCRIPTION
Depends on https://github.com/rapidsai/gha-tools/pull/111

Test PR - https://github.com/rapidsai/cucim/pull/743
Succeeding job - https://github.com/rapidsai/cucim/actions/runs/9747594045/job/26901055023?pr=743

Published wheels (test-pypi):
cucim-cu11 - https://test.pypi.org/manage/project/cucim-cu11/releases/
cucim-cu12 - https://test.pypi.org/manage/project/cucim-cu12/releases/