### PR TITLE
Pass changed files as file rather than environment variable

### DIFF
--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -78,4 +78,5 @@ jobs:
           TRANSFORM_EXPR: ${{ inputs.transform_expr }}
         run: |
           ls .github/outputs
+          cat .github/outputs/changed_keys.json
           (echo -n "transformed-output="; jq -c -n "env.CHANGED_FILES | fromjson | $TRANSFORM_EXPR") | tee --append "$GITHUB_OUTPUT"

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -69,10 +69,12 @@ jobs:
           base_sha: ${{ steps.calculate-merge-base.outputs.merge-base }}
           sha: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).head.sha }}
           files_yaml: ${{ inputs.files_yaml }}
+          write_output_files: true
       - name: Transform changed files into output
         id: transform-changed-files
         env:
           CHANGED_FILES: ${{ toJSON(steps.changed-files.outputs) }}
           TRANSFORM_EXPR: ${{ inputs.transform_expr }}
         run: |
+          ls .github/outputs
           (echo -n "transformed-output="; jq -c -n "env.CHANGED_FILES | fromjson | $TRANSFORM_EXPR") | tee --append "$GITHUB_OUTPUT"

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -13,7 +13,7 @@ on:
             select(.key | endswith("_any_changed")) |
             {
               "key": (.key | rtrimstr("_any_changed")),
-              "value": (.value == "true"),
+              "value": .value,
             }
           ) |
           from_entries
@@ -81,5 +81,4 @@ jobs:
             key="$(echo "$file" | sed -E 's/^\.github\/outputs\/(.*)\.json$/\1/g')"
             file_args=("${file_args[@]}" --slurpfile "$key" "$file")
           done
-          jq -n "\$ARGS.named | to_entries | map(select((.value | length) > 0) | {"key": .key, "value": .value[]}) | from_entries" "${file_args[@]}"
           (echo -n "transformed-output="; jq -c -n "\$ARGS.named | to_entries | map(select((.value | length) > 0) | {"key": .key, "value": .value[]}) | from_entries | $TRANSFORM_EXPR" "${file_args[@]}") | tee --append "$GITHUB_OUTPUT"

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -81,5 +81,5 @@ jobs:
             key="$(echo "$file" | sed -E 's/^\.github\/outputs\/(.*)\.json$/\1/g')"
             file_args=("${file_args[@]}" --slurpfile "$key" "$file")
           done
-          "jq -n "\$ARGS.named | to_entries | map(select((.value | length) > 0) | {"key": .key, "value": .value[]}) | from_entries" "${file_args[@]}"
+          jq -n "\$ARGS.named | to_entries | map(select((.value | length) > 0) | {"key": .key, "value": .value[]}) | from_entries" "${file_args[@]}"
           (echo -n "transformed-output="; jq -c -n "\$ARGS.named | to_entries | map(select((.value | length) > 0) | {"key": .key, "value": .value[]}) | from_entries | $TRANSFORM_EXPR" "${file_args[@]}") | tee --append "$GITHUB_OUTPUT"

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -81,4 +81,5 @@ jobs:
             key="$(echo "$file" | sed -E 's/^\.github\/outputs\/(.*)\.json$/\1/g')"
             file_args=("${file_args[@]}" --slurpfile "$key" "$file")
           done
+          "jq -n "\$ARGS.named | to_entries | map(select((.value | length) > 0) | {"key": .key, "value": .value[]}) | from_entries" "${file_args[@]}"
           (echo -n "transformed-output="; jq -c -n "\$ARGS.named | to_entries | map(select((.value | length) > 0) | {"key": .key, "value": .value[]}) | from_entries | $TRANSFORM_EXPR" "${file_args[@]}") | tee --append "$GITHUB_OUTPUT"

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -77,6 +77,10 @@ jobs:
           CHANGED_FILES: ${{ toJSON(steps.changed-files.outputs) }}
           TRANSFORM_EXPR: ${{ inputs.transform_expr }}
         run: |
