### PR TITLE
add if: always() to telemetry checkout steps

### DIFF
--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -152,6 +152,7 @@ jobs:
             ${{ inputs.build_command }}
       - name: Clone shared-actions
         uses: actions/checkout@v4
+        if: always()
         with:
             repository: ${{inputs.shared_actions_repo}}
             ref: ${{inputs.shared_actions_ref}}
@@ -159,7 +160,7 @@ jobs:
 
       - name: Telemetry summary
         id: telemetry-summary
-        if: "always()"
+        if: always()
         uses: ./shared-actions/telemetry-summarize
         with:
           traceparent: "${{ inputs.traceparent }}"

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -84,6 +84,7 @@ jobs:
           persist-credentials: false
       - name: Clone shared-actions
         uses: actions/checkout@v4
+        if: always()
         with:
             repository: ${{inputs.shared_actions_repo}}
             ref: ${{inputs.shared_actions_ref}}
@@ -118,7 +119,7 @@ jobs:
 
       - name: Telemetry summary
         id: telemetry-summary
-        if: "always()"
+        if: always()
         uses: ./shared-actions/telemetry-summarize
         with:
           traceparent: "${{ inputs.traceparent }}"

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -73,6 +73,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Checkout actions
         uses: actions/checkout@v4
+        if: always()
         with:
             repository: ${{inputs.shared_actions_repo}}
             ref: ${{inputs.shared_actions_ref}}
@@ -93,7 +94,7 @@ jobs:
 
       - name: Telemetry summary
         id: telemetry-summary
-        if: "always()"
+        if: always()
         uses: ./shared-actions/telemetry-summarize
         with:
           traceparent: "${{ inputs.traceparent }}"
@@ -113,6 +114,7 @@ jobs:
           fetch-depth: 0
       - name: Checkout actions
         uses: actions/checkout@v4
+        if: always()
         with:
             repository: ${{inputs.shared_actions_repo}}
             ref: ${{inputs.shared_actions_ref}}
@@ -131,7 +133,7 @@ jobs:
 
       - name: Telemetry summary
         id: telemetry-summary
-        if: "always()"
+        if: always()
         uses: ./shared-actions/telemetry-summarize
         with:
           traceparent: "${{ inputs.traceparent }}"

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -139,13 +139,16 @@ jobs:
       # Sets TRACEPARENT to the value appropriate for this job (which includes the various matrix values)
       - name: Telemetry setup
         id: job-traceparent
+        if: always()
         uses: ./shared-actions/telemetry-traceparent
 
       - name: Get GitHub job info, to obtain machine info
         uses: ./shared-actions/github-actions-job-info
+        if: always()
         id: job-info
 
       - name: Add machine details to attributes metadata
+        if: always()
         run: |
           labels=$(echo "${{steps.job-info.outputs.job-info}}" | jq -r '.labels | join(" ")')
           echo OTEL_RESOURCE_ATTRIBUTES="${OTEL_RESOURCE_ATTRIBUTES},${labels}" >> ${GITHUB_ENV}

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -124,6 +124,7 @@ jobs:
           fetch-depth: 0
       - name: Checkout actions
         uses: actions/checkout@v4
+        if: always()
         with:
             repository: ${{inputs.shared_actions_repo}}
             ref: ${{inputs.shared_actions_ref}}
@@ -160,7 +161,7 @@ jobs:
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)
       - name: Telemetry summary
         id: telemetry-summary
-        if: "always()"
+        if: always()
         continue-on-error: true
         uses: ./shared-actions/telemetry-summarize
         with:

--- a/.github/workflows/conda-cpp-post-build-checks.yaml
+++ b/.github/workflows/conda-cpp-post-build-checks.yaml
@@ -110,6 +110,7 @@ jobs:
             python ./tool/detect.py ${RAPIDS_EXTRACTED_DIR}/lib
           fi
       - name: Clone shared-actions
+        if: always()
         uses: actions/checkout@v4
         with:
             repository: ${{inputs.shared_actions_repo}}
