### PR TITLE
refactor shared actions to simplify telemetry

### DIFF
--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -30,26 +30,6 @@ on:
         required: false
         type: string
         default: ''
-      default_endpoint:
-        type: string
-        description: "Destination to send telemetry to, not including path like /v1/traces"
-      traceparent:
-        type: string
-        description: |
-            Opentelemetry traceparent. Format is described in https://medium.com/@mesutatasoy/understanding-traceparent-and-microservices-in-opentelemetry-notepad-series-7-de5c16bf6462
-            Generally, 00-<trace_id 32 chars>-<span_id 16 chars>-01
-      otel_resource_attributes:
-        type: string
-        description: |
-          Comma-separated key=value pairs used for storing additional "tags" to better identify data
-      shared_actions_repo:
-        type: string
-        description: git repo for rapidsai/shared-actions code
-        default: rapidsai/shared-actions
-      shared_actions_ref:
-        type: string
-        description: git ref of branch/tag/sha for rapidsai/shared-actions repo
-        default: main
     # the use of secrets in shared-workflows is discouraged, especially for public repositories.
     # these values were added for situations where the use of secrets is unavoidable.
     secrets:
@@ -70,12 +50,6 @@ permissions:
   repository-projects: none
   security-events: none
   statuses: none
-
-env:
-  # TODO: this should be set as an org-wide variable
-  OTEL_EXPORTER_OTLP_ENDPOINT: ${{inputs.default_endpoint}}
-  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
-  OTEL_RESOURCE_ATTRIBUTES: ${{inputs.otel_resource_attributes}}
 
 jobs:
   build:
@@ -150,20 +124,10 @@ jobs:
 
             cd ~/"${REPOSITORY}";
             ${{ inputs.build_command }}
-      - name: Clone shared-actions
-        uses: actions/checkout@v4
-        if: always()
-        with:
-            repository: ${{inputs.shared_actions_repo}}
-            ref: ${{inputs.shared_actions_ref}}
-            path: ./shared-actions
 
-      - name: Telemetry summary
-        id: telemetry-summary
+      - name: Telemetry summarize
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@telemetry-dispatch-actions
+        continue-on-error: true
         if: always()
-        uses: ./shared-actions/telemetry-summarize
         with:
-          traceparent: "${{ inputs.traceparent }}"
-          ca_cert: "${{secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE}}"
-          client_cert: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}}"
-          client_key: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY}}"
+          cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -17,26 +17,6 @@ on:
             }
           ) |
           from_entries
-      default_endpoint:
-        type: string
-        description: "Destination to send telemetry to, not including path like /v1/traces"
-      traceparent:
-        type: string
-        description: |
-            Opentelemetry traceparent. Format is described in https://medium.com/@mesutatasoy/understanding-traceparent-and-microservices-in-opentelemetry-notepad-series-7-de5c16bf6462
-            Generally, 00-<trace_id 32 chars>-<span_id 16 chars>-01
-      otel_resource_attributes:
-        type: string
-        description: |
-          Comma-separated key=value pairs used for storing additional "tags" to better identify data
-      shared_actions_repo:
-        type: string
-        description: git repo for rapidsai/shared-actions code
-        default: rapidsai/shared-actions
-      shared_actions_ref:
-        type: string
-        description: git ref of branch/tag/sha for rapidsai/shared-actions repo
-        default: main
     outputs:
       changed_file_groups:
         value: ${{ jobs.changed-files.outputs.transformed_output }}
@@ -60,12 +40,6 @@ permissions:
   security-events: none
   statuses: none
 
-env:
-  # TODO: this should be set as an org-wide variable
-  OTEL_EXPORTER_OTLP_ENDPOINT: ${{inputs.default_endpoint}}
-  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
-  OTEL_RESOURCE_ATTRIBUTES: ${{inputs.otel_resource_attributes}}
-
 jobs:
   changed-files:
     runs-on: ubuntu-latest
@@ -82,13 +56,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Clone shared-actions
-        uses: actions/checkout@v4
-        if: always()
-        with:
-            repository: ${{inputs.shared_actions_repo}}
-            ref: ${{inputs.shared_actions_ref}}
-            path: ./shared-actions
       - name: Calculate merge base
         id: calculate-merge-base
         env:
@@ -117,12 +84,9 @@ jobs:
           done
           (echo -n "transformed-output="; jq -c -n "\$ARGS.named | to_entries | map({"key": .key, "value": .value[]}) | from_entries | $TRANSFORM_EXPR" "${file_args[@]}") | tee --append "$GITHUB_OUTPUT"
 
-      - name: Telemetry summary
-        id: telemetry-summary
+      - name: Telemetry summarize
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@telemetry-dispatch-actions
+        continue-on-error: true
         if: always()
-        uses: ./shared-actions/telemetry-summarize
         with:
-          traceparent: "${{ inputs.traceparent }}"
-          ca_cert: "${{secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE}}"
-          client_cert: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}}"
-          client_key: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY}}"
+          cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -31,35 +31,10 @@ on:
         default: ""
         type: string
         required: false
