### PR TITLE
Add `changed-files` workflow

### DIFF
--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -18,7 +18,7 @@ on:
           ) |
           from_entries
     outputs:
-      transformed_output:
+      changed_file_groups:
         value: ${{ jobs.changed-files.outputs.transformed_output }}
 
 defaults:

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -1,0 +1,68 @@
+on:
+  workflow_call:
+    inputs:
+      files_yaml:
+        type: string
+        required: true
+      transform_expr:
+        type: string
+        required: true
+    outputs:
+      transformed_output:
+        value: ${{ jobs.changed-files.outputs.transformed_output }}
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  actions: read
+  checks: none
+  contents: read
+  deployments: none
+  discussions: none
+  id-token: write
+  issues: none
+  packages: read
+  pages: none
+  pull-requests: read
+  repository-projects: none
+  security-events: none
+  statuses: none
+
+jobs:
+  changed-files:
+    runs-on: ubuntu-latest
+    name: "Check changed files"
+    outputs:
+      transformed_output: ${{ steps.transform-changed-files.outputs.transformed-output }}
+    steps:
+      - name: Get PR info
+        id: get-pr-info
+        uses: rapidsai/shared-actions/get-pr-info@main
+      - name: Checkout code repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Calculate merge base
+        id: calculate-merge-base
+        env:
+          PR_SHA: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).head.sha }}
+          BASE_SHA: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.sha }}
+        run: |
+          (echo -n "merge-base="; git merge-base "$BASE_SHA" "$PR_SHA") | tee --append "$GITHUB_OUTPUT"
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+        with:
+          base_sha: ${{ steps.calculate-merge-base.outputs.merge-base }}
+          sha: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).head.sha }}
+          files_yaml: ${{ inputs.files_yaml }}
+      - name: Transform changed files into output
+        id: transform-changed-files
+        env:
+          CHANGED_FILES: ${{ toJSON(steps.changed-files.outputs) }}
+          TRANSFORM_EXPR: ${{ inputs.transform_expr }}
+        run: |
+          (echo -n "transformed-output="; jq -c -n "env.CHANGED_FILES | $TRANSFORM_EXPR") | tee --append "$GITHUB_OUTPUT"

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -65,4 +65,4 @@ jobs:
           CHANGED_FILES: ${{ toJSON(steps.changed-files.outputs) }}
           TRANSFORM_EXPR: ${{ inputs.transform_expr }}
         run: |
-          (echo -n "transformed-output="; jq -c -n "env.CHANGED_FILES | $TRANSFORM_EXPR") | tee --append "$GITHUB_OUTPUT"
+          (echo -n "transformed-output="; jq -c -n "env.CHANGED_FILES | fromjson | $TRANSFORM_EXPR") | tee --append "$GITHUB_OUTPUT"

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -10,10 +10,7 @@ on:
         default: |
           to_entries |
           map(
-            select(
-              .key |
-              endswith("_any_changed")
-            ) |
+            select(.key | endswith("_any_changed")) |
             {
               "key": ("test_" + (.key | rtrimstr("_any_changed"))),
               "value": (.value == "true"),

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -7,7 +7,19 @@ on:
       transform_expr:
         type: string
         required: false
-        default: '.'
+        default: |
+          to_entries |
+          map(
+            select(
+              .key |
+              endswith("_any_changed")
+            ) |
+            {
+              "key": ("test_" + (.key | rtrimstr("_any_changed"))),
+              "value": (.value == "true"),
+            }
+          ) |
+          from_entries
     outputs:
       transformed_output:
         value: ${{ jobs.changed-files.outputs.transformed_output }}

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -6,7 +6,8 @@ on:
         required: true
       transform_expr:
         type: string
-        required: true
+        required: false
+        default: '.'
     outputs:
       transformed_output:
         value: ${{ jobs.changed-files.outputs.transformed_output }}

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -12,7 +12,7 @@ on:
           map(
             select(.key | endswith("_any_changed")) |
             {
-              "key": ("test_" + (.key | rtrimstr("_any_changed"))),
+              "key": (.key | rtrimstr("_any_changed")),
               "value": (.value == "true"),
             }
           ) |


### PR DESCRIPTION
The logic for the "figure out which files changed" workflow is rather complex. Establish a shared workflow to handle the complexity of it.

Contributes to https://github.com/rapidsai/build-planning/issues/94

Tested in https://github.com/rapidsai/cugraph/pull/4634 and https://github.com/rapidsai/cudf/pull/16713