### PR TITLE
remove required flag from shared-actions param

### DIFF
--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -36,13 +36,9 @@ on:
       shared_actions_repo:
         type: string
         description: git repo for rapidsai/shared-actions code
-        # require this instead of defaulting, so that downstream users supply this with their repo
-        required: true
       shared_actions_ref:
         type: string
         description: git ref of branch/tag/sha for rapidsai/shared-actions repo
-        # require this instead of defaulting, so that downstream users supply this with their repo branch
-        required: true
 
 defaults:
   run:

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -36,9 +36,11 @@ on:
       shared_actions_repo:
         type: string
         description: git repo for rapidsai/shared-actions code
+        default: rapidsai/shared-actions
       shared_actions_ref:
         type: string
         description: git ref of branch/tag/sha for rapidsai/shared-actions repo
+        default: main
 
 defaults:
   run:


### PR DESCRIPTION
This caused existing workflows that do not yet add this parameter to fail. Other workflows did not have this parameter as a required parameter.

These parameters are part of a rework of how shared actions get called. It is described in the readme in https://github.com/rapidsai/shared-actions