@@ -117,7 +118,7 @@ jobs:
             path: ./shared-actions
       - name: Telemetry summary
         id: telemetry-summary
-        if: "always()"
+        if: always()
         uses: ./shared-actions/telemetry-summarize
         with:
             traceparent: "${{ inputs.traceparent }}"

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -150,6 +150,7 @@ jobs:
           fetch-depth: 0
       - name: Checkout actions
         uses: actions/checkout@v4
+        if: always()
         with:
             repository: ${{inputs.shared_actions_repo}}
             ref: ${{inputs.shared_actions_ref}}
@@ -162,10 +163,12 @@ jobs:
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
 
       - name: Get GitHub job info, to obtain machine info
+        if: always()
         uses: ./shared-actions/github-actions-job-info
         id: job-info
 
       - name: Add machine details to attributes metadata
+        if: always()
         run: |
           labels=$(echo "${{steps.job-info.outputs.job-info}}" | jq -r '.labels | join(" ")')
           echo OTEL_RESOURCE_ATTRIBUTES="${OTEL_RESOURCE_ATTRIBUTES},rapids.labels=${labels}" >> ${GITHUB_ENV}
@@ -185,7 +188,7 @@ jobs:
 
       - name: Telemetry summary
         id: telemetry-summary
-        if: "always()"
+        if: always()
         uses: ./shared-actions/telemetry-summarize
         with:
           traceparent: "${{ inputs.traceparent }}"

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -134,6 +134,7 @@ jobs:
           fetch-depth: 0
       - name: Checkout actions
         uses: actions/checkout@v4
+        if: always()
         with:
             repository: ${{inputs.shared_actions_repo}}
             ref: ${{inputs.shared_actions_ref}}
@@ -148,13 +149,16 @@ jobs:
       - name: Get GitHub job info, to obtain machine info
         uses: ./shared-actions/github-actions-job-info
         id: job-info
+        if: always()
       - name: Add machine details to attributes metadata
+        if: always()
         run: |
           labels=$(echo "${{steps.job-info.outputs.job-info}}" | jq -r '.labels | join(" ")')
           echo OTEL_RESOURCE_ATTRIBUTES="${OTEL_RESOURCE_ATTRIBUTES},rapids.labels=${labels}" >> ${GITHUB_ENV}
 
       - name: Telemetry setup
         id: job-traceparent
+        if: always()
         uses: ./shared-actions/telemetry-traceparent
 
       - name: Python build
@@ -166,7 +170,7 @@ jobs:
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
       - name: Telemetry summary
         id: telemetry-summary
-        if: "always()"
+        if: always()
         uses: ./shared-actions/telemetry-summarize
         with:
           traceparent: "${{ inputs.traceparent }}"

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -155,6 +155,7 @@ jobs:
           ref: ${{ inputs.sha }}
           fetch-depth: 0
       - name: Checkout actions
+        if: always()
         uses: actions/checkout@v4
         with:
             repository: ${{inputs.shared_actions_repo}}
@@ -168,14 +169,17 @@ jobs:
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
 
       - name: Get GitHub job info, to obtain machine info
+        if: always()
         uses: ./shared-actions/github-actions-job-info
         id: job-info
       - name: Add machine details to attributes metadata
+        if: always()
         run: |
           labels=$(echo "${{steps.job-info.outputs.job-info}}" | jq -r '.labels | join(" ")')
           echo OTEL_RESOURCE_ATTRIBUTES="${OTEL_RESOURCE_ATTRIBUTES},rapids.labels=${labels}"  >> ${GITHUB_ENV}
       - name: Telemetry setup
         id: job-traceparent
+        if: always()
         uses: ./shared-actions/telemetry-traceparent
 
       - name: Python tests
@@ -203,7 +207,7 @@ jobs:
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
       - name: Telemetry summary
         id: telemetry-summary
-        if: "always()"
+        if: always()
         uses: ./shared-actions/telemetry-summarize
         with:
           traceparent: "${{ inputs.traceparent }}"

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -84,6 +84,7 @@ jobs:
           fetch-depth: 0
       - name: Checkout actions
         uses: actions/checkout@v4
