### PR TITLE
Project automation: Update the option selection to no longer be required

### DIFF
--- a/.github/workflows/project-get-item-id.yaml
+++ b/.github/workflows/project-get-item-id.yaml
@@ -41,13 +41,15 @@ jobs:
         id: get_item_id
         env:
           GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_GITHUB_TOKEN }}
+          ENV_ITEM_NODE_ID: ${{ inputs.ITEM_NODE_ID }}
+          ENV_PROJECT_ID: ${{ inputs.PROJECT_ID }}
         run: |
             # Query up to 10 projects for the PR
             # There's no graphQL filter configured to query by a specific project
             # So we need to query all projects and filter the result ourselves
             gh api graphql -f query='
               query {
-                node(id: "${{ inputs.ITEM_NODE_ID }}") {
+                node(id: "${{ env.ENV_ITEM_NODE_ID }}") {
                   ... on PullRequest {
                     projectItems(first: 10) {
                       nodes {
@@ -73,7 +75,7 @@ jobs:
             
             # Use jq to do the actual filtering
             item_project_id=$(jq -r '.data.node.projectItems.nodes[] |
-                              select(.project.id == "${{ inputs.PROJECT_ID }}") |
+                              select(.project.id == "${{ env.ENV_PROJECT_ID }}") |
                               .id' project_data.json)
             echo "ITEM_PROJECT_ID=$item_project_id" >> $GITHUB_OUTPUT
         continue-on-error: true

--- a/.github/workflows/project-get-item-id.yaml
+++ b/.github/workflows/project-get-item-id.yaml
@@ -35,7 +35,10 @@ jobs:
       - name: Sleep 10s
         id: sleep
         run: |
-          sleep 10 # Ensure the PR is added to the project before we query its ID
+          # Ensure the PR is added to the project before we query its ID
+          # This is a workaround for the fact that the PR is not immediately added to the project
+          # Previously it was ~3s but that didn't guarantee the PR was added to the project
+          sleep 10
 
       - name: Get Item Project ID
         id: get_item_id
@@ -47,9 +50,9 @@ jobs:
             # Query up to 10 projects for the PR
             # There's no graphQL filter configured to query by a specific project
             # So we need to query all projects and filter the result ourselves
-            gh api graphql -f query='
-              query {
-                node(id: "${{ env.ENV_ITEM_NODE_ID }}") {
+            gh api graphql -F nodeId="$ENV_ITEM_NODE_ID" -f query='
+              query($nodeId: ID!) {
+                node(id: $nodeId) { 
                   ... on PullRequest {
                     projectItems(first: 10) {
                       nodes {
@@ -73,9 +76,9 @@ jobs:
                 }
               }' > project_data.json
             
-            # Use jq to do the actual filtering
-            item_project_id=$(jq -r '.data.node.projectItems.nodes[] |
-                              select(.project.id == "${{ env.ENV_PROJECT_ID }}") |
+            # Use jq to do the actual filtering, using --arg for safe variable passing
+            item_project_id=$(jq --arg project_id "$ENV_PROJECT_ID" -r '.data.node.projectItems.nodes[] |
+                              select(.project.id == $project_id) |
                               .id' project_data.json)
             echo "ITEM_PROJECT_ID=$item_project_id" >> $GITHUB_OUTPUT
         continue-on-error: true

--- a/.github/workflows/project-get-set-iteration-field.yaml
+++ b/.github/workflows/project-get-set-iteration-field.yaml
@@ -69,12 +69,12 @@ jobs:
         run: |
             # Get current iteration iteration id
             # The current iteration is always the first element in the returned list
-            gh api graphql -f query='
-            query {
-                node(id: "${{ env.ENV_PROJECT_ID }}") {
+            gh api graphql -F projectId="$ENV_PROJECT_ID" -F fieldName="$ENV_ITERATION_FIELD_NAME" -f query='
+            query($projectId: ID!, $fieldName: String!) {
+                node(id: $projectId) {
                     ... on ProjectV2 {
                     id
-                    field(name: "${{ env.ENV_ITERATION_FIELD_NAME }}") {
+                    field(name: $fieldName) {
                         ... on ProjectV2IterationField {
                         id
                         name
@@ -88,7 +88,9 @@ jobs:
                     }
                   }
                 }' > iteration_option_data.json
-            current_iteration_option_id=$(jq -r '.data.node.field.configuration.iterations[0].id' iteration_option_data.json)
+            
+            # Use jq with --arg for safe variable handling
+            current_iteration_option_id=$(jq --exit-status -r '.data.node.field.configuration.iterations[0].id' iteration_option_data.json)
             echo "ITERATION_OPTION_ID=$current_iteration_option_id" >> "$GITHUB_OUTPUT"
 
       - name: Update item iteration field
@@ -100,25 +102,27 @@ jobs:
           ENV_ITEM_PROJECT_ID: ${{ inputs.ITEM_PROJECT_ID }}
           ENV_ITERATION_FIELD_ID: ${{ inputs.ITERATION_FIELD_ID }}
         run: |
-            # Set the iteration based on the query above
-            # This overwrites whatever was in it before, we may want to make an "OVERWRITE" option
-            gh api graphql -f query='
-              mutation {
+            gh api graphql -F projectId="$ENV_PROJECT_ID" \
+                          -F itemId="$ENV_ITEM_PROJECT_ID" \
+                          -F fieldId="$ENV_ITERATION_FIELD_ID" \
+                          -F iterationId="${{ steps.get_iteration_option_id.outputs.ITERATION_OPTION_ID }}" \
+                          -f query='
+              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $iterationId: String!) {
                 updateProjectV2ItemFieldValue(
                   input: {
-                    projectId: "${{ env.ENV_PROJECT_ID }}"
-                    itemId: "${{ env.ENV_ITEM_PROJECT_ID }}"
-                    fieldId: "${{ env.ENV_ITERATION_FIELD_ID }}"
-                  value: {
-                    iterationId: "${{ steps.get_iteration_option_id.outputs.ITERATION_OPTION_ID }}"
+                    projectId: $projectId
+                    itemId: $itemId
+                    fieldId: $fieldId
+                    value: {
+                      iterationId: $iterationId
                     }
                   }
                 ) {
                     projectV2Item {
-                    id
+                      id
                     }
                 }
-                }'
+              }'
         continue-on-error: true
 
   update_linked_issues:

--- a/.github/workflows/project-get-set-iteration-field.yaml
+++ b/.github/workflows/project-get-set-iteration-field.yaml
@@ -66,32 +66,58 @@ jobs:
           GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_GITHUB_TOKEN }}
           ENV_PROJECT_ID: ${{ inputs.PROJECT_ID }}
           ENV_ITERATION_FIELD_NAME: ${{ inputs.ITERATION_FIELD_NAME }}
+        continue-on-error: true
         run: |
+            echo "Attempting to get current iteration for project field: $ENV_ITERATION_FIELD_NAME"
+            
             # Get current iteration iteration id
             # The current iteration is always the first element in the returned list
-            gh api graphql -F projectId="$ENV_PROJECT_ID" -F fieldName="$ENV_ITERATION_FIELD_NAME" -f query='
-            query($projectId: ID!, $fieldName: String!) {
+            gh api graphql -F projectId="$ENV_PROJECT_ID" \
+                         -F fieldName="$ENV_ITERATION_FIELD_NAME" \
+                         -f query='
+              query($projectId: ID!, $fieldName: String!) {
                 node(id: $projectId) {
-                    ... on ProjectV2 {
-                    id
+                  ... on ProjectV2 {
                     field(name: $fieldName) {
-                        ... on ProjectV2IterationField {
+                      ... on ProjectV2IterationField {
                         id
                         name
                         configuration {
                           iterations {
-                          id
-                            }
+                            id
+                            title
+                            duration
+                            startDate
+                            isStarted
                           }
                         }
                       }
                     }
                   }
-                }' > iteration_option_data.json
+                }
+              }' > iteration_option_data.json || {
+                echo "::warning::Failed to fetch iteration data from GitHub API" >&2
+                exit 1
+              }
             
-            # Use jq with --arg for safe variable handling
-            current_iteration_option_id=$(jq --exit-status -r '.data.node.field.configuration.iterations[0].id' iteration_option_data.json)
+            # Use jq with --exit-status to fail if no iterations found
+            # Get the first iteration (current sprint)
+            current_iteration_option_id=$(jq --exit-status -r '.data.node.field.configuration.iterations[0].id' iteration_option_data.json) || {
+                echo "::warning::No current iteration found in the response" >&2
+                echo "Response data:" >&2
+                cat iteration_option_data.json >&2
+                exit 1
+            }
+            
+            if [ -z "$current_iteration_option_id" ]; then
+              echo "::warning::Current iteration ID is empty" >&2
+              exit 1
+            fi
+            
             echo "ITERATION_OPTION_ID=$current_iteration_option_id" >> "$GITHUB_OUTPUT"
+            
+            # Log the selected iteration for debugging
+            jq -r '.data.node.field.configuration.iterations[0] | "Selected iteration: \(.title) (Start date: \(.startDate))"' iteration_option_data.json
 
       - name: Update item iteration field
         id: update_item_iteration_field
@@ -101,12 +127,14 @@ jobs:
           ENV_PROJECT_ID: ${{ inputs.PROJECT_ID }}
           ENV_ITEM_PROJECT_ID: ${{ inputs.ITEM_PROJECT_ID }}
           ENV_ITERATION_FIELD_ID: ${{ inputs.ITERATION_FIELD_ID }}
+        continue-on-error: true
         run: |
+            echo "Attempting to update iteration field for item"
             gh api graphql -F projectId="$ENV_PROJECT_ID" \
-                          -F itemId="$ENV_ITEM_PROJECT_ID" \
-                          -F fieldId="$ENV_ITERATION_FIELD_ID" \
-                          -F iterationId="${{ steps.get_iteration_option_id.outputs.ITERATION_OPTION_ID }}" \
-                          -f query='
+                         -F itemId="$ENV_ITEM_PROJECT_ID" \
+                         -F fieldId="$ENV_ITERATION_FIELD_ID" \
+                         -F iterationId="${{ steps.get_iteration_option_id.outputs.ITERATION_OPTION_ID }}" \
+                         -f query='
               mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $iterationId: String!) {
                 updateProjectV2ItemFieldValue(
                   input: {
@@ -118,12 +146,14 @@ jobs:
                     }
                   }
                 ) {
-                    projectV2Item {
-                      id
-                    }
+                  projectV2Item {
+                    id
+                  }
                 }
-              }'
-        continue-on-error: true
+              }' || {
+                echo "::warning::Failed to update iteration field" >&2
+                exit 1
+              }
 
   update_linked_issues:
     if: ${{ inputs.UPDATE_LINKED_ISSUES == true }}

--- a/.github/workflows/project-get-set-iteration-field.yaml
+++ b/.github/workflows/project-get-set-iteration-field.yaml
@@ -64,15 +64,17 @@ jobs:
         id: get_iteration_option_id
         env:
           GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_GITHUB_TOKEN }}
+          ENV_PROJECT_ID: ${{ inputs.PROJECT_ID }}
+          ENV_ITERATION_FIELD_NAME: ${{ inputs.ITERATION_FIELD_NAME }}
         run: |
             # Get current iteration iteration id
             # The current iteration is always the first element in the returned list
             gh api graphql -f query='
             query {
-                node(id: "${{ inputs.PROJECT_ID }}") {
+                node(id: "${{ env.ENV_PROJECT_ID }}") {
                     ... on ProjectV2 {
                     id
-                    field(name: "${{ inputs.ITERATION_FIELD_NAME }}") {
+                    field(name: "${{ env.ENV_ITERATION_FIELD_NAME }}") {
                         ... on ProjectV2IterationField {
                         id
                         name
@@ -94,6 +96,9 @@ jobs:
         if: ${{ inputs.UPDATE_ITEM == true }}
         env:
           GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_GITHUB_TOKEN }}
+          ENV_PROJECT_ID: ${{ inputs.PROJECT_ID }}
+          ENV_ITEM_PROJECT_ID: ${{ inputs.ITEM_PROJECT_ID }}
+          ENV_ITERATION_FIELD_ID: ${{ inputs.ITERATION_FIELD_ID }}
         run: |
             # Set the iteration based on the query above
             # This overwrites whatever was in it before, we may want to make an "OVERWRITE" option
@@ -101,9 +106,9 @@ jobs:
               mutation {
                 updateProjectV2ItemFieldValue(
                   input: {
-                    projectId: "${{ inputs.PROJECT_ID }}"
-                    itemId: "${{ inputs.ITEM_PROJECT_ID }}"
-                    fieldId: "${{ inputs.ITERATION_FIELD_ID }}"
+                    projectId: "${{ env.ENV_PROJECT_ID }}"
+                    itemId: "${{ env.ENV_ITEM_PROJECT_ID }}"
+                    fieldId: "${{ env.ENV_ITERATION_FIELD_ID }}"
                   value: {
                     iterationId: "${{ steps.get_iteration_option_id.outputs.ITERATION_OPTION_ID }}"
                     }

--- a/.github/workflows/project-get-set-iteration-field.yaml
+++ b/.github/workflows/project-get-set-iteration-field.yaml
@@ -66,58 +66,33 @@ jobs:
           GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_GITHUB_TOKEN }}
           ENV_PROJECT_ID: ${{ inputs.PROJECT_ID }}
           ENV_ITERATION_FIELD_NAME: ${{ inputs.ITERATION_FIELD_NAME }}
-        continue-on-error: true
         run: |
-            echo "Attempting to get current iteration for project field: $ENV_ITERATION_FIELD_NAME"
-            
             # Get current iteration iteration id
             # The current iteration is always the first element in the returned list
-            gh api graphql -F projectId="$ENV_PROJECT_ID" \
-                         -F fieldName="$ENV_ITERATION_FIELD_NAME" \
-                         -f query='
-              query($projectId: ID!, $fieldName: String!) {
+            gh api graphql -F projectId="$ENV_PROJECT_ID" -F fieldName="$ENV_ITERATION_FIELD_NAME" -f query='
+            query($projectId: ID!, $fieldName: String!) {
                 node(id: $projectId) {
-                  ... on ProjectV2 {
+                    ... on ProjectV2 {
+                    id
                     field(name: $fieldName) {
-                      ... on ProjectV2IterationField {
+                        ... on ProjectV2IterationField {
                         id
                         name
                         configuration {
                           iterations {
-                            id
-                            title
-                            duration
-                            startDate
-                            isStarted
+                          id
+                            }
                           }
                         }
                       }
                     }
                   }
-                }
-              }' > iteration_option_data.json || {
-                echo "::warning::Failed to fetch iteration data from GitHub API" >&2
-                exit 1
-              }
+                }' > iteration_option_data.json
             
-            # Use jq with --exit-status to fail if no iterations found
-            # Get the first iteration (current sprint)
-            current_iteration_option_id=$(jq --exit-status -r '.data.node.field.configuration.iterations[0].id' iteration_option_data.json) || {
-                echo "::warning::No current iteration found in the response" >&2
-                echo "Response data:" >&2
-                cat iteration_option_data.json >&2
-                exit 1
-            }
-            
-            if [ -z "$current_iteration_option_id" ]; then
-              echo "::warning::Current iteration ID is empty" >&2
-              exit 1
-            fi
-            
+            # Use jq with --arg for safe variable handling
+            current_iteration_option_id=$(jq --exit-status -r '.data.node.field.configuration.iterations[0].id' iteration_option_data.json)
             echo "ITERATION_OPTION_ID=$current_iteration_option_id" >> "$GITHUB_OUTPUT"
-            
-            # Log the selected iteration for debugging
-            jq -r '.data.node.field.configuration.iterations[0] | "Selected iteration: \(.title) (Start date: \(.startDate))"' iteration_option_data.json
+        continue-on-error: true
 
       - name: Update item iteration field
         id: update_item_iteration_field
@@ -127,14 +102,12 @@ jobs:
           ENV_PROJECT_ID: ${{ inputs.PROJECT_ID }}
           ENV_ITEM_PROJECT_ID: ${{ inputs.ITEM_PROJECT_ID }}
           ENV_ITERATION_FIELD_ID: ${{ inputs.ITERATION_FIELD_ID }}
-        continue-on-error: true
         run: |
-            echo "Attempting to update iteration field for item"
             gh api graphql -F projectId="$ENV_PROJECT_ID" \
-                         -F itemId="$ENV_ITEM_PROJECT_ID" \
-                         -F fieldId="$ENV_ITERATION_FIELD_ID" \
-                         -F iterationId="${{ steps.get_iteration_option_id.outputs.ITERATION_OPTION_ID }}" \
-                         -f query='
+                          -F itemId="$ENV_ITEM_PROJECT_ID" \
+                          -F fieldId="$ENV_ITERATION_FIELD_ID" \
+                          -F iterationId="${{ steps.get_iteration_option_id.outputs.ITERATION_OPTION_ID }}" \
+                          -f query='
               mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $iterationId: String!) {
                 updateProjectV2ItemFieldValue(
                   input: {
@@ -146,14 +119,12 @@ jobs:
                     }
                   }
                 ) {
-                  projectV2Item {
-                    id
-                  }
+                    projectV2Item {
+                      id
+                    }
                 }
-              }' || {
-                echo "::warning::Failed to update iteration field" >&2
-                exit 1
-              }
+              }'
+        continue-on-error: true
 
   update_linked_issues:
     if: ${{ inputs.UPDATE_LINKED_ISSUES == true }}

--- a/.github/workflows/project-get-set-iteration-field.yaml
+++ b/.github/workflows/project-get-set-iteration-field.yaml
@@ -102,11 +102,12 @@ jobs:
           ENV_PROJECT_ID: ${{ inputs.PROJECT_ID }}
           ENV_ITEM_PROJECT_ID: ${{ inputs.ITEM_PROJECT_ID }}
           ENV_ITERATION_FIELD_ID: ${{ inputs.ITERATION_FIELD_ID }}
+          ENV_ITERATION_OPTION_ID: ${{ steps.get_iteration_option_id.outputs.ITERATION_OPTION_ID }}
         run: |
             gh api graphql -F projectId="$ENV_PROJECT_ID" \
                           -F itemId="$ENV_ITEM_PROJECT_ID" \
                           -F fieldId="$ENV_ITERATION_FIELD_ID" \
-                          -F iterationId="${{ steps.get_iteration_option_id.outputs.ITERATION_OPTION_ID }}" \
+                          -F iterationId="$ENV_ITERATION_OPTION_ID" \
                           -f query='
               mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $iterationId: String!) {
                 updateProjectV2ItemFieldValue(

--- a/.github/workflows/project-get-set-single-select-field.yaml
+++ b/.github/workflows/project-get-set-single-select-field.yaml
@@ -70,17 +70,20 @@ jobs:
         id: get_single_select_option_id
         env:
           GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_GITHUB_TOKEN }}
+          ENV_SINGLE_SELECT_OPTION_VALUE: ${{ inputs.SINGLE_SELECT_OPTION_VALUE }}
+          ENV_PROJECT_ID: ${{ inputs.PROJECT_ID }}
+          ENV_SINGLE_SELECT_FIELD_NAME: ${{ inputs.SINGLE_SELECT_FIELD_NAME }}
         run: |
             # Get single_select option id
-            if [ -z "${{ inputs.SINGLE_SELECT_OPTION_VALUE }}" ]; then
+            if [ -z "${{ env.ENV_SINGLE_SELECT_OPTION_VALUE }}" ]; then
               # No option specified, we will get the first option in the list
               # graphQL doesn't appear to provide a wildcard option, so separate queries are necessary
               gh api graphql -f query='
                 query {
-                    node(id: "${{ inputs.PROJECT_ID }}") {
+                    node(id: "${{ env.ENV_PROJECT_ID }}") {
                         ... on ProjectV2 {
                         id
-                        field(name: "${{ inputs.SINGLE_SELECT_FIELD_NAME }}") {
+                        field(name: "${{ env.ENV_SINGLE_SELECT_FIELD_NAME }}") {
                             ... on ProjectV2SingleSelectField {
                             id
                             options {id}
@@ -93,13 +96,13 @@ jobs:
               # Get the specific value only
               gh api graphql -f query='
                 query {
-                    node(id: "${{ inputs.PROJECT_ID }}") {
+                    node(id: "${{ env.ENV_PROJECT_ID }}") {
                         ... on ProjectV2 {
                         id
-                        field(name: "${{ inputs.SINGLE_SELECT_FIELD_NAME }}") {
+                        field(name: "${{ env.ENV_SINGLE_SELECT_FIELD_NAME }}") {
                             ... on ProjectV2SingleSelectField {
                             id
-                            options(names: "${{ inputs.SINGLE_SELECT_OPTION_VALUE }}") {id}
+                            options(names: "${{ env.ENV_SINGLE_SELECT_OPTION_VALUE }}") {id}
                               }
                             }
                           }
@@ -114,6 +117,9 @@ jobs:
         if: ${{ inputs.UPDATE_ITEM == true }}
         env:
           GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_GITHUB_TOKEN }}
+          ENV_PROJECT_ID: ${{ inputs.PROJECT_ID }}
+          ENV_ITEM_PROJECT_ID: ${{ inputs.ITEM_PROJECT_ID }}
+          ENV_SINGLE_SELECT_FIELD_ID: ${{ inputs.SINGLE_SELECT_FIELD_ID }}
         run: |
             # Set the single_select based on the query above
             # This overwrites whatever was in it before, we may want to make an "OVERWRITE" option
@@ -121,9 +127,9 @@ jobs:
               mutation {
                 updateProjectV2ItemFieldValue(
                   input: {
-                    projectId: "${{ inputs.PROJECT_ID }}"
-                    itemId: "${{ inputs.ITEM_PROJECT_ID }}"
-                    fieldId: "${{ inputs.SINGLE_SELECT_FIELD_ID }}"
+                    projectId: "${{ env.ENV_PROJECT_ID }}"
+                    itemId: "${{ env.ENV_ITEM_PROJECT_ID }}"
+                    fieldId: "${{ env.ENV_SINGLE_SELECT_FIELD_ID }}"
                   value: {
                     singleSelectOptionId: "${{ steps.get_single_select_option_id.outputs.SINGLE_SELECT_OPTION_ID }}"
                     }

--- a/.github/workflows/project-get-set-single-select-field.yaml
+++ b/.github/workflows/project-get-set-single-select-field.yaml
@@ -113,6 +113,7 @@ jobs:
             # Use jq with --exit-status to fail if no option is found
             current_single_select_option_id=$(jq --exit-status -r '.data.node.field.options[0].id' single_select_option_data.json)
             echo "SINGLE_SELECT_OPTION_ID=$current_single_select_option_id" >> "$GITHUB_OUTPUT"
+        continue-on-error: true
 
       - name: Update item single_select field
         id: update_item_single_select_field

--- a/.github/workflows/project-get-set-single-select-field.yaml
+++ b/.github/workflows/project-get-set-single-select-field.yaml
@@ -75,17 +75,16 @@ jobs:
           ENV_SINGLE_SELECT_FIELD_NAME: ${{ inputs.SINGLE_SELECT_FIELD_NAME }}
         run: |
             # Get single_select option id
-            if [ -z "${{ env.ENV_SINGLE_SELECT_OPTION_VALUE }}" ]; then
-              # No option specified, we will get the first option in the list
-              # graphQL doesn't appear to provide a wildcard option, so separate queries are necessary
-              gh api graphql -f query='
-                query {
-                    node(id: "${{ env.ENV_PROJECT_ID }}") {
+            if [ -z "$ENV_SINGLE_SELECT_OPTION_VALUE" ]; then
+              # No option specified, get first option in list
+              gh api graphql -F projectId="$ENV_PROJECT_ID" \
+                           -F fieldName="$ENV_SINGLE_SELECT_FIELD_NAME" \
+                           -f query='
+                query($projectId: ID!, $fieldName: String!) {
+                    node(id: $projectId) {
                         ... on ProjectV2 {
-                        id
-                        field(name: "${{ env.ENV_SINGLE_SELECT_FIELD_NAME }}") {
+                        field(name: $fieldName) {
                             ... on ProjectV2SingleSelectField {
-                            id
                             options {id}
                               }
                             }
@@ -93,23 +92,26 @@ jobs:
                         }
                       }' > single_select_option_data.json
             else
-              # Get the specific value only
-              gh api graphql -f query='
-                query {
-                    node(id: "${{ env.ENV_PROJECT_ID }}") {
+              # Get specific value
+              gh api graphql -F projectId="$ENV_PROJECT_ID" \
+                           -F fieldName="$ENV_SINGLE_SELECT_FIELD_NAME" \
+                           -F optionName="$ENV_SINGLE_SELECT_OPTION_VALUE" \
+                           -f query='
+                query($projectId: ID!, $fieldName: String!, $optionName: String!) {
+                    node(id: $projectId) {
                         ... on ProjectV2 {
-                        id
-                        field(name: "${{ env.ENV_SINGLE_SELECT_FIELD_NAME }}") {
+                        field(name: $fieldName) {
                             ... on ProjectV2SingleSelectField {
-                            id
-                            options(names: "${{ env.ENV_SINGLE_SELECT_OPTION_VALUE }}") {id}
+                            options(names: $optionName) {id}
                               }
                             }
                           }
                         }
                       }' > single_select_option_data.json
             fi
-            current_single_select_option_id=$(jq -r '.data.node.field.options[0].id' single_select_option_data.json)
+            
+            # Use jq with --exit-status to fail if no option is found
+            current_single_select_option_id=$(jq --exit-status -r '.data.node.field.options[0].id' single_select_option_data.json)
             echo "SINGLE_SELECT_OPTION_ID=$current_single_select_option_id" >> "$GITHUB_OUTPUT"
 
       - name: Update item single_select field
@@ -120,18 +122,21 @@ jobs:
           ENV_PROJECT_ID: ${{ inputs.PROJECT_ID }}
           ENV_ITEM_PROJECT_ID: ${{ inputs.ITEM_PROJECT_ID }}
           ENV_SINGLE_SELECT_FIELD_ID: ${{ inputs.SINGLE_SELECT_FIELD_ID }}
+          ENV_SINGLE_SELECT_OPTION_ID: ${{ steps.get_single_select_option_id.outputs.SINGLE_SELECT_OPTION_ID }}
         run: |
-            # Set the single_select based on the query above
-            # This overwrites whatever was in it before, we may want to make an "OVERWRITE" option
-            gh api graphql -f query='
-              mutation {
+            gh api graphql -F projectId="$ENV_PROJECT_ID" \
+                         -F itemId="$ENV_ITEM_PROJECT_ID" \
+                         -F fieldId="$ENV_SINGLE_SELECT_FIELD_ID" \
+                         -F optionId="$ENV_SINGLE_SELECT_OPTION_ID" \
+                         -f query='
+              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
                 updateProjectV2ItemFieldValue(
                   input: {
-                    projectId: "${{ env.ENV_PROJECT_ID }}"
-                    itemId: "${{ env.ENV_ITEM_PROJECT_ID }}"
-                    fieldId: "${{ env.ENV_SINGLE_SELECT_FIELD_ID }}"
-                  value: {
-                    singleSelectOptionId: "${{ steps.get_single_select_option_id.outputs.SINGLE_SELECT_OPTION_ID }}"
+                    projectId: $projectId
+                    itemId: $itemId
+                    fieldId: $fieldId
+                    value: {
+                      singleSelectOptionId: $optionId
                     }
                   }
                 ) {

--- a/.github/workflows/project-get-set-single-select-field.yaml
+++ b/.github/workflows/project-get-set-single-select-field.yaml
@@ -15,11 +15,6 @@ on:
         type: string
         required: true
 
-      SINGLE_SELECT_OPTION_VALUE:
-        description: "The value of the option we'd like to get/set"
-        type: string
-        required: true
-
       SINGLE_SELECT_FIELD_ID:
         description: "The graphQL node ID of the single-select field"
         type: string
@@ -46,6 +41,12 @@ on:
         default: false
         type: boolean
 
+      # Optional, if not specified, we default to the first option in the selector
+      SINGLE_SELECT_OPTION_VALUE:
+        description: "The value of the option we'd like to get/set"
+        type: string
+        default: null
+
     secrets:
       ADD_TO_PROJECT_GITHUB_TOKEN:
         description: "Project Access Token"
@@ -71,20 +72,40 @@ jobs:
           GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_GITHUB_TOKEN }}
         run: |
             # Get single_select option id
-            gh api graphql -f query='
-            query {
-                node(id: "${{ inputs.PROJECT_ID }}") {
-                    ... on ProjectV2 {
-                    id
-                    field(name: "${{ inputs.SINGLE_SELECT_FIELD_NAME }}") {
-                        ... on ProjectV2SingleSelectField {
+            if [ -z "${{ inputs.SINGLE_SELECT_OPTION_VALUE }}" ]; then
+              # No option specified, we will get the first option in the list
+              # graphQL doesn't appear to provide a wildcard option, so separate queries are necessary
+              gh api graphql -f query='
+                query {
+                    node(id: "${{ inputs.PROJECT_ID }}") {
+                        ... on ProjectV2 {
                         id
-                        options(names: "${{ inputs.SINGLE_SELECT_OPTION_VALUE }}") {id}
+                        field(name: "${{ inputs.SINGLE_SELECT_FIELD_NAME }}") {
+                            ... on ProjectV2SingleSelectField {
+                            id
+                            options {id}
+                              }
+                            }
                           }
                         }
-                      }
-                    }
-                  }' > single_select_option_data.json
+                      }' > single_select_option_data.json
+            else
+              # Get the specific value only
+              gh api graphql -f query='
+                query {
+                    node(id: "${{ inputs.PROJECT_ID }}") {
+                        ... on ProjectV2 {
+                        id
+                        field(name: "${{ inputs.SINGLE_SELECT_FIELD_NAME }}") {
+                            ... on ProjectV2SingleSelectField {
+                            id
+                            options(names: "${{ inputs.SINGLE_SELECT_OPTION_VALUE }}") {id}
+                              }
+                            }
+                          }
+                        }
+                      }' > single_select_option_data.json
+            fi
             current_single_select_option_id=$(jq -r '.data.node.field.options[0].id' single_select_option_data.json)
             echo "SINGLE_SELECT_OPTION_ID=$current_single_select_option_id" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/project-set-text-date-numeric-field.yaml
+++ b/.github/workflows/project-set-text-date-numeric-field.yaml
@@ -58,19 +58,24 @@ jobs:
         id: update_item_text_date_numeric_field
         env:
           GH_TOKEN: ${{ secrets.ADD_TO_PROJECT_GITHUB_TOKEN }}
+          ENV_FIELD_TYPE: ${{ inputs.FIELD_TYPE }}
+          ENV_PROJECT_ID: ${{ inputs.PROJECT_ID }}
+          ENV_ITEM_PROJECT_ID: ${{ inputs.ITEM_PROJECT_ID }}
+          ENV_FIELD_ID: ${{ inputs.FIELD_ID }}
+          ENV_SET_VALUE: ${{ inputs.SET_VALUE }}
         run: |
             # Set the field based on the inputted desired value
             # This overwrites whatever was in it before, we may want to make an "OVERWRITE" option
-            if [ "${{ inputs.FIELD_TYPE }}" == "date" ] || \
-               [ "${{ inputs.FIELD_TYPE }}" == "text" ]; then
+            if [ "${{ env.ENV_FIELD_TYPE }}" == "date" ] || \
+               [ "${{ env.ENV_FIELD_TYPE }}" == "text" ]; then
               gh api graphql -f query="
                 mutation {
                   updateProjectV2ItemFieldValue(
                     input: {
-                      projectId: \"${{ inputs.PROJECT_ID }}\"
-                      itemId: \"${{ inputs.ITEM_PROJECT_ID }}\"
-                      fieldId: \"${{ inputs.FIELD_ID }}\"
-                      value: { ${{ inputs.FIELD_TYPE }}: \"${{ inputs.SET_VALUE }}\" }
+                      projectId: \"${{ env.ENV_PROJECT_ID }}\"
+                      itemId: \"${{ env.ENV_ITEM_PROJECT_ID }}\"
+                      fieldId: \"${{ env.ENV_FIELD_ID }}\"
+                      value: { ${{ env.ENV_FIELD_TYPE }}: \"${{ env.ENV_SET_VALUE }}\" }
                     }
                   ) {
                     projectV2Item {
@@ -79,15 +84,15 @@ jobs:
                   }
                 }"
 
-            elif [ "${{ inputs.FIELD_TYPE }}" == "number" ]; then
+            elif [ "${{ env.ENV_FIELD_TYPE }}" == "number" ]; then
                gh api graphql -f query="
                  mutation {
                    updateProjectV2ItemFieldValue(
                      input: {
-                       projectId: \"${{ inputs.PROJECT_ID }}\"
-                       itemId: \"${{ inputs.ITEM_PROJECT_ID }}\"
-                       fieldId: \"${{ inputs.FIELD_ID }}\"
-                       value: { ${{ inputs.FIELD_TYPE }}: ${{ inputs.SET_VALUE }} }
+                       projectId: \"${{ env.ENV_PROJECT_ID }}\"
+                       itemId: \"${{ env.ENV_ITEM_PROJECT_ID }}\"
+                       fieldId: \"${{ env.ENV_FIELD_ID }}\"
+                       value: { ${{ env.ENV_FIELD_TYPE }}: ${{ env.ENV_SET_VALUE }} }
                      }
                    ) {
                      projectV2Item {

--- a/.github/workflows/project-set-text-date-numeric-field.yaml
+++ b/.github/workflows/project-set-text-date-numeric-field.yaml
@@ -65,44 +65,58 @@ jobs:
           ENV_SET_VALUE: ${{ inputs.SET_VALUE }}
         run: |
             # Set the field based on the inputted desired value
-            # This overwrites whatever was in it before, we may want to make an "OVERWRITE" option
-            if [ "${{ env.ENV_FIELD_TYPE }}" == "date" ] || \
-               [ "${{ env.ENV_FIELD_TYPE }}" == "text" ]; then
-              gh api graphql -f query="
-                mutation {
+            if [ "$ENV_FIELD_TYPE" == "date" ] || [ "$ENV_FIELD_TYPE" == "text" ]; then
+              gh api graphql -F projectId="$ENV_PROJECT_ID" \
+                           -F itemId="$ENV_ITEM_PROJECT_ID" \
+                           -F fieldId="$ENV_FIELD_ID" \
+                           -F value="$ENV_SET_VALUE" \
+                           -F fieldType="$ENV_FIELD_TYPE" \
+                           -f query='
+                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!, $fieldType: String!) {
                   updateProjectV2ItemFieldValue(
                     input: {
-                      projectId: \"${{ env.ENV_PROJECT_ID }}\"
-                      itemId: \"${{ env.ENV_ITEM_PROJECT_ID }}\"
-                      fieldId: \"${{ env.ENV_FIELD_ID }}\"
-                      value: { ${{ env.ENV_FIELD_TYPE }}: \"${{ env.ENV_SET_VALUE }}\" }
+                      projectId: $projectId
+                      itemId: $itemId
+                      fieldId: $fieldId
+                      value: { text: $value }
                     }
                   ) {
                     projectV2Item {
                       id
                     }
                   }
-                }"
+                }'
 
-            elif [ "${{ env.ENV_FIELD_TYPE }}" == "number" ]; then
-               gh api graphql -f query="
-                 mutation {
-                   updateProjectV2ItemFieldValue(
-                     input: {
-                       projectId: \"${{ env.ENV_PROJECT_ID }}\"
-                       itemId: \"${{ env.ENV_ITEM_PROJECT_ID }}\"
-                       fieldId: \"${{ env.ENV_FIELD_ID }}\"
-                       value: { ${{ env.ENV_FIELD_TYPE }}: ${{ env.ENV_SET_VALUE }} }
-                     }
-                   ) {
-                     projectV2Item {
-                       id
-                     }
-                   }
-                 }"
+            elif [ "$ENV_FIELD_TYPE" == "number" ]; then
+              gh api graphql -F projectId="$ENV_PROJECT_ID" \
+                           -F itemId="$ENV_ITEM_PROJECT_ID" \
+                           -F fieldId="$ENV_FIELD_ID" \
+                           -F value="$ENV_SET_VALUE" \
+                           -f query='
+                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: Float!) {
+                  updateProjectV2ItemFieldValue(
+                    input: {
+                      projectId: $projectId
+                      itemId: $itemId
+                      fieldId: $fieldId
+                      value: { number: $value }
+                    }
+                  ) {
+                    projectV2Item {
+                      id
+                    }
+                  }
+                }' | jq --exit-status --raw-output '.data.updateProjectV2ItemFieldValue.projectV2Item.id'
 
             else
-              echo "Invalid field type"
+              echo "Error: Invalid field type '$ENV_FIELD_TYPE'. Must be 'date', 'text', or 'number'" >&2
+              exit 1
+            fi
+
+            # Validate the response
+            if [ $? -ne 0 ]; then
+              echo "Error: Failed to update field value" >&2
+              exit 1
             fi
         continue-on-error: true
 

--- a/.github/workflows/project-update-linked-issues.yaml
+++ b/.github/workflows/project-update-linked-issues.yaml
@@ -192,3 +192,4 @@ jobs:
                 exit 1
               fi
             done
+          continue-on-error: true

--- a/.github/workflows/project-update-linked-issues.yaml
+++ b/.github/workflows/project-update-linked-issues.yaml
@@ -61,80 +61,134 @@ jobs:
             ENV_UPDATE_FIELD_VALUE: ${{ inputs.UPDATE_FIELD_VALUE }}
           run: |
             # Find the linked issues to the PR
-            # If an issue is passed in, the json will return null and the for loop won't trigger
-            # Potential future improvement could be some nicer error messaging on incorrect input
-            gh api graphql -f query='
-                query {
-                    node(id: "${{ env.ENV_PR_NODE_ID }}") {
-                    ... on PullRequest {
-                        closingIssuesReferences(first: 10) {
-                        nodes {
-                            projectItems(first: 10) {
-                            nodes {id, project{id}}
+            gh api graphql -F prNodeId="$ENV_PR_NODE_ID" -f query='
+              query($prNodeId: ID!) {
+                node(id: $prNodeId) {
+                  ... on PullRequest {
+                    closingIssuesReferences(first: 10) {
+                      nodes {
+                        projectItems(first: 10) {
+                          nodes {
+                            id
+                            project {
+                              id
                             }
                           }
                         }
                       }
                     }
-                  }' > linked_issues.json
-            issue_ids=$(jq -r '.data.node.closingIssuesReferences.nodes[].projectItems.nodes[] |
-                        select(.project.id == "${{ env.ENV_PROJECT_ID }}") | .id' linked_issues.json)
+                  }
+                }
+              }' > linked_issues.json
 
-            for issue_id in $issue_ids; do
-              # Each field type has a different `value` that is needed by the mutation. 
+            # Use jq with proper variable handling to get issue IDs
+            issue_ids=$(jq --exit-status --arg project_id "$ENV_PROJECT_ID" -r '
+              .data.node.closingIssuesReferences.nodes[].projectItems.nodes[] |
+              select(.project.id == $project_id) |
+              .id' linked_issues.json)
 
-              if [ "${{ env.ENV_UPDATE_FIELD_TYPE }}" == "iteration" ]; then
-                gh api graphql -f query='
-                  mutation {
-                    updateProjectV2ItemFieldValue(
-                      input: {
-                        projectId: "${{ env.ENV_PROJECT_ID }}"
-                        itemId: "'"$issue_id"'"
-                        fieldId: "${{ env.ENV_UPDATE_FIELD_ID }}"
-                        value: {iterationId: "${{ env.ENV_UPDATE_FIELD_VALUE }}"}}) 
-                    {projectV2Item {id}}}'
-                    
-              elif [ "${{ env.ENV_UPDATE_FIELD_TYPE }}" == "single_select" ]; then
-                gh api graphql -f query='
-                  mutation {
-                    updateProjectV2ItemFieldValue(
-                      input: {
-                        projectId: "${{ env.ENV_PROJECT_ID }}"
-                        itemId: "'"$issue_id"'"
-                        fieldId: "${{ env.ENV_UPDATE_FIELD_ID }}"
-                        value: {singleSelectOptionId: "${{ env.ENV_UPDATE_FIELD_VALUE }}"}}) 
-                    {projectV2Item {id}}}'
+            # Exit if no issues found
+            if [ -z "$issue_ids" ]; then
+              echo "No linked issues found in project" >&2
+              exit 0
+            fi
 
-              elif [ "${{ env.ENV_UPDATE_FIELD_TYPE }}" == "date" ] || \
-                   [ "${{ env.ENV_UPDATE_FIELD_TYPE }}" == "text" ]; then
-                gh api graphql -f query="
-                  mutation {
-                    updateProjectV2ItemFieldValue(
-                      input: {
-                        projectId: \"${{ env.ENV_PROJECT_ID }}\"
-                        itemId: \"$issue_id\"
-                        fieldId: \"${{ env.ENV_UPDATE_FIELD_ID }}\"
-                        value: {${{ env.ENV_UPDATE_FIELD_TYPE }}: \"${{ env.ENV_UPDATE_FIELD_VALUE }}\"}
+            # Process each issue
+            echo "$issue_ids" | while read -r issue_id; do
+              if [ -z "$issue_id" ]; then
+                continue
+              fi
+
+              case "$ENV_UPDATE_FIELD_TYPE" in
+                "iteration")
+                  gh api graphql -F projectId="$ENV_PROJECT_ID" \
+                               -F itemId="$issue_id" \
+                               -F fieldId="$ENV_UPDATE_FIELD_ID" \
+                               -F iterationId="$ENV_UPDATE_FIELD_VALUE" \
+                               -f query='
+                    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $iterationId: String!) {
+                      updateProjectV2ItemFieldValue(
+                        input: {
+                          projectId: $projectId
+                          itemId: $itemId
+                          fieldId: $fieldId
+                          value: {iterationId: $iterationId}
+                        }
+                      ) {
+                        projectV2Item {id}
                       }
-                    ) {
-                      projectV2Item {
-                        id
+                    }'
+                  ;;
+
+                "single_select")
+                  gh api graphql -F projectId="$ENV_PROJECT_ID" \
+                               -F itemId="$issue_id" \
+                               -F fieldId="$ENV_UPDATE_FIELD_ID" \
+                               -F optionId="$ENV_UPDATE_FIELD_VALUE" \
+                               -f query='
+                    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                      updateProjectV2ItemFieldValue(
+                        input: {
+                          projectId: $projectId
+                          itemId: $itemId
+                          fieldId: $fieldId
+                          value: {singleSelectOptionId: $optionId}
+                        }
+                      ) {
+                        projectV2Item {id}
                       }
-                    }
-                  }"
+                    }'
+                  ;;
 
-              elif [ "${{ env.ENV_UPDATE_FIELD_TYPE }}" == "number" ]; then
-                gh api graphql -f query="
-                  mutation {
-                    updateProjectV2ItemFieldValue(
-                      input: {
-                        projectId: \"${{ env.ENV_PROJECT_ID }}\"
-                        itemId: \"$issue_id\"
-                        fieldId: \"${{ env.ENV_UPDATE_FIELD_ID }}\"
-                        value: {${{ env.ENV_UPDATE_FIELD_TYPE }}: ${{ env.ENV_UPDATE_FIELD_VALUE }}}}
-                    ) {projectV2Item {id}}}"
+                "date"|"text")
+                  gh api graphql -F projectId="$ENV_PROJECT_ID" \
+                               -F itemId="$issue_id" \
+                               -F fieldId="$ENV_UPDATE_FIELD_ID" \
+                               -F value="$ENV_UPDATE_FIELD_VALUE" \
+                               -F fieldType="$ENV_UPDATE_FIELD_TYPE" \
+                               -f query='
+                    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!, $fieldType: String!) {
+                      updateProjectV2ItemFieldValue(
+                        input: {
+                          projectId: $projectId
+                          itemId: $itemId
+                          fieldId: $fieldId
+                          value: { text: $value }
+                        }
+                      ) {
+                        projectV2Item {id}
+                      }
+                    }'
+                  ;;
 
-              else
-                echo "Invalid field type"
+                "number")
+                  gh api graphql -F projectId="$ENV_PROJECT_ID" \
+                               -F itemId="$issue_id" \
+                               -F fieldId="$ENV_UPDATE_FIELD_ID" \
+                               -F value="$ENV_UPDATE_FIELD_VALUE" \
+                               -f query='
+                    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: Float!) {
+                      updateProjectV2ItemFieldValue(
+                        input: {
+                          projectId: $projectId
+                          itemId: $itemId
+                          fieldId: $fieldId
+                          value: { number: $value }
+                        }
+                      ) {
+                        projectV2Item {id}
+                      }
+                    }'
+                  ;;
+
+                *)
+                  echo "Error: Invalid field type '$ENV_UPDATE_FIELD_TYPE'" >&2
+                  exit 1
+                  ;;
+              esac
+
+              if [ $? -ne 0 ]; then
+                echo "Error: Failed to update field for issue $issue_id" >&2
+                exit 1
               fi
             done

--- a/.github/workflows/project-update-linked-issues.yaml
+++ b/.github/workflows/project-update-linked-issues.yaml
@@ -54,13 +54,18 @@ jobs:
           id: sync_linked_issues
           env:
             GITHUB_TOKEN: ${{ secrets.ADD_TO_PROJECT_GITHUB_TOKEN }}
+            ENV_PR_NODE_ID: ${{ inputs.PR_NODE_ID }}
+            ENV_PROJECT_ID: ${{ inputs.PROJECT_ID }}
+            ENV_UPDATE_FIELD_TYPE: ${{ inputs.UPDATE_FIELD_TYPE }}
+            ENV_UPDATE_FIELD_ID: ${{ inputs.UPDATE_FIELD_ID }}
+            ENV_UPDATE_FIELD_VALUE: ${{ inputs.UPDATE_FIELD_VALUE }}
           run: |
             # Find the linked issues to the PR
             # If an issue is passed in, the json will return null and the for loop won't trigger
             # Potential future improvement could be some nicer error messaging on incorrect input
             gh api graphql -f query='
                 query {
-                    node(id: "${{ inputs.PR_NODE_ID }}") {
+                    node(id: "${{ env.ENV_PR_NODE_ID }}") {
                     ... on PullRequest {
                         closingIssuesReferences(first: 10) {
                         nodes {
@@ -73,43 +78,43 @@ jobs:
                     }
                   }' > linked_issues.json
             issue_ids=$(jq -r '.data.node.closingIssuesReferences.nodes[].projectItems.nodes[] |
-                        select(.project.id == "${{ inputs.PROJECT_ID }}") | .id' linked_issues.json)
+                        select(.project.id == "${{ env.ENV_PROJECT_ID }}") | .id' linked_issues.json)
 
             for issue_id in $issue_ids; do
               # Each field type has a different `value` that is needed by the mutation. 
 
-              if [ "${{ inputs.UPDATE_FIELD_TYPE }}" == "iteration" ]; then
+              if [ "${{ env.ENV_UPDATE_FIELD_TYPE }}" == "iteration" ]; then
                 gh api graphql -f query='
                   mutation {
                     updateProjectV2ItemFieldValue(
                       input: {
-                        projectId: "${{ inputs.PROJECT_ID }}"
+                        projectId: "${{ env.ENV_PROJECT_ID }}"
                         itemId: "'"$issue_id"'"
-                        fieldId: "${{ inputs.UPDATE_FIELD_ID }}"
-                        value: {iterationId: "${{ inputs.UPDATE_FIELD_VALUE }}"}}) 
+                        fieldId: "${{ env.ENV_UPDATE_FIELD_ID }}"
+                        value: {iterationId: "${{ env.ENV_UPDATE_FIELD_VALUE }}"}}) 
                     {projectV2Item {id}}}'
                     
-              elif [ "${{ inputs.UPDATE_FIELD_TYPE }}" == "single_select" ]; then
+              elif [ "${{ env.ENV_UPDATE_FIELD_TYPE }}" == "single_select" ]; then
                 gh api graphql -f query='
                   mutation {
                     updateProjectV2ItemFieldValue(
                       input: {
-                        projectId: "${{ inputs.PROJECT_ID }}"
+                        projectId: "${{ env.ENV_PROJECT_ID }}"
                         itemId: "'"$issue_id"'"
-                        fieldId: "${{ inputs.UPDATE_FIELD_ID }}"
-                        value: {singleSelectOptionId: "${{ inputs.UPDATE_FIELD_VALUE }}"}}) 
+                        fieldId: "${{ env.ENV_UPDATE_FIELD_ID }}"
+                        value: {singleSelectOptionId: "${{ env.ENV_UPDATE_FIELD_VALUE }}"}}) 
                     {projectV2Item {id}}}'
 
-              elif [ "${{ inputs.UPDATE_FIELD_TYPE }}" == "date" ] || \
-                   [ "${{ inputs.UPDATE_FIELD_TYPE }}" == "text" ]; then
+              elif [ "${{ env.ENV_UPDATE_FIELD_TYPE }}" == "date" ] || \
+                   [ "${{ env.ENV_UPDATE_FIELD_TYPE }}" == "text" ]; then
                 gh api graphql -f query="
                   mutation {
                     updateProjectV2ItemFieldValue(
                       input: {
-                        projectId: \"${{ inputs.PROJECT_ID }}\"
+                        projectId: \"${{ env.ENV_PROJECT_ID }}\"
                         itemId: \"$issue_id\"
-                        fieldId: \"${{ inputs.UPDATE_FIELD_ID }}\"
-                        value: {${{ inputs.UPDATE_FIELD_TYPE }}: \"${{ inputs.UPDATE_FIELD_VALUE }}\"}
+                        fieldId: \"${{ env.ENV_UPDATE_FIELD_ID }}\"
+                        value: {${{ env.ENV_UPDATE_FIELD_TYPE }}: \"${{ env.ENV_UPDATE_FIELD_VALUE }}\"}
                       }
                     ) {
                       projectV2Item {
@@ -118,15 +123,15 @@ jobs:
                     }
                   }"
 
-              elif [ "${{ inputs.UPDATE_FIELD_TYPE }}" == "number" ]; then
+              elif [ "${{ env.ENV_UPDATE_FIELD_TYPE }}" == "number" ]; then
                 gh api graphql -f query="
                   mutation {
                     updateProjectV2ItemFieldValue(
                       input: {
-                        projectId: \"${{ inputs.PROJECT_ID }}\"
+                        projectId: \"${{ env.ENV_PROJECT_ID }}\"
                         itemId: \"$issue_id\"
-                        fieldId: \"${{ inputs.UPDATE_FIELD_ID }}\"
-                        value: {${{ inputs.UPDATE_FIELD_TYPE }}: ${{ inputs.UPDATE_FIELD_VALUE }}}}
+                        fieldId: \"${{ env.ENV_UPDATE_FIELD_ID }}\"
+                        value: {${{ env.ENV_UPDATE_FIELD_TYPE }}: ${{ env.ENV_UPDATE_FIELD_VALUE }}}}
                     ) {projectV2Item {id}}}"
 
               else


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/project-get-set-single-select-field.yaml` file to improve the handling of the `SINGLE_SELECT_OPTION_VALUE` input. The changes ensure that if no option value is specified, the workflow defaults to the first option in the selector.

Key changes:

*Workflow improvements:*

* [`.github/workflows/project-get-set-single-select-field.yaml`](diffhunk://#diff-d45100b06985e94f86e4180d682f0f3aa17bd366899a62e1c3117bf5080621e7L18-L22): Removed the `SINGLE_SELECT_OPTION_VALUE` input as a required parameter and added it as an optional parameter with a default value of `null`. [[1]](diffhunk://#diff-d45100b06985e94f86e4180d682f0f3aa17bd366899a62e1c3117bf5080621e7L18-L22) [[2]](diffhunk://#diff-d45100b06985e94f86e4180d682f0f3aa17bd366899a62e1c3117bf5080621e7R44-R49)
* [`.github/workflows/project-get-set-single-select-field.yaml`](diffhunk://#diff-d45100b06985e94f86e4180d682f0f3aa17bd366899a62e1c3117bf5080621e7R75-R93): Updated the job to handle cases where `SINGLE_SELECT_OPTION_VALUE` is not specified by querying the first option in the list. [[1]](diffhunk://#diff-d45100b06985e94f86e4180d682f0f3aa17bd366899a62e1c3117bf5080621e7R75-R93) [[2]](diffhunk://#diff-d45100b06985e94f86e4180d682f0f3aa17bd366899a62e1c3117bf5080621e7R108)