### PR TITLE
use get-pr-info from nv-gha-runners

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Get PR Info
         id: get-pr-info
-        uses: rapidsai/shared-actions/get-pr-info@main
+        uses: nv-gha-runners/get-pr-info@main
       - name: Run rapids-size-checker
         if: ${{ inputs.enable_check_size }}
         run: rapids-size-checker
@@ -71,7 +71,7 @@ jobs:
           fetch-depth: 0
       - name: Get PR Info
         id: get-pr-info
-        uses: rapidsai/shared-actions/get-pr-info@main
+        uses: nv-gha-runners/get-pr-info@main
       - uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Get PR Info
         if: startsWith(github.ref_name, 'pull-request/')
         id: get-pr-info
-        uses: rapidsai/shared-actions/get-pr-info@main
+        uses: nv-gha-runners/get-pr-info@main
       - name: Add PR Info
         if: startsWith(github.ref_name, 'pull-request/')
         run: |


### PR DESCRIPTION
There are two implementations of the same action; one in [rapidsai/shared-actions](https://github.com/rapidsai/shared-actions/tree/main/get-pr-info) and [the other](https://github.com/nv-gha-runners/get-pr-info) in the nv-gha-runners org. This PR switches to the implementation in the nv-gha-runners group in order to keep a single source of truth.

Tested in:
- https://github.com/rapidsai/rmm/actions/runs/10907991262/job/30272937231?pr=1682#step:4:1
- https://github.com/rapidsai/rmm/actions/runs/10907991262/job/30273536396?pr=1682