-      default_endpoint:
-        type: string
-        description: "Destination to send telemetry to, not including path like /v1/traces"
-      traceparent:
-        type: string
-        description: |
-            Opentelemetry traceparent. Format is described in https://medium.com/@mesutatasoy/understanding-traceparent-and-microservices-in-opentelemetry-notepad-series-7-de5c16bf6462
-            Generally, 00-<trace_id 32 chars>-<span_id 16 chars>-01
-      otel_resource_attributes:
-        type: string
-        description: |
-          Comma-separated key=value pairs used for storing additional "tags" to better identify data
-      shared_actions_repo:
-        type: string
-        description: git repo for rapidsai/shared-actions code
-        default: rapidsai/shared-actions
-      shared_actions_ref:
-        type: string
-        description: git ref of branch/tag/sha for rapidsai/shared-actions repo
-        default: main
 
 defaults:
   run:
     shell: bash
-
-env:
-  OTEL_EXPORTER_OTLP_ENDPOINT: "${{ inputs.default_endpoint }}"
-  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
-  OTEL_RESOURCE_ATTRIBUTES: ${{inputs.otel_resource_attributes}}
 
 jobs:
   other-checks:
@@ -71,13 +46,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Checkout actions
-        uses: actions/checkout@v4
-        if: always()
-        with:
-            repository: ${{inputs.shared_actions_repo}}
-            ref: ${{inputs.shared_actions_ref}}
-            path: ./shared-actions
       - name: Get PR Info
         id: get-pr-info
         uses: nv-gha-runners/get-pr-info@main
@@ -92,15 +60,12 @@ jobs:
         env:
           IGNORED_JOBS: ${{ inputs.ignored_pr_jobs }}
 
-      - name: Telemetry summary
-        id: telemetry-summary
+      - name: Telemetry summarize
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@telemetry-dispatch-actions
+        continue-on-error: true
         if: always()
-        uses: ./shared-actions/telemetry-summarize
         with:
-          traceparent: "${{ inputs.traceparent }}"
-          ca_cert: "${{secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE}}"
-          client_cert: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}}"
-          client_key: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY}}"
+          cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
 
   check-style:
     if: ${{ inputs.enable_check_style }}
@@ -112,13 +77,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Checkout actions
-        uses: actions/checkout@v4
-        if: always()
-        with:
-            repository: ${{inputs.shared_actions_repo}}
-            ref: ${{inputs.shared_actions_ref}}
-            path: ./shared-actions
       - name: Get PR Info
         id: get-pr-info
         uses: nv-gha-runners/get-pr-info@main
@@ -131,12 +89,9 @@ jobs:
         env:
           RAPIDS_BASE_BRANCH: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}
 
-      - name: Telemetry summary
-        id: telemetry-summary
+      - name: Telemetry summarize
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@telemetry-dispatch-actions
+        continue-on-error: true
         if: always()
-        uses: ./shared-actions/telemetry-summarize
         with:
-          traceparent: "${{ inputs.traceparent }}"
-          ca_cert: "${{secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE}}"
-          client_cert: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}}"
-          client_key: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY}}"
+          cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -21,25 +21,6 @@ on:
       matrix_filter:
         type: string
         default: "."
-      default_endpoint:
-        type: string
-      traceparent:
-        type: string
-        description: |
-            Opentelemetry traceparent. Format is described in https://medium.com/@mesutatasoy/understanding-traceparent-and-microservices-in-opentelemetry-notepad-series-7-de5c16bf6462
-            Generally, 00-<trace_id 32 chars>-<span_id 16 chars>-01
-      otel_resource_attributes:
-        type: string
-        description: |
-          Comma-separated key=value pairs used for storing additional "tags" to better identify data
-      shared_actions_repo:
-        type: string
-        description: git repo for rapidsai/shared-actions code
-        default: rapidsai/shared-actions
-      shared_actions_ref:
-        type: string
-        description: git ref of branch/tag/sha for rapidsai/shared-actions repo
-        default: main
 
 defaults:
   run:
@@ -59,12 +40,6 @@ permissions:
   repository-projects: none
   security-events: none
   statuses: none
-
-env:
-  OTEL_EXPORTER_OTLP_ENDPOINT: "${{ inputs.default_endpoint }}"
-  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
-  OTEL_PYTHON_DISABLED_INSTRUMENTATIONS: "jinja2"
-
 
 jobs:
   compute-matrix:
@@ -106,7 +81,6 @@ jobs:
     runs-on: "linux-${{ matrix.ARCH }}-${{ inputs.node_type }}"
     env:
       RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
-      OTEL_RESOURCE_ATTRIBUTES: "${{inputs.otel_resource_attributes}},rapids.operation=test-cpp,rapids.package_type=conda,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}}"
     container:
       image: rapidsai/ci-conda:cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
       env:
@@ -122,36 +96,12 @@ jobs:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}
           fetch-depth: 0
-      - name: Checkout actions
-        uses: actions/checkout@v4
-        if: always()
-        with:
-            repository: ${{inputs.shared_actions_repo}}
-            ref: ${{inputs.shared_actions_ref}}
-            path: ./shared-actions
       - name: Standardize repository information
         run: |
           echo "RAPIDS_REPOSITORY=${{ inputs.repo || github.repository }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_SHA=$(git rev-parse HEAD)" >> "${GITHUB_ENV}"
           echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
