### PR TITLE
Simplify pr-builder check

### DIFF
--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -14,4 +14,4 @@ jobs:
       - name: "Check all dependent jobs"
         env:
           NEEDS: ${{ inputs.needs }}
-        run: echo "$NEEDS" | jq -e 'any((.result as $result | ["success", "skipped"] | any($result == .)) | not) | not'
+        run: jq -en 'env.NEEDS | fromjson | all(.result as $result | ["success", "skipped"] | any($result == .))'


### PR DESCRIPTION
Use DeMorgan's law to simplify the expression, and use `jq`'s built-in `env` object instead of piping in the string.

Follow-up to https://github.com/rapidsai/shared-workflows/pull/237#discussion_r1727945520