+        if: always()
         with:
             repository: ${{inputs.shared_actions_repo}}
             ref: ${{inputs.shared_actions_ref}}
@@ -97,6 +98,7 @@ jobs:
 
       - name: Telemetry setup
         id: job-traceparent
+        if: always()
         uses: ./shared-actions/telemetry-traceparent
 
       - name: Set Proper Conda Upload Token
@@ -113,7 +115,7 @@ jobs:
           RAPIDS_CONDA_UPLOAD_LABEL: ${{ inputs.upload_to_label }}
       - name: Telemetry summary
         id: telemetry-summary
-        if: "always()"
+        if: always()
         uses: ./shared-actions/telemetry-summarize
         with:
           traceparent: "${{ inputs.traceparent }}"

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -97,6 +97,7 @@ jobs:
           fetch-depth: 0
       - name: Checkout actions
         uses: actions/checkout@v4
+        if: always()
         with:
             repository: ${{inputs.shared_actions_repo}}
             ref: ${{inputs.shared_actions_ref}}
@@ -129,7 +130,7 @@ jobs:
 
       - name: Telemetry summary
         id: telemetry-summary
-        if: "always()"
+        if: always()
         uses: ./shared-actions/telemetry-summarize
         with:
           traceparent: "${{ inputs.traceparent }}"

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -161,6 +161,7 @@ jobs:
 
       - name: Checkout actions
         uses: actions/checkout@v4
+        if: always()
         with:
             repository: ${{inputs.shared_actions_repo}}
             ref: ${{inputs.shared_actions_ref}}
@@ -193,14 +194,17 @@ jobs:
 
       - name: Get GitHub job info, to obtain machine info
         uses: ./shared-actions/github-actions-job-info
+        if: always()
         id: job-info
       - name: Add machine details to attributes metadata
+        if: always()
         run: |
           labels=$(echo "${{steps.job-info.outputs.job-info}}" | jq -r '.labels | join(" ")')
           echo OTEL_RESOURCE_ATTRIBUTES="${OTEL_RESOURCE_ATTRIBUTES},rapids.labels=${labels}"  >> ${GITHUB_ENV}
 
       - name: Telemetry setup
         id: job-traceparent
+        if: always()
         uses: ./shared-actions/telemetry-traceparent
 
       - name: Build and repair the wheel
@@ -215,7 +219,7 @@ jobs:
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
       - name: Telemetry summary
         id: telemetry-summary
-        if: "always()"
+        if: always()
         uses: ./shared-actions/telemetry-summarize
         with:
           traceparent: "${{ inputs.traceparent }}"

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -92,6 +92,7 @@ jobs:
 
     - name: Checkout actions
       uses: actions/checkout@v4
+      if: always()
       with:
         repository: ${{inputs.shared_actions_repo}}
         ref: ${{inputs.shared_actions_ref}}
@@ -129,7 +130,7 @@ jobs:
 
     - name: Telemetry summary
       id: telemetry-summary
-      if: "always()"
+      if: always()
       uses: ./shared-actions/telemetry-summarize
       with:
         traceparent: "${{ inputs.traceparent }}"

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -167,6 +167,7 @@ jobs:
 
     - name: Checkout actions
       uses: actions/checkout@v4
+      if: always()
       with:
         repository: ${{inputs.shared_actions_repo}}
         ref: ${{inputs.shared_actions_ref}}
@@ -206,7 +207,7 @@ jobs:
 
     - name: Telemetry summary
       id: telemetry-summary
-      if: "always()"
+      if: always()
       uses: ./shared-actions/telemetry-summarize
       with:
         traceparent: "${{ inputs.traceparent }}"


### PR DESCRIPTION
The telemetry additions here were masking other failed jobs because the telemetry was spread across too many steps. Only the last step had `if: always()`, when all of them should have it. We do want telemetry on failed jobs - that's why we have the `always()` set.