-
-      # Sets TRACEPARENT to the value appropriate for this job (which includes the various matrix values)
-      - name: Telemetry setup
-        id: job-traceparent
-        if: always()
-        uses: ./shared-actions/telemetry-traceparent
-
-      - name: Get GitHub job info, to obtain machine info
-        uses: ./shared-actions/github-actions-job-info
-        if: always()
-        id: job-info
-
-      - name: Add machine details to attributes metadata
-        if: always()
-        run: |
-          labels=$(echo "${{steps.job-info.outputs.job-info}}" | jq -r '.labels | join(" ")')
-          echo OTEL_RESOURCE_ATTRIBUTES="${OTEL_RESOURCE_ATTRIBUTES},${labels}" >> ${GITHUB_ENV}
 
       - name: C++ build
         run: ${{ inputs.script }}
@@ -162,13 +112,11 @@ jobs:
       - name: Upload additional artifacts
         if: "!cancelled()"
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)
-      - name: Telemetry summary
-        id: telemetry-summary
-        if: always()
+
+      - name: Telemetry summarize
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@telemetry-dispatch-actions
         continue-on-error: true
-        uses: ./shared-actions/telemetry-summarize
+        if: always()
         with:
-          traceparent: "${{ inputs.traceparent }}"
-          ca_cert: "${{secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE}}"
-          client_cert: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}}"
-          client_key: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY}}"
+          cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
+          extra_attributes: "rapids.operation=test-cpp,rapids.package_type=conda,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}}"

--- a/.github/workflows/conda-cpp-post-build-checks.yaml
+++ b/.github/workflows/conda-cpp-post-build-checks.yaml
@@ -18,25 +18,6 @@ on:
         required: false
       symbol_exclusions:
         type: string
-      default_endpoint:
-        type: string
-      traceparent:
-        type: string
-        description: |
-            Opentelemetry traceparent. Format is described in https://medium.com/@mesutatasoy/understanding-traceparent-and-microservices-in-opentelemetry-notepad-series-7-de5c16bf6462
-            Generally, 00-<trace_id 32 chars>-<span_id 16 chars>-01
-      otel_resource_attributes:
-        type: string
-        description: |
-          Comma-separated key=value pairs used for storing additional "tags" to better identify data
-      shared_actions_repo:
-        type: string
-        description: git repo for rapidsai/shared-actions code
-        default: rapidsai/shared-actions
-      shared_actions_ref:
-        type: string
-        description: git ref of branch/tag/sha for rapidsai/shared-actions repo
-        default: main
 
 defaults:
   run:
@@ -56,11 +37,6 @@ permissions:
   repository-projects: none
   security-events: none
   statuses: none
-
-env:
-  OTEL_EXPORTER_OTLP_ENDPOINT: "${{ inputs.default_endpoint }}"
-  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
-  OTEL_PYTHON_DISABLED_INSTRUMENTATIONS: "jinja2"
 
 jobs:
   check-symbols:
@@ -109,19 +85,10 @@ jobs:
           else
             python ./tool/detect.py ${RAPIDS_EXTRACTED_DIR}/lib
           fi
-      - name: Clone shared-actions
+
+      - name: Telemetry summarize
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@telemetry-dispatch-actions
+        continue-on-error: true
         if: always()
-        uses: actions/checkout@v4
         with:
-            repository: ${{inputs.shared_actions_repo}}
-            ref: ${{inputs.shared_actions_ref}}
-            path: ./shared-actions
-      - name: Telemetry summary
-        id: telemetry-summary
-        if: always()
-        uses: ./shared-actions/telemetry-summarize
-        with:
-            traceparent: "${{ inputs.traceparent }}"
-            ca_cert: "${{secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE}}"
-            client_cert: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}}"
-            client_key: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY}}"
+          cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -22,26 +22,6 @@ on:
         required: false
         type: string
         default: "-e _NOOP"
-      default_endpoint:
-        type: string
-        description: "Destination to send telemetry to, not including path like /v1/traces"
-      traceparent:
-        type: string
-        description: |
-            Opentelemetry traceparent. Format is described in https://medium.com/@mesutatasoy/understanding-traceparent-and-microservices-in-opentelemetry-notepad-series-7-de5c16bf6462
-            Generally, 00-<trace_id 32 chars>-<span_id 16 chars>-01w
-      otel_resource_attributes:
-        type: string
-        description: |
-          Comma-separated key=value pairs used for storing additional "tags" to better identify data
-      shared_actions_repo:
-        type: string
-        description: git repo for rapidsai/shared-actions code
-        default: rapidsai/shared-actions
-      shared_actions_ref:
-        type: string
-        description: git ref of branch/tag/sha for rapidsai/shared-actions repo
-        default: main
 
 defaults:
   run:
@@ -61,11 +41,6 @@ permissions:
   repository-projects: none
   security-events: none
   statuses: none
-
-env:
-  OTEL_EXPORTER_OTLP_ENDPOINT: "${{ inputs.default_endpoint }}"
-  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
-  OTEL_PYTHON_DISABLED_INSTRUMENTATIONS: "jinja2"
 
 jobs:
   compute-matrix:
@@ -127,7 +102,6 @@ jobs:
     runs-on: "linux-${{ matrix.ARCH }}-gpu-${{ matrix.GPU }}-${{ matrix.DRIVER }}-1"
     env:
       RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
