### PR TITLE
Check job results in pr-builder

### DIFF
--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -2,7 +2,7 @@ on:
   workflow_call:
     inputs:
       needs:
-        description: 'Value should always be `${{ needs }}`'
+        description: 'Value should always be `${{ toJSON(needs) }}`'
         required: false
         type: string
         default: '{}'

--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -2,7 +2,6 @@ on:
   workflow_call:
     inputs:
       needs:
-        description: "Value should always be `${{ '${{ toJSON(needs) }}' }}`"
         required: false
         type: string
         default: '{}'

--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -2,7 +2,7 @@ on:
   workflow_call:
     inputs:
       needs:
-        description: 'Value should always be `${{ toJSON(needs) }}`'
+        description: 'Value should always be `${{ '${{ toJSON(needs) }}' }}`'
         required: false
         type: string
         default: '{}'

--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -14,4 +14,4 @@ jobs:
       - name: "Check all dependent jobs"
         env:
           NEEDS: ${{ inputs.needs }}
-        run: echo "$NEEDS" | jq -e 'map(select((.result == "success" or .result == "skipped") | not)) | length == 0'
+        run: echo "$NEEDS" | jq -e 'any((.result as $result | ["success", "skipped"] | any($result == .)) | not) | not'

--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -9,5 +9,8 @@ jobs:
           cat <<EOFFFFFF
             ${{ toJSON(needs) }}
           EOFFFFFF
+          cat <<EOFFFFFF
+            ${{ toJSON(github) }}
+          EOFFFFFF
       # This reusable workflow should depend on all other jobs in the calling workflow.
       - run: exit 0

--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -8,6 +8,7 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
+    if: always()
     steps:
       - run: |
           cat <<EOFFFFFF

--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -1,5 +1,9 @@
 on:
   workflow_call:
+    inputs:
+      needs:
+        required: true
+        type: string
 
 jobs:
   run:
@@ -11,6 +15,9 @@ jobs:
           EOFFFFFF
           cat <<EOFFFFFF
             ${{ toJSON(github) }}
+          EOFFFFFF
+          cat <<EOFFFFFF
+            ${{ toJSON(inputs.needs) }}
           EOFFFFFF
       # This reusable workflow should depend on all other jobs in the calling workflow.
       - run: exit 0

--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - run: |
           cat <<EOFFFFFF
-            ${{ needs }}
+            ${{ toJSON(needs) }}
           EOFFFFFF
       # This reusable workflow should depend on all other jobs in the calling workflow.
       - run: exit 0

--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -2,16 +2,17 @@ on:
   workflow_call:
     inputs:
       needs:
-        required: true
+        description: 'Value should always be `${{ needs }}`'
+        required: false
         type: string
+        default: '{}'
 
 jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          cat <<EOFFFFFF
-            ${{ toJSON(fromJSON(inputs.needs)) }}
-          EOFFFFFF
       # This reusable workflow should depend on all other jobs in the calling workflow.
-      - run: exit 0
+      - name: "Check all dependent jobs"
+        env:
+          NEEDS: ${{ inputs.needs }}
+        run: echo "$NEEDS" | jq -e 'map(select((.result == "success" or .result == "skipped") | not)) | length == 0'

--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -8,7 +8,6 @@ on:
 jobs:
   run:
     runs-on: ubuntu-latest
-    if: always()
     steps:
       - run: |
           cat <<EOFFFFFF

--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -2,7 +2,7 @@ on:
   workflow_call:
     inputs:
       needs:
-        description: 'Value should always be `${{ '${{ toJSON(needs) }}' }}`'
+        description: "Value should always be `${{ '${{ toJSON(needs) }}' }}`"
         required: false
         type: string
         default: '{}'

--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -11,13 +11,7 @@ jobs:
     steps:
       - run: |
           cat <<EOFFFFFF
-            ${{ toJSON(needs) }}
-          EOFFFFFF
-          cat <<EOFFFFFF
-            ${{ toJSON(github) }}
-          EOFFFFFF
-          cat <<EOFFFFFF
-            ${{ toJSON(inputs.needs) }}
+            ${{ toJSON(fromJSON(inputs.needs)) }}
           EOFFFFFF
       # This reusable workflow should depend on all other jobs in the calling workflow.
       - run: exit 0

--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -5,5 +5,9 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
+      - run: |
+          cat <<EOFFFFFF
+            ${{ needs }}
+          EOFFFFFF
       # This reusable workflow should depend on all other jobs in the calling workflow.
       - run: exit 0


### PR DESCRIPTION
Add a new input, `needs`, which should just be the value of `${{ toJSON(needs) }}` from the calling workflow. This input will be checked to see if all of the needed jobs have a result of either `success` or `skipped`. This allows dependencies of `pr-builder` to be skipped. See https://github.com/rapidsai/cudf/pull/16642#discussion_r1727663594 for the motivating use case.

Workflows that use `pr-builder` should have `if: always()` and `with: needs: ${{ toJSON(needs) }}`. Workflows that have not yet been updated for this new input will continue to work as before, because the `needs` input has a default value of `{}`, which will always pass this check, just as if the old `exit 0` had been called.