### PR TITLE
remove unneeded get-pr-info action

### DIFF
--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -49,7 +49,7 @@ jobs:
     steps:
       - name: Get PR info
         id: get-pr-info
-        uses: rapidsai/shared-actions/get-pr-info@main
+        uses: nv-gha-runners/get-pr-info@main
       - name: Checkout code repo
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Picks up the newly added reference following https://github.com/rapidsai/shared-workflows/pull/240