-      OTEL_RESOURCE_ATTRIBUTES: "${{inputs.otel_resource_attributes}},rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}},rapids.gpu=${{matrix.GPU}},rapids.driver=${{matrix.DRIVER}},rapids.deps=${{matrix.DEPENDENCIES}}"
       RAPIDS_DEPENDENCIES: ${{ matrix.DEPENDENCIES }}
       RAPIDS_TESTS_DIR: ${{ github.workspace }}/test-results
     container:
@@ -148,30 +122,13 @@ jobs:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}
           fetch-depth: 0
-      - name: Checkout actions
-        uses: actions/checkout@v4
-        if: always()
-        with:
-            repository: ${{inputs.shared_actions_repo}}
-            ref: ${{inputs.shared_actions_ref}}
-            path: ./shared-actions
+
       - name: Standardize repository information
         run: |
           echo "RAPIDS_REPOSITORY=${{ inputs.repo || github.repository }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_SHA=$(git rev-parse HEAD)" >> "${GITHUB_ENV}"
           echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
-
-      - name: Get GitHub job info, to obtain machine info
-        if: always()
-        uses: ./shared-actions/github-actions-job-info
-        id: job-info
-
-      - name: Add machine details to attributes metadata
-        if: always()
-        run: |
-          labels=$(echo "${{steps.job-info.outputs.job-info}}" | jq -r '.labels | join(" ")')
-          echo OTEL_RESOURCE_ATTRIBUTES="${OTEL_RESOURCE_ATTRIBUTES},rapids.labels=${labels}" >> ${GITHUB_ENV}
 
       - name: C++ tests
         run: ${{ inputs.script }}
@@ -186,12 +143,10 @@ jobs:
         if: "!cancelled()"
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)
 
-      - name: Telemetry summary
-        id: telemetry-summary
+      - name: Telemetry summarize
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@telemetry-dispatch-actions
+        continue-on-error: true
         if: always()
-        uses: ./shared-actions/telemetry-summarize
         with:
-          traceparent: "${{ inputs.traceparent }}"
-          ca_cert: "${{secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE}}"
-          client_cert: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}}"
-          client_key: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY}}"
+          cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
+          extra_attributes: "rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}},rapids.gpu=${{matrix.GPU}},rapids.driver=${{matrix.DRIVER}},rapids.deps=${{matrix.DEPENDENCIES}}"

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -21,26 +21,6 @@ on:
       matrix_filter:
         type: string
         default: "."
-      default_endpoint:
-        type: string
-        description: "Destination to send telemetry to, not including path like /v1/traces"
-      traceparent:
-        type: string
-        description: |
-            Opentelemetry traceparent. Format is described in https://medium.com/@mesutatasoy/understanding-traceparent-and-microservices-in-opentelemetry-notepad-series-7-de5c16bf6462
-            Generally, 00-<trace_id 32 chars>-<span_id 16 chars>-01
-      otel_resource_attributes:
-        type: string
-        description: |
-          Comma-separated key=value pairs used for storing additional "tags" to better identify data
-      shared_actions_repo:
-        type: string
-        description: git repo for rapidsai/shared-actions code
-        default: rapidsai/shared-actions
-      shared_actions_ref:
-        type: string
-        description: git ref of branch/tag/sha for rapidsai/shared-actions repo
-        default: main
 
 defaults:
   run:
@@ -60,12 +40,6 @@ permissions:
   repository-projects: none
   security-events: none
   statuses: none
-
-env:
-  OTEL_EXPORTER_OTLP_ENDPOINT: "${{ inputs.default_endpoint }}"
-  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
-  OTEL_PYTHON_DISABLED_INSTRUMENTATIONS: "jinja2"
-  OTEL_RESOURCE_ATTRIBUTES: ${{inputs.otel_resource_attributes}}
 
 jobs:
   compute-matrix:
@@ -114,7 +88,6 @@ jobs:
     runs-on: "linux-${{ matrix.ARCH }}-${{ inputs.node_type }}"
     env:
       RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
-      OTEL_RESOURCE_ATTRIBUTES: "${{inputs.otel_resource_attributes}},rapids.operation=build-python,rapids.package_type=conda,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}}"
     container:
       image: rapidsai/ci-conda:cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
       env:
@@ -130,34 +103,12 @@ jobs:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}
           fetch-depth: 0
-      - name: Checkout actions
-        uses: actions/checkout@v4
-        if: always()
-        with:
-            repository: ${{inputs.shared_actions_repo}}
-            ref: ${{inputs.shared_actions_ref}}
-            path: ./shared-actions
       - name: Standardize repository information
         run: |
           echo "RAPIDS_REPOSITORY=${{ inputs.repo || github.repository }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_SHA=$(git rev-parse HEAD)" >> "${GITHUB_ENV}"
           echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
-
-      - name: Get GitHub job info, to obtain machine info
-        uses: ./shared-actions/github-actions-job-info
-        id: job-info
-        if: always()
-      - name: Add machine details to attributes metadata
-        if: always()
-        run: |
-          labels=$(echo "${{steps.job-info.outputs.job-info}}" | jq -r '.labels | join(" ")')
-          echo OTEL_RESOURCE_ATTRIBUTES="${OTEL_RESOURCE_ATTRIBUTES},rapids.labels=${labels}" >> ${GITHUB_ENV}
-
-      - name: Telemetry setup
-        id: job-traceparent
-        if: always()
-        uses: ./shared-actions/telemetry-traceparent
 
       - name: Python build
         run: ${{ inputs.script }}
