### PR TITLE
Remove repository-url specification

### DIFF
--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -97,4 +97,3 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
-        repository-url: https://pypi.org/legacy/


### PR DESCRIPTION
Its not exactly clear in the [pypi-publish action docs](https://github.com/marketplace/actions/pypi-publish) what the upload URL for `pypi.org` should be. For `https://test.pypi.org/`, it's clearly documented to be `https://test.pypi.org/legacy`. However, for `pypi.org`, its not exactly clear in the docs.

These comments suggest https://upload.pypi.org/legacy/:

https://github.com/pypa/gh-action-pypi-publish/issues/130#issuecomment-1471374724
https://github.com/pypa/gh-action-pypi-publish/issues/130#issuecomment-1471374724

but not specifying a repository-url at should cause the action to default to the actual upload url for `pypi.org`.