-          ls .github/outputs
-          cat .github/outputs/changed_keys.json
+          file_args=()
+          for file in .github/outputs/*.json; do
+            key="$(echo "$file" | sed -E 's/^\.github\/outputs\/(.*)\.json$/\1/g')"
+            file_args=("${file_args[@]}" --slurpfile "$key" "$file")
+          done
+          jq -n '$ARGS.named' "${file_args[@]}"
           (echo -n "transformed-output="; jq -c -n "env.CHANGED_FILES | fromjson | $TRANSFORM_EXPR") | tee --append "$GITHUB_OUTPUT"

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -82,5 +82,4 @@ jobs:
             key="$(echo "$file" | sed -E 's/^\.github\/outputs\/(.*)\.json$/\1/g')"
             file_args=("${file_args[@]}" --slurpfile "$key" "$file")
           done
-          jq -c -n "$ARGS.named | to_entries | select((.value | length) > 0)" "${file_args[@]}"
-          (echo -n "transformed-output="; jq -c -n "$ARGS.named | to_entries | select((.value | length) > 0) | map({"key": .key, "value": .value[]}) | from_entries | $TRANSFORM_EXPR" "${file_args[@]}") | tee --append "$GITHUB_OUTPUT"
+          (echo -n "transformed-output="; jq -c -n "\$ARGS.named | to_entries | select((.value | length) > 0) | map({"key": .key, "value": .value[]}) | from_entries | $TRANSFORM_EXPR" "${file_args[@]}") | tee --append "$GITHUB_OUTPUT"

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -82,4 +82,4 @@ jobs:
             key="$(echo "$file" | sed -E 's/^\.github\/outputs\/(.*)\.json$/\1/g')"
             file_args=("${file_args[@]}" --slurpfile "$key" "$file")
           done
-          (echo -n "transformed-output="; jq -c -n "\$ARGS.named | to_entries | select((.value | length) > 0) | map({"key": .key, "value": .value[]}) | from_entries | $TRANSFORM_EXPR" "${file_args[@]}") | tee --append "$GITHUB_OUTPUT"
+          (echo -n "transformed-output="; jq -c -n "\$ARGS.named | to_entries | map(select((.value | length) > 0) | {"key": .key, "value": .value[]}) | from_entries | $TRANSFORM_EXPR" "${file_args[@]}") | tee --append "$GITHUB_OUTPUT"

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -74,7 +74,6 @@ jobs:
       - name: Transform changed files into output
         id: transform-changed-files
         env:
-          CHANGED_FILES: ${{ toJSON(steps.changed-files.outputs) }}
           TRANSFORM_EXPR: ${{ inputs.transform_expr }}
         run: |
           file_args=()

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -82,4 +82,5 @@ jobs:
             key="$(echo "$file" | sed -E 's/^\.github\/outputs\/(.*)\.json$/\1/g')"
             file_args=("${file_args[@]}" --slurpfile "$key" "$file")
           done
+          jq -c -n "$ARGS.named | to_entries | select((.value | length) > 0)" "${file_args[@]}"
           (echo -n "transformed-output="; jq -c -n "$ARGS.named | to_entries | select((.value | length) > 0) | map({"key": .key, "value": .value[]}) | from_entries | $TRANSFORM_EXPR" "${file_args[@]}") | tee --append "$GITHUB_OUTPUT"

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -81,4 +81,4 @@ jobs:
             key="$(echo "$file" | sed -E 's/^\.github\/outputs\/(.*)\.json$/\1/g')"
             file_args=("${file_args[@]}" --slurpfile "$key" "$file")
           done
-          (echo -n "transformed-output="; jq -c -n "\$ARGS.named | to_entries | map(select((.value | length) > 0) | {"key": .key, "value": .value[]}) | from_entries | $TRANSFORM_EXPR" "${file_args[@]}") | tee --append "$GITHUB_OUTPUT"
+          (echo -n "transformed-output="; jq -c -n "\$ARGS.named | to_entries | map({"key": .key, "value": .value[]}) | from_entries | $TRANSFORM_EXPR" "${file_args[@]}") | tee --append "$GITHUB_OUTPUT"

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -82,5 +82,4 @@ jobs:
             key="$(echo "$file" | sed -E 's/^\.github\/outputs\/(.*)\.json$/\1/g')"
             file_args=("${file_args[@]}" --slurpfile "$key" "$file")
           done
-          jq -n '$ARGS.named' "${file_args[@]}"
-          (echo -n "transformed-output="; jq -c -n "env.CHANGED_FILES | fromjson | $TRANSFORM_EXPR") | tee --append "$GITHUB_OUTPUT"
+          (echo -n "transformed-output="; jq -c -n "$ARGS.named | to_entries | map({"key": .key, "value": .value[]}) | from_entries | $TRANSFORM_EXPR" "${file_args[@]}") | tee --append "$GITHUB_OUTPUT"

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -70,6 +70,7 @@ jobs:
           sha: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).head.sha }}
           files_yaml: ${{ inputs.files_yaml }}
           write_output_files: true
+          json: true
       - name: Transform changed files into output
         id: transform-changed-files
         env:

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -82,4 +82,4 @@ jobs:
             key="$(echo "$file" | sed -E 's/^\.github\/outputs\/(.*)\.json$/\1/g')"
             file_args=("${file_args[@]}" --slurpfile "$key" "$file")
           done
-          (echo -n "transformed-output="; jq -c -n "$ARGS.named | to_entries | map({"key": .key, "value": .value[]}) | from_entries | $TRANSFORM_EXPR" "${file_args[@]}") | tee --append "$GITHUB_OUTPUT"
+          (echo -n "transformed-output="; jq -c -n "$ARGS.named | to_entries | select((.value | length) > 0) | map({"key": .key, "value": .value[]}) | from_entries | $TRANSFORM_EXPR" "${file_args[@]}") | tee --append "$GITHUB_OUTPUT"


### PR DESCRIPTION
Take advantage of the file writing capabilities of https://github.com/tj-actions/changed-files, and pass these files to `jq` in the next step, rather than through environment variables. This avoids situations where the environment variable is too big for Bash to handle.

Fixes https://github.com/rapidsai/shared-workflows/issues/251

Tested at https://github.com/rapidsai/cudf/pull/17125