### PR TITLE
Always use rapidsai channel token.

### DIFF
--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -62,27 +62,11 @@ jobs:
           echo "RAPIDS_SHA=$(git rev-parse HEAD)" >> "${GITHUB_ENV}"
           echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
-      - name: Check if repository is private
-        uses: actions/github-script@v7
-        id: is-private
-        with:
-          result-encoding: string
-          retries: 5
-          script: |
-            return (await github.rest.repos.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            })).data.private
       - name: Set Proper Conda Upload Token
-        env:
-          REPO_IS_PRIVATE: ${{steps.is-private.outputs.result}}
         run: |
           RAPIDS_CONDA_TOKEN=${{ secrets.CONDA_RAPIDSAI_NIGHTLY_TOKEN }}
           if rapids-is-release-build; then
             RAPIDS_CONDA_TOKEN=${{ secrets.CONDA_RAPIDSAI_TOKEN }}
-            if [ "${REPO_IS_PRIVATE}" = "true" ]; then
-              RAPIDS_CONDA_TOKEN=${{ secrets.CONDA_NVIDIA_TOKEN }}
-            fi
           fi
           echo "RAPIDS_CONDA_TOKEN=${RAPIDS_CONDA_TOKEN}" >> "${GITHUB_ENV}"
       - name: Upload packages


### PR DESCRIPTION
We would like to publish the conda packages for the `cugraph-ops` & `cumlprims_mg` repos to `rapidsai` instead of `nvidia` for releases to continue to reduce our dependence on the `nvidia` channel.