@@ -166,12 +117,11 @@ jobs:
       - name: Upload additional artifacts
         if: "!cancelled()"
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
-      - name: Telemetry summary
-        id: telemetry-summary
+
+      - name: Telemetry summarize
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@telemetry-dispatch-actions
+        continue-on-error: true
         if: always()
-        uses: ./shared-actions/telemetry-summarize
         with:
-          traceparent: "${{ inputs.traceparent }}"
-          ca_cert: "${{secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE}}"
-          client_cert: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}}"
-          client_key: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY}}"
+          cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
+          extra_attributes: "rapids.operation=build-python,rapids.package_type=conda,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}}"

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -25,26 +25,6 @@ on:
         required: false
         type: string
         default: "-e _NOOP"
-      default_endpoint:
-        type: string
-        description: "Destination to send telemetry to, not including path like /v1/traces"
-      traceparent:
-        type: string
-        description: |
-            Opentelemetry traceparent. Format is described in https://medium.com/@mesutatasoy/understanding-traceparent-and-microservices-in-opentelemetry-notepad-series-7-de5c16bf6462
-            Generally, 00-<trace_id 32 chars>-<span_id 16 chars>-01
-      otel_resource_attributes:
-        type: string
-        description: |
-          Comma-separated key=value pairs used for storing additional "tags" to better identify data
-      shared_actions_repo:
-        type: string
-        description: git repo for rapidsai/shared-actions code
-        default: rapidsai/shared-actions
-      shared_actions_ref:
-        type: string
-        description: git ref of branch/tag/sha for rapidsai/shared-actions repo
-        default: main
 
 defaults:
   run:
@@ -64,12 +44,6 @@ permissions:
   repository-projects: none
   security-events: none
   statuses: none
-
-env:
-  OTEL_EXPORTER_OTLP_ENDPOINT: "${{ inputs.default_endpoint }}"
-  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
-  OTEL_PYTHON_DISABLED_INSTRUMENTATIONS: "jinja2"
-  OTEL_RESOURCE_ATTRIBUTES: ${{inputs.otel_resource_attributes}}
 
 jobs:
   compute-matrix:
@@ -134,8 +108,6 @@ jobs:
       RAPIDS_COVERAGE_DIR: ${{ github.workspace }}/coverage-results
       RAPIDS_DEPENDENCIES: ${{ matrix.DEPENDENCIES }}
       RAPIDS_TESTS_DIR: ${{ github.workspace }}/test-results
-      # TODO: need to determine what the "operation" is here
-      OTEL_RESOURCE_ATTRIBUTES: "${{inputs.otel_resource_attributes}},rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}},rapids.gpu=${{matrix.GPU}},rapids.driver=${{matrix.DRIVER}},rapids.deps=${{matrix.DEPENDENCIES}}"
     container:
       image: rapidsai/ci-conda:cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
       options: ${{ inputs.container-options }}
@@ -154,33 +126,13 @@ jobs:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}
           fetch-depth: 0
-      - name: Checkout actions
-        if: always()
-        uses: actions/checkout@v4
-        with:
-            repository: ${{inputs.shared_actions_repo}}
-            ref: ${{inputs.shared_actions_ref}}
-            path: ./shared-actions
+
       - name: Standardize repository information
         run: |
           echo "RAPIDS_REPOSITORY=${{ inputs.repo || github.repository }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_SHA=$(git rev-parse HEAD)" >> "${GITHUB_ENV}"
           echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
-
-      - name: Get GitHub job info, to obtain machine info
-        if: always()
-        uses: ./shared-actions/github-actions-job-info
-        id: job-info
-      - name: Add machine details to attributes metadata
-        if: always()
-        run: |
-          labels=$(echo "${{steps.job-info.outputs.job-info}}" | jq -r '.labels | join(" ")')
-          echo OTEL_RESOURCE_ATTRIBUTES="${OTEL_RESOURCE_ATTRIBUTES},rapids.labels=${labels}"  >> ${GITHUB_ENV}
-      - name: Telemetry setup
-        id: job-traceparent
-        if: always()
-        uses: ./shared-actions/telemetry-traceparent
 
       - name: Python tests
         run: ${{ inputs.script }}
@@ -205,12 +157,11 @@ jobs:
       - name: Upload additional artifacts
         if: "!cancelled()"
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
-      - name: Telemetry summary
-        id: telemetry-summary
+
+      - name: Telemetry summarize
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@telemetry-dispatch-actions
+        continue-on-error: true
         if: always()
-        uses: ./shared-actions/telemetry-summarize
         with:
-          traceparent: "${{ inputs.traceparent }}"
-          ca_cert: "${{secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE}}"
-          client_cert: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}}"
-          client_key: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY}}"
+          cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
+          extra_attributes:  "rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}},rapids.gpu=${{matrix.GPU}},rapids.driver=${{matrix.DRIVER}},rapids.deps=${{matrix.DEPENDENCIES}}"

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -18,26 +18,6 @@ on:
         description: The label that should be applied to packages uploaded to Anaconda.org
         type: string
         default: main
-      default_endpoint:
-        type: string
-        description: "Destination to send telemetry to, not including path like /v1/traces"
-      traceparent:
-        type: string
-        description: |
-            Opentelemetry traceparent. Format is described in https://medium.com/@mesutatasoy/understanding-traceparent-and-microservices-in-opentelemetry-notepad-series-7-de5c16bf6462
-            Generally, 00-<trace_id 32 chars>-<span_id 16 chars>-01
-      otel_resource_attributes:
-        type: string
-        description: |
-          Comma-separated key=value pairs used for storing additional "tags" to better identify data
-      shared_actions_repo:
-        type: string
-        description: git repo for rapidsai/shared-actions code
-        default: rapidsai/shared-actions
-      shared_actions_ref:
-        type: string
-        description: git ref of branch/tag/sha for rapidsai/shared-actions repo
-        default: main
 
 defaults:
   run:
@@ -58,12 +38,6 @@ permissions:
   security-events: none
   statuses: none
 
-env:
-  OTEL_EXPORTER_OTLP_ENDPOINT: "${{ inputs.default_endpoint }}"
-  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
-  OTEL_PYTHON_DISABLED_INSTRUMENTATIONS: "jinja2"
-  OTEL_RESOURCE_ATTRIBUTES: ${{inputs.otel_resource_attributes}}
-
 jobs:
   upload:
     runs-on: linux-amd64-cpu4
@@ -82,24 +56,13 @@ jobs:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}
           fetch-depth: 0
-      - name: Checkout actions
-        uses: actions/checkout@v4
-        if: always()
-        with:
-            repository: ${{inputs.shared_actions_repo}}
-            ref: ${{inputs.shared_actions_ref}}
-            path: ./shared-actions
+
       - name: Standardize repository information
         run: |
           echo "RAPIDS_REPOSITORY=${{ inputs.repo || github.repository }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_SHA=$(git rev-parse HEAD)" >> "${GITHUB_ENV}"
           echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
-
-      - name: Telemetry setup
-        id: job-traceparent
-        if: always()
-        uses: ./shared-actions/telemetry-traceparent
 
       - name: Set Proper Conda Upload Token
         run: |
@@ -113,12 +76,10 @@ jobs:
         env:
           SKIP_UPLOAD_PKGS: ${{ inputs.skip_upload_pkgs }}
           RAPIDS_CONDA_UPLOAD_LABEL: ${{ inputs.upload_to_label }}
-      - name: Telemetry summary
-        id: telemetry-summary
+
+      - name: Telemetry summarize
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@telemetry-dispatch-actions
+        continue-on-error: true
         if: always()
-        uses: ./shared-actions/telemetry-summarize
         with:
-          traceparent: "${{ inputs.traceparent }}"
-          ca_cert: "${{secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE}}"
-          client_cert: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}}"
-          client_key: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY}}"
+          cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -24,29 +24,6 @@ on:
       run_script:
         required: true
         type: string
-      default_endpoint:
-        type: string
-        description: "Destination to send telemetry to, not including path like /v1/traces"
-      traceparent:
-        type: string
-        description: |
-            Opentelemetry traceparent. Format is described in https://medium.com/@mesutatasoy/understanding-traceparent-and-microservices-in-opentelemetry-notepad-series-7-de5c16bf6462
-            Generally, 00-<trace_id 32 chars>-<span_id 16 chars>-01
-      otel_resource_attributes:
-        type: string
-        description: |
-          Comma-separated key=value pairs used for storing additional "tags" to better identify data
-      shared_actions_repo:
-        type: string
-        description: git repo for rapidsai/shared-actions code
-        default: rapidsai/shared-actions
-      shared_actions_ref:
-        type: string
-        description: git ref of branch/tag/sha for rapidsai/shared-actions repo
-        default: main
-      file_to_upload:
-        type: string
-        default: "gh-status.json"
 
 defaults:
   run:
@@ -66,13 +43,6 @@ permissions:
   repository-projects: none
   security-events: none
   statuses: none
-
-env:
-  # TODO: this should be set as an org-wide variable
-  OTEL_EXPORTER_OTLP_ENDPOINT: "${{ inputs.default_endpoint }}"
-  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
-  OTEL_PYTHON_DISABLED_INSTRUMENTATIONS: "jinja2"
-  OTEL_RESOURCE_ATTRIBUTES: ${{inputs.otel_resource_attributes}}
 
 jobs:
   build:
@@ -95,13 +65,6 @@ jobs:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}
           fetch-depth: 0
-      - name: Checkout actions
-        uses: actions/checkout@v4
-        if: always()
-        with:
-            repository: ${{inputs.shared_actions_repo}}
-            ref: ${{inputs.shared_actions_ref}}
-            path: ./shared-actions
       - name: Get PR Info
         if: startsWith(github.ref_name, 'pull-request/')
         id: get-pr-info
@@ -128,12 +91,9 @@ jobs:
           path: ${{ inputs.file_to_upload }}
           if-no-files-found: ignore
 
-      - name: Telemetry summary
-        id: telemetry-summary
+      - name: Telemetry summarize
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@telemetry-dispatch-actions
+        continue-on-error: true
         if: always()
-        uses: ./shared-actions/telemetry-summarize
         with:
-          traceparent: "${{ inputs.traceparent }}"
-          ca_cert: "${{secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE}}"
-          client_cert: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}}"
-          client_key: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY}}"
+          cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -44,26 +44,6 @@ on:
         required: false
         type: string
         default: ''
-      default_endpoint:
-        type: string
-        description: "Destination to send telemetry to, not including path like /v1/traces"
-      traceparent:
-        type: string
-        description: |
-            Opentelemetry traceparent. Format is described in https://medium.com/@mesutatasoy/understanding-traceparent-and-microservices-in-opentelemetry-notepad-series-7-de5c16bf6462
-            Generally, 00-<trace_id 32 chars>-<span_id 16 chars>-01
-      otel_resource_attributes:
-        type: string
-        description: |
-          Comma-separated key=value pairs used for storing additional "tags" to better identify data
-      shared_actions_repo:
-        type: string
-        description: git repo for rapidsai/shared-actions code
-        default: rapidsai/shared-actions
-      shared_actions_ref:
-        type: string
-        description: git ref of branch/tag/sha for rapidsai/shared-actions repo
-        default: main
 
 defaults:
   run:
@@ -83,13 +63,6 @@ permissions:
   repository-projects: none
   security-events: none
   statuses: none
-
-env:
-  # TODO: this should be set as an org-wide variable
-  OTEL_EXPORTER_OTLP_ENDPOINT: "${{ inputs.default_endpoint }}"
-  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
-  OTEL_PYTHON_DISABLED_INSTRUMENTATIONS: "jinja2"
-  # OTEL_RESOURCE_ATTRIBUTES is set inside the matrix
 
 jobs:
   compute-matrix:
@@ -137,8 +110,6 @@ jobs:
     runs-on: "linux-${{ matrix.ARCH }}-${{ inputs.node_type }}"
     env:
       RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
-      # TODO: set operation name somehow # rapids.operation=${{inputs.OTEL_SERVICE_NAME_PREFIX}}
-      OTEL_RESOURCE_ATTRIBUTES: "${{inputs.otel_resource_attributes}},rapids.operation=build,rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}}"
     container:
       image: "rapidsai/ci-wheel:cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
       env:
@@ -158,14 +129,6 @@ jobs:
           ref: ${{ inputs.sha }}
           fetch-depth: 0 # unshallow fetch for setuptools-scm
           persist-credentials: false
-
-      - name: Checkout actions
-        uses: actions/checkout@v4
-        if: always()
-        with:
-            repository: ${{inputs.shared_actions_repo}}
-            ref: ${{inputs.shared_actions_ref}}
-            path: ./shared-actions
 
       - name: Standardize repository information
         uses: ./shared-actions/rapids-github-info
@@ -192,21 +155,6 @@ jobs:
           ssh-key: ${{ secrets[inputs.extra-repo-deploy-key] }}
           persist-credentials: false
 
-      - name: Get GitHub job info, to obtain machine info
-        uses: ./shared-actions/github-actions-job-info
-        if: always()
-        id: job-info
-      - name: Add machine details to attributes metadata
-        if: always()
-        run: |
-          labels=$(echo "${{steps.job-info.outputs.job-info}}" | jq -r '.labels | join(" ")')
-          echo OTEL_RESOURCE_ATTRIBUTES="${OTEL_RESOURCE_ATTRIBUTES},rapids.labels=${labels}"  >> ${GITHUB_ENV}
-
-      - name: Telemetry setup
-        id: job-traceparent
-        if: always()
-        uses: ./shared-actions/telemetry-traceparent
-
       - name: Build and repair the wheel
         run: |
           ${{ inputs.script }}
@@ -217,12 +165,11 @@ jobs:
       - name: Upload additional artifacts
         if: "!cancelled()"
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
-      - name: Telemetry summary
-        id: telemetry-summary
+
+      - name: Telemetry summarize
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@telemetry-dispatch-actions
+        continue-on-error: true
         if: always()
-        uses: ./shared-actions/telemetry-summarize
         with:
-          traceparent: "${{ inputs.traceparent }}"
-          ca_cert: "${{secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE}}"
-          client_cert: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}}"
-          client_key: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY}}"
+          cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
+          extra_attributes: "rapids.operation=build,rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}}"

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -28,27 +28,6 @@ on:
         required: false
         type: boolean
         default: false
-      # telemetry
-      default_endpoint:
-        type: string
-        description: "Destination to send telemetry to, not including path like /v1/traces"
-      traceparent:
-        type: string
-        description: |
-            Opentelemetry traceparent. Format is described in https://medium.com/@mesutatasoy/understanding-traceparent-and-microservices-in-opentelemetry-notepad-series-7-de5c16bf6462
-            Generally, 00-<trace_id 32 chars>-<span_id 16 chars>-01
-      otel_resource_attributes:
-        type: string
-        description: |
-          Comma-separated key=value pairs used for storing additional "tags" to better identify data
-      shared_actions_repo:
-        type: string
-        description: git repo for rapidsai/shared-actions code
-        default: rapidsai/shared-actions
-      shared_actions_ref:
-        type: string
-        description: git ref of branch/tag/sha for rapidsai/shared-actions repo
-        default: main
 
 permissions:
   actions: read
@@ -90,16 +69,8 @@ jobs:
         fetch-depth: 0 # unshallow fetch for setuptools-scm
         persist-credentials: false
 
-    - name: Checkout actions
-      uses: actions/checkout@v4
-      if: always()
-      with:
-        repository: ${{inputs.shared_actions_repo}}
-        ref: ${{inputs.shared_actions_ref}}
-        path: ./shared-actions
-
     - name: Standardize repository information
-      uses: ./shared-actions/rapids-github-info
+      uses: rapidsai/shared-actions/rapids-github-info@main
       with:
         repo: ${{ inputs.repo }}
         branch: ${{ inputs.branch }}
@@ -128,12 +99,9 @@ jobs:
       with:
         password: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
 
-    - name: Telemetry summary
-      id: telemetry-summary
+    - name: Telemetry summarize
+      uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@telemetry-dispatch-actions
+      continue-on-error: true
       if: always()
-      uses: ./shared-actions/telemetry-summarize
       with:
-        traceparent: "${{ inputs.traceparent }}"
-        ca_cert: "${{secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE}}"
-        client_cert: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}}"
-        client_key: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY}}"
+        cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -29,26 +29,6 @@ on:
         required: false
         type: string
         default: "fail"
-      default_endpoint:
-        type: string
-        description: "Destination to send telemetry to, not including path like /v1/traces"
-      traceparent:
-        type: string
-        description: |
-            Opentelemetry traceparent. Format is described in https://medium.com/@mesutatasoy/understanding-traceparent-and-microservices-in-opentelemetry-notepad-series-7-de5c16bf6462
-            Generally, 00-<trace_id 32 chars>-<span_id 16 chars>-01
-      otel_resource_attributes:
-        type: string
-        description: |
-          Comma-separated key=value pairs used for storing additional "tags" to better identify data
-      shared_actions_repo:
-        type: string
-        description: git repo for rapidsai/shared-actions code
-        default: rapidsai/shared-actions
-      shared_actions_ref:
-        type: string
-        description: git ref of branch/tag/sha for rapidsai/shared-actions repo
-        default: main
     # the use of secrets in shared-workflows is discouraged, especially for public repositories.
     # these values were added for situations where the use of secrets is unavoidable.
     secrets:
@@ -73,12 +53,6 @@ permissions:
   repository-projects: none
   security-events: none
   statuses: none
-
-env:
-  # TODO: this should be set as an org-wide variable
-  OTEL_EXPORTER_OTLP_ENDPOINT: "${{ inputs.default_endpoint }}"
-  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
-  OTEL_PYTHON_DISABLED_INSTRUMENTATIONS: "jinja2"
 
 jobs:
   compute-matrix:
@@ -137,7 +111,6 @@ jobs:
       RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
       RAPIDS_DEPENDENCIES: ${{ matrix.DEPENDENCIES }}
       RAPIDS_TESTS_DIR: ${{ github.workspace }}/test-results
-      OTEL_RESOURCE_ATTRIBUTES: "${{inputs.otel_resource_attributes}},rapids.operation=wheels-test,rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}},rapids.gpu=${{matrix.GPU}},rapids.driver=${{matrix.DRIVER}},rapids.deps=${{matrix.DEPENDENCIES}}"
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
@@ -165,14 +138,6 @@ jobs:
         fetch-depth: 0 # unshallow fetch for setuptools-scm
         persist-credentials: false
 
-    - name: Checkout actions
-      uses: actions/checkout@v4
-      if: always()
-      with:
-        repository: ${{inputs.shared_actions_repo}}
-        ref: ${{inputs.shared_actions_ref}}
-        path: ./shared-actions
-
     - name: Standardize repository information
       uses: ./shared-actions/rapids-github-info
       with:
@@ -197,20 +162,11 @@ jobs:
     - name: Upload additional artifacts
       if: "!cancelled()"
       run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
-    - name: Get GitHub job info, to obtain machine info
-      uses: ./shared-actions/github-actions-job-info
-      id: job-info
-    - name: Add machine details to attributes metadata
-      run: |
-        labels=$(echo "${{steps.job-info.outputs.job-info}}" | jq -r '.labels | join(" ")')
-        echo OTEL_RESOURCE_ATTRIBUTES="${OTEL_RESOURCE_ATTRIBUTES},rapids.labels=${labels}" >> ${GITHUB_ENV}
 
-    - name: Telemetry summary
-      id: telemetry-summary
+    - name: Telemetry summarize
+      uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@telemetry-dispatch-actions
+      continue-on-error: true
       if: always()
-      uses: ./shared-actions/telemetry-summarize
       with:
-        traceparent: "${{ inputs.traceparent }}"
-        ca_cert: "${{secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE}}"
-        client_cert: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}}"
-        client_key: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY}}"
+        cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
+        extra_attributes: "rapids.operation=wheels-test,rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}},rapids.gpu=${{matrix.GPU}},rapids.driver=${{matrix.DRIVER}},rapids.deps=${{matrix.DEPENDENCIES}}"


### PR DESCRIPTION
Uses https://github.com/rapidsai/shared-actions/pull/21 to reduce the parameter passing. Instead of passing parameters as inputs, they are stored in a file that gets uploaded, then downloaded by later jobs.