### PR TITLE
Revert "refactor shared actions to simplify telemetry"

### DIFF
--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -30,6 +30,26 @@ on:
         required: false
         type: string
         default: ''
+      default_endpoint:
+        type: string
+        description: "Destination to send telemetry to, not including path like /v1/traces"
+      traceparent:
+        type: string
+        description: |
+            Opentelemetry traceparent. Format is described in https://medium.com/@mesutatasoy/understanding-traceparent-and-microservices-in-opentelemetry-notepad-series-7-de5c16bf6462
+            Generally, 00-<trace_id 32 chars>-<span_id 16 chars>-01
+      otel_resource_attributes:
+        type: string
+        description: |
+          Comma-separated key=value pairs used for storing additional "tags" to better identify data
+      shared_actions_repo:
+        type: string
+        description: git repo for rapidsai/shared-actions code
+        default: rapidsai/shared-actions
+      shared_actions_ref:
+        type: string
+        description: git ref of branch/tag/sha for rapidsai/shared-actions repo
+        default: main
     # the use of secrets in shared-workflows is discouraged, especially for public repositories.
     # these values were added for situations where the use of secrets is unavoidable.
     secrets:
@@ -51,6 +71,12 @@ permissions:
   security-events: none
   statuses: none
 
+env:
+  # TODO: this should be set as an org-wide variable
+  OTEL_EXPORTER_OTLP_ENDPOINT: ${{inputs.default_endpoint}}
+  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
+  OTEL_RESOURCE_ATTRIBUTES: ${{inputs.otel_resource_attributes}}
+
 jobs:
   build:
     strategy:
@@ -67,9 +93,6 @@ jobs:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}
           fetch-depth: 0
-
-      - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
 
       - name: Check if repo has devcontainer
         run: |
@@ -127,10 +150,20 @@ jobs:
 
             cd ~/"${REPOSITORY}";
             ${{ inputs.build_command }}
-
-      - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
-        continue-on-error: true
+      - name: Clone shared-actions
+        uses: actions/checkout@v4
         if: always()
         with:
-          cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
+            repository: ${{inputs.shared_actions_repo}}
+            ref: ${{inputs.shared_actions_ref}}
+            path: ./shared-actions
+
+      - name: Telemetry summary
+        id: telemetry-summary
+        if: always()
+        uses: ./shared-actions/telemetry-summarize
+        with:
+          traceparent: "${{ inputs.traceparent }}"
+          ca_cert: "${{secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE}}"
+          client_cert: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}}"
+          client_key: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY}}"

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -17,6 +17,26 @@ on:
             }
           ) |
           from_entries
+      default_endpoint:
+        type: string
+        description: "Destination to send telemetry to, not including path like /v1/traces"
+      traceparent:
+        type: string
+        description: |
+            Opentelemetry traceparent. Format is described in https://medium.com/@mesutatasoy/understanding-traceparent-and-microservices-in-opentelemetry-notepad-series-7-de5c16bf6462
+            Generally, 00-<trace_id 32 chars>-<span_id 16 chars>-01
+      otel_resource_attributes:
+        type: string
+        description: |
+          Comma-separated key=value pairs used for storing additional "tags" to better identify data
+      shared_actions_repo:
+        type: string
+        description: git repo for rapidsai/shared-actions code
+        default: rapidsai/shared-actions
+      shared_actions_ref:
+        type: string
+        description: git ref of branch/tag/sha for rapidsai/shared-actions repo
+        default: main
     outputs:
       changed_file_groups:
         value: ${{ jobs.changed-files.outputs.transformed_output }}
@@ -40,6 +60,12 @@ permissions:
   security-events: none
   statuses: none
 
+env:
+  # TODO: this should be set as an org-wide variable
+  OTEL_EXPORTER_OTLP_ENDPOINT: ${{inputs.default_endpoint}}
+  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
+  OTEL_RESOURCE_ATTRIBUTES: ${{inputs.otel_resource_attributes}}
+
 jobs:
   changed-files:
     runs-on: ubuntu-latest
@@ -47,8 +73,7 @@ jobs:
     outputs:
       transformed_output: ${{ steps.transform-changed-files.outputs.transformed-output }}
     steps:
-      - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+
       - name: Get PR info
         id: get-pr-info
         uses: nv-gha-runners/get-pr-info@main
@@ -57,6 +82,13 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+      - name: Clone shared-actions
+        uses: actions/checkout@v4
+        if: always()
+        with:
+            repository: ${{inputs.shared_actions_repo}}
+            ref: ${{inputs.shared_actions_ref}}
+            path: ./shared-actions
       - name: Calculate merge base
         id: calculate-merge-base
         env:
@@ -85,9 +117,12 @@ jobs:
           done
           (echo -n "transformed-output="; jq -c -n "\$ARGS.named | to_entries | map({"key": .key, "value": .value[]}) | from_entries | $TRANSFORM_EXPR" "${file_args[@]}") | tee --append "$GITHUB_OUTPUT"
 
-      - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
-        continue-on-error: true
+      - name: Telemetry summary
+        id: telemetry-summary
         if: always()
+        uses: ./shared-actions/telemetry-summarize
         with:
-          cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
+          traceparent: "${{ inputs.traceparent }}"
+          ca_cert: "${{secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE}}"
+          client_cert: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}}"
+          client_key: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY}}"

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -31,10 +31,35 @@ on:
         default: ""
         type: string
         required: false
+      default_endpoint:
+        type: string
+        description: "Destination to send telemetry to, not including path like /v1/traces"
+      traceparent:
+        type: string
+        description: |
+            Opentelemetry traceparent. Format is described in https://medium.com/@mesutatasoy/understanding-traceparent-and-microservices-in-opentelemetry-notepad-series-7-de5c16bf6462
+            Generally, 00-<trace_id 32 chars>-<span_id 16 chars>-01
+      otel_resource_attributes:
+        type: string
+        description: |
+          Comma-separated key=value pairs used for storing additional "tags" to better identify data
+      shared_actions_repo:
+        type: string
+        description: git repo for rapidsai/shared-actions code
+        default: rapidsai/shared-actions
+      shared_actions_ref:
+        type: string
+        description: git ref of branch/tag/sha for rapidsai/shared-actions repo
+        default: main
 
 defaults:
   run:
     shell: bash
+
+env:
+  OTEL_EXPORTER_OTLP_ENDPOINT: "${{ inputs.default_endpoint }}"
+  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
+  OTEL_RESOURCE_ATTRIBUTES: ${{inputs.otel_resource_attributes}}
 
 jobs:
   other-checks:
@@ -44,10 +69,15 @@ jobs:
       env:
         RAPIDS_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: Checkout actions
+        uses: actions/checkout@v4
+        if: always()
+        with:
+            repository: ${{inputs.shared_actions_repo}}
+            ref: ${{inputs.shared_actions_ref}}
+            path: ./shared-actions
       - name: Get PR Info
         id: get-pr-info
         uses: nv-gha-runners/get-pr-info@main
@@ -62,12 +92,15 @@ jobs:
         env:
           IGNORED_JOBS: ${{ inputs.ignored_pr_jobs }}
 
-      - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
-        continue-on-error: true
+      - name: Telemetry summary
+        id: telemetry-summary
         if: always()
+        uses: ./shared-actions/telemetry-summarize
         with:
-          cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
+          traceparent: "${{ inputs.traceparent }}"
+          ca_cert: "${{secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE}}"
+          client_cert: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}}"
+          client_key: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY}}"
 
   check-style:
     if: ${{ inputs.enable_check_style }}
@@ -75,12 +108,17 @@ jobs:
     container:
       image: rapidsai/ci-conda:latest
     steps:
-      - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Checkout actions
+        uses: actions/checkout@v4
+        if: always()
+        with:
+            repository: ${{inputs.shared_actions_repo}}
+            ref: ${{inputs.shared_actions_ref}}
+            path: ./shared-actions
       - name: Get PR Info
         id: get-pr-info
         uses: nv-gha-runners/get-pr-info@main
@@ -93,9 +131,12 @@ jobs:
         env:
           RAPIDS_BASE_BRANCH: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}
 
-      - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
-        continue-on-error: true
+      - name: Telemetry summary
+        id: telemetry-summary
         if: always()
+        uses: ./shared-actions/telemetry-summarize
         with:
-          cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
+          traceparent: "${{ inputs.traceparent }}"
+          ca_cert: "${{secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE}}"
+          client_cert: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}}"
+          client_key: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY}}"

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -21,6 +21,25 @@ on:
       matrix_filter:
         type: string
         default: "."
+      default_endpoint:
+        type: string
+      traceparent:
+        type: string
+        description: |
+            Opentelemetry traceparent. Format is described in https://medium.com/@mesutatasoy/understanding-traceparent-and-microservices-in-opentelemetry-notepad-series-7-de5c16bf6462
+            Generally, 00-<trace_id 32 chars>-<span_id 16 chars>-01
+      otel_resource_attributes:
+        type: string
+        description: |
+          Comma-separated key=value pairs used for storing additional "tags" to better identify data
+      shared_actions_repo:
+        type: string
+        description: git repo for rapidsai/shared-actions code
+        default: rapidsai/shared-actions
+      shared_actions_ref:
+        type: string
+        description: git ref of branch/tag/sha for rapidsai/shared-actions repo
+        default: main
 
 defaults:
   run:
@@ -40,6 +59,12 @@ permissions:
   repository-projects: none
   security-events: none
   statuses: none
+
+env:
+  OTEL_EXPORTER_OTLP_ENDPOINT: "${{ inputs.default_endpoint }}"
+  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
+  OTEL_PYTHON_DISABLED_INSTRUMENTATIONS: "jinja2"
+
 
 jobs:
   compute-matrix:
@@ -81,13 +106,12 @@ jobs:
     runs-on: "linux-${{ matrix.ARCH }}-${{ inputs.node_type }}"
     env:
       RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
+      OTEL_RESOURCE_ATTRIBUTES: "${{inputs.otel_resource_attributes}},rapids.operation=test-cpp,rapids.package_type=conda,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}}"
     container:
       image: rapidsai/ci-conda:cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:
-      - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
@@ -98,12 +122,36 @@ jobs:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}
           fetch-depth: 0
+      - name: Checkout actions
+        uses: actions/checkout@v4
+        if: always()
+        with:
+            repository: ${{inputs.shared_actions_repo}}
+            ref: ${{inputs.shared_actions_ref}}
+            path: ./shared-actions
       - name: Standardize repository information
         run: |
           echo "RAPIDS_REPOSITORY=${{ inputs.repo || github.repository }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_SHA=$(git rev-parse HEAD)" >> "${GITHUB_ENV}"
           echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
+
+      # Sets TRACEPARENT to the value appropriate for this job (which includes the various matrix values)
+      - name: Telemetry setup
+        id: job-traceparent
+        if: always()
+        uses: ./shared-actions/telemetry-traceparent
+
+      - name: Get GitHub job info, to obtain machine info
+        uses: ./shared-actions/github-actions-job-info
+        if: always()
+        id: job-info
+
+      - name: Add machine details to attributes metadata
+        if: always()
+        run: |
+          labels=$(echo "${{steps.job-info.outputs.job-info}}" | jq -r '.labels | join(" ")')
+          echo OTEL_RESOURCE_ATTRIBUTES="${OTEL_RESOURCE_ATTRIBUTES},${labels}" >> ${GITHUB_ENV}
 
       - name: C++ build
         run: ${{ inputs.script }}
@@ -114,11 +162,13 @@ jobs:
       - name: Upload additional artifacts
         if: "!cancelled()"
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)
-
-      - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
-        continue-on-error: true
+      - name: Telemetry summary
+        id: telemetry-summary
         if: always()
+        continue-on-error: true
+        uses: ./shared-actions/telemetry-summarize
         with:
-          cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
-          extra_attributes: "rapids.operation=test-cpp,rapids.package_type=conda,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}}"
+          traceparent: "${{ inputs.traceparent }}"
+          ca_cert: "${{secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE}}"
+          client_cert: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}}"
+          client_key: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY}}"

--- a/.github/workflows/conda-cpp-post-build-checks.yaml
+++ b/.github/workflows/conda-cpp-post-build-checks.yaml
@@ -18,6 +18,25 @@ on:
         required: false
       symbol_exclusions:
         type: string
+      default_endpoint:
+        type: string
+      traceparent:
+        type: string
+        description: |
+            Opentelemetry traceparent. Format is described in https://medium.com/@mesutatasoy/understanding-traceparent-and-microservices-in-opentelemetry-notepad-series-7-de5c16bf6462
+            Generally, 00-<trace_id 32 chars>-<span_id 16 chars>-01
+      otel_resource_attributes:
+        type: string
+        description: |
+          Comma-separated key=value pairs used for storing additional "tags" to better identify data
+      shared_actions_repo:
+        type: string
+        description: git repo for rapidsai/shared-actions code
+        default: rapidsai/shared-actions
+      shared_actions_ref:
+        type: string
+        description: git ref of branch/tag/sha for rapidsai/shared-actions repo
+        default: main
 
 defaults:
   run:
@@ -38,6 +57,11 @@ permissions:
   security-events: none
   statuses: none
 
+env:
+  OTEL_EXPORTER_OTLP_ENDPOINT: "${{ inputs.default_endpoint }}"
+  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
+  OTEL_PYTHON_DISABLED_INSTRUMENTATIONS: "jinja2"
+
 jobs:
   check-symbols:
     if: ${{ inputs.enable_check_symbols }}
@@ -47,9 +71,6 @@ jobs:
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:
-      - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
-
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
@@ -88,10 +109,19 @@ jobs:
           else
             python ./tool/detect.py ${RAPIDS_EXTRACTED_DIR}/lib
           fi
-
-      - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
-        continue-on-error: true
+      - name: Clone shared-actions
         if: always()
+        uses: actions/checkout@v4
         with:
-          cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
+            repository: ${{inputs.shared_actions_repo}}
+            ref: ${{inputs.shared_actions_ref}}
+            path: ./shared-actions
+      - name: Telemetry summary
+        id: telemetry-summary
+        if: always()
+        uses: ./shared-actions/telemetry-summarize
+        with:
+            traceparent: "${{ inputs.traceparent }}"
+            ca_cert: "${{secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE}}"
+            client_cert: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}}"
+            client_key: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY}}"

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -22,6 +22,26 @@ on:
         required: false
         type: string
         default: "-e _NOOP"
+      default_endpoint:
+        type: string
+        description: "Destination to send telemetry to, not including path like /v1/traces"
+      traceparent:
+        type: string
+        description: |
+            Opentelemetry traceparent. Format is described in https://medium.com/@mesutatasoy/understanding-traceparent-and-microservices-in-opentelemetry-notepad-series-7-de5c16bf6462
+            Generally, 00-<trace_id 32 chars>-<span_id 16 chars>-01w
+      otel_resource_attributes:
+        type: string
+        description: |
+          Comma-separated key=value pairs used for storing additional "tags" to better identify data
+      shared_actions_repo:
+        type: string
+        description: git repo for rapidsai/shared-actions code
+        default: rapidsai/shared-actions
+      shared_actions_ref:
+        type: string
+        description: git ref of branch/tag/sha for rapidsai/shared-actions repo
+        default: main
 
 defaults:
   run:
@@ -41,6 +61,11 @@ permissions:
   repository-projects: none
   security-events: none
   statuses: none
+
+env:
+  OTEL_EXPORTER_OTLP_ENDPOINT: "${{ inputs.default_endpoint }}"
+  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
+  OTEL_PYTHON_DISABLED_INSTRUMENTATIONS: "jinja2"
 
 jobs:
   compute-matrix:
@@ -102,6 +127,7 @@ jobs:
     runs-on: "linux-${{ matrix.ARCH }}-gpu-${{ matrix.GPU }}-${{ matrix.DRIVER }}-1"
     env:
       RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
+      OTEL_RESOURCE_ATTRIBUTES: "${{inputs.otel_resource_attributes}},rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}},rapids.gpu=${{matrix.GPU}},rapids.driver=${{matrix.DRIVER}},rapids.deps=${{matrix.DEPENDENCIES}}"
       RAPIDS_DEPENDENCIES: ${{ matrix.DEPENDENCIES }}
       RAPIDS_TESTS_DIR: ${{ github.workspace }}/test-results
     container:
@@ -111,8 +137,6 @@ jobs:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
     steps:
-      - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
@@ -124,13 +148,30 @@ jobs:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}
           fetch-depth: 0
-
+      - name: Checkout actions
+        uses: actions/checkout@v4
+        if: always()
+        with:
+            repository: ${{inputs.shared_actions_repo}}
+            ref: ${{inputs.shared_actions_ref}}
+            path: ./shared-actions
       - name: Standardize repository information
         run: |
           echo "RAPIDS_REPOSITORY=${{ inputs.repo || github.repository }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_SHA=$(git rev-parse HEAD)" >> "${GITHUB_ENV}"
           echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
+
+      - name: Get GitHub job info, to obtain machine info
+        if: always()
+        uses: ./shared-actions/github-actions-job-info
+        id: job-info
+
+      - name: Add machine details to attributes metadata
+        if: always()
+        run: |
+          labels=$(echo "${{steps.job-info.outputs.job-info}}" | jq -r '.labels | join(" ")')
+          echo OTEL_RESOURCE_ATTRIBUTES="${OTEL_RESOURCE_ATTRIBUTES},rapids.labels=${labels}" >> ${GITHUB_ENV}
 
       - name: C++ tests
         run: ${{ inputs.script }}
@@ -145,10 +186,12 @@ jobs:
         if: "!cancelled()"
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)
 
-      - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
-        continue-on-error: true
+      - name: Telemetry summary
+        id: telemetry-summary
         if: always()
+        uses: ./shared-actions/telemetry-summarize
         with:
-          cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
-          extra_attributes: "rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}},rapids.gpu=${{matrix.GPU}},rapids.driver=${{matrix.DRIVER}},rapids.deps=${{matrix.DEPENDENCIES}}"
+          traceparent: "${{ inputs.traceparent }}"
+          ca_cert: "${{secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE}}"
+          client_cert: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}}"
+          client_key: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY}}"

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -21,6 +21,26 @@ on:
       matrix_filter:
         type: string
         default: "."
+      default_endpoint:
+        type: string
+        description: "Destination to send telemetry to, not including path like /v1/traces"
+      traceparent:
+        type: string
+        description: |
+            Opentelemetry traceparent. Format is described in https://medium.com/@mesutatasoy/understanding-traceparent-and-microservices-in-opentelemetry-notepad-series-7-de5c16bf6462
+            Generally, 00-<trace_id 32 chars>-<span_id 16 chars>-01
+      otel_resource_attributes:
+        type: string
+        description: |
+          Comma-separated key=value pairs used for storing additional "tags" to better identify data
+      shared_actions_repo:
+        type: string
+        description: git repo for rapidsai/shared-actions code
+        default: rapidsai/shared-actions
+      shared_actions_ref:
+        type: string
+        description: git ref of branch/tag/sha for rapidsai/shared-actions repo
+        default: main
 
 defaults:
   run:
@@ -40,6 +60,12 @@ permissions:
   repository-projects: none
   security-events: none
   statuses: none
+
+env:
+  OTEL_EXPORTER_OTLP_ENDPOINT: "${{ inputs.default_endpoint }}"
+  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
+  OTEL_PYTHON_DISABLED_INSTRUMENTATIONS: "jinja2"
+  OTEL_RESOURCE_ATTRIBUTES: ${{inputs.otel_resource_attributes}}
 
 jobs:
   compute-matrix:
@@ -88,13 +114,12 @@ jobs:
     runs-on: "linux-${{ matrix.ARCH }}-${{ inputs.node_type }}"
     env:
       RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
+      OTEL_RESOURCE_ATTRIBUTES: "${{inputs.otel_resource_attributes}},rapids.operation=build-python,rapids.package_type=conda,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}}"
     container:
       image: rapidsai/ci-conda:cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:
-      - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
@@ -105,12 +130,34 @@ jobs:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}
           fetch-depth: 0
+      - name: Checkout actions
+        uses: actions/checkout@v4
+        if: always()
+        with:
+            repository: ${{inputs.shared_actions_repo}}
+            ref: ${{inputs.shared_actions_ref}}
+            path: ./shared-actions
       - name: Standardize repository information
         run: |
           echo "RAPIDS_REPOSITORY=${{ inputs.repo || github.repository }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_SHA=$(git rev-parse HEAD)" >> "${GITHUB_ENV}"
           echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
+
+      - name: Get GitHub job info, to obtain machine info
+        uses: ./shared-actions/github-actions-job-info
+        id: job-info
+        if: always()
+      - name: Add machine details to attributes metadata
+        if: always()
+        run: |
+          labels=$(echo "${{steps.job-info.outputs.job-info}}" | jq -r '.labels | join(" ")')
+          echo OTEL_RESOURCE_ATTRIBUTES="${OTEL_RESOURCE_ATTRIBUTES},rapids.labels=${labels}" >> ${GITHUB_ENV}
+
+      - name: Telemetry setup
+        id: job-traceparent
+        if: always()
+        uses: ./shared-actions/telemetry-traceparent
 
       - name: Python build
         run: ${{ inputs.script }}
@@ -119,11 +166,12 @@ jobs:
       - name: Upload additional artifacts
         if: "!cancelled()"
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
-
-      - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
-        continue-on-error: true
+      - name: Telemetry summary
+        id: telemetry-summary
         if: always()
+        uses: ./shared-actions/telemetry-summarize
         with:
-          cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
-          extra_attributes: "rapids.operation=build-python,rapids.package_type=conda,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}}"
+          traceparent: "${{ inputs.traceparent }}"
+          ca_cert: "${{secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE}}"
+          client_cert: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}}"
+          client_key: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY}}"

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -25,6 +25,26 @@ on:
         required: false
         type: string
         default: "-e _NOOP"
+      default_endpoint:
+        type: string
+        description: "Destination to send telemetry to, not including path like /v1/traces"
+      traceparent:
+        type: string
+        description: |
+            Opentelemetry traceparent. Format is described in https://medium.com/@mesutatasoy/understanding-traceparent-and-microservices-in-opentelemetry-notepad-series-7-de5c16bf6462
+            Generally, 00-<trace_id 32 chars>-<span_id 16 chars>-01
+      otel_resource_attributes:
+        type: string
+        description: |
+          Comma-separated key=value pairs used for storing additional "tags" to better identify data
+      shared_actions_repo:
+        type: string
+        description: git repo for rapidsai/shared-actions code
+        default: rapidsai/shared-actions
+      shared_actions_ref:
+        type: string
+        description: git ref of branch/tag/sha for rapidsai/shared-actions repo
+        default: main
 
 defaults:
   run:
@@ -44,6 +64,12 @@ permissions:
   repository-projects: none
   security-events: none
   statuses: none
+
+env:
+  OTEL_EXPORTER_OTLP_ENDPOINT: "${{ inputs.default_endpoint }}"
+  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
+  OTEL_PYTHON_DISABLED_INSTRUMENTATIONS: "jinja2"
+  OTEL_RESOURCE_ATTRIBUTES: ${{inputs.otel_resource_attributes}}
 
 jobs:
   compute-matrix:
@@ -108,6 +134,8 @@ jobs:
       RAPIDS_COVERAGE_DIR: ${{ github.workspace }}/coverage-results
       RAPIDS_DEPENDENCIES: ${{ matrix.DEPENDENCIES }}
       RAPIDS_TESTS_DIR: ${{ github.workspace }}/test-results
+      # TODO: need to determine what the "operation" is here
+      OTEL_RESOURCE_ATTRIBUTES: "${{inputs.otel_resource_attributes}},rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}},rapids.gpu=${{matrix.GPU}},rapids.driver=${{matrix.DRIVER}},rapids.deps=${{matrix.DEPENDENCIES}}"
     container:
       image: rapidsai/ci-conda:cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
       options: ${{ inputs.container-options }}
@@ -115,8 +143,6 @@ jobs:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
     steps:
-      - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
@@ -128,13 +154,33 @@ jobs:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}
           fetch-depth: 0
-
+      - name: Checkout actions
+        if: always()
+        uses: actions/checkout@v4
+        with:
+            repository: ${{inputs.shared_actions_repo}}
+            ref: ${{inputs.shared_actions_ref}}
+            path: ./shared-actions
       - name: Standardize repository information
         run: |
           echo "RAPIDS_REPOSITORY=${{ inputs.repo || github.repository }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_SHA=$(git rev-parse HEAD)" >> "${GITHUB_ENV}"
           echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
+
+      - name: Get GitHub job info, to obtain machine info
+        if: always()
+        uses: ./shared-actions/github-actions-job-info
+        id: job-info
+      - name: Add machine details to attributes metadata
+        if: always()
+        run: |
+          labels=$(echo "${{steps.job-info.outputs.job-info}}" | jq -r '.labels | join(" ")')
+          echo OTEL_RESOURCE_ATTRIBUTES="${OTEL_RESOURCE_ATTRIBUTES},rapids.labels=${labels}"  >> ${GITHUB_ENV}
+      - name: Telemetry setup
+        id: job-traceparent
+        if: always()
+        uses: ./shared-actions/telemetry-traceparent
 
       - name: Python tests
         run: ${{ inputs.script }}
@@ -159,11 +205,12 @@ jobs:
       - name: Upload additional artifacts
         if: "!cancelled()"
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
-
-      - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
-        continue-on-error: true
+      - name: Telemetry summary
+        id: telemetry-summary
         if: always()
+        uses: ./shared-actions/telemetry-summarize
         with:
-          cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
-          extra_attributes:  "rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}},rapids.gpu=${{matrix.GPU}},rapids.driver=${{matrix.DRIVER}},rapids.deps=${{matrix.DEPENDENCIES}}"
+          traceparent: "${{ inputs.traceparent }}"
+          ca_cert: "${{secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE}}"
+          client_cert: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}}"
+          client_key: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY}}"

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -18,6 +18,26 @@ on:
         description: The label that should be applied to packages uploaded to Anaconda.org
         type: string
         default: main
+      default_endpoint:
+        type: string
+        description: "Destination to send telemetry to, not including path like /v1/traces"
+      traceparent:
+        type: string
+        description: |
+            Opentelemetry traceparent. Format is described in https://medium.com/@mesutatasoy/understanding-traceparent-and-microservices-in-opentelemetry-notepad-series-7-de5c16bf6462
+            Generally, 00-<trace_id 32 chars>-<span_id 16 chars>-01
+      otel_resource_attributes:
+        type: string
+        description: |
+          Comma-separated key=value pairs used for storing additional "tags" to better identify data
+      shared_actions_repo:
+        type: string
+        description: git repo for rapidsai/shared-actions code
+        default: rapidsai/shared-actions
+      shared_actions_ref:
+        type: string
+        description: git ref of branch/tag/sha for rapidsai/shared-actions repo
+        default: main
 
 defaults:
   run:
@@ -38,6 +58,12 @@ permissions:
   security-events: none
   statuses: none
 
+env:
+  OTEL_EXPORTER_OTLP_ENDPOINT: "${{ inputs.default_endpoint }}"
+  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
+  OTEL_PYTHON_DISABLED_INSTRUMENTATIONS: "jinja2"
+  OTEL_RESOURCE_ATTRIBUTES: ${{inputs.otel_resource_attributes}}
+
 jobs:
   upload:
     runs-on: linux-amd64-cpu4
@@ -46,8 +72,6 @@ jobs:
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:
-      - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
@@ -58,13 +82,24 @@ jobs:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}
           fetch-depth: 0
-
+      - name: Checkout actions
+        uses: actions/checkout@v4
+        if: always()
+        with:
+            repository: ${{inputs.shared_actions_repo}}
+            ref: ${{inputs.shared_actions_ref}}
+            path: ./shared-actions
       - name: Standardize repository information
         run: |
           echo "RAPIDS_REPOSITORY=${{ inputs.repo || github.repository }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_SHA=$(git rev-parse HEAD)" >> "${GITHUB_ENV}"
           echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
+
+      - name: Telemetry setup
+        id: job-traceparent
+        if: always()
+        uses: ./shared-actions/telemetry-traceparent
 
       - name: Set Proper Conda Upload Token
         run: |
@@ -78,10 +113,12 @@ jobs:
         env:
           SKIP_UPLOAD_PKGS: ${{ inputs.skip_upload_pkgs }}
           RAPIDS_CONDA_UPLOAD_LABEL: ${{ inputs.upload_to_label }}
-
-      - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
-        continue-on-error: true
+      - name: Telemetry summary
+        id: telemetry-summary
         if: always()
+        uses: ./shared-actions/telemetry-summarize
         with:
-          cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
+          traceparent: "${{ inputs.traceparent }}"
+          ca_cert: "${{secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE}}"
+          client_cert: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}}"
+          client_key: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY}}"

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -24,6 +24,29 @@ on:
       run_script:
         required: true
         type: string
+      default_endpoint:
+        type: string
+        description: "Destination to send telemetry to, not including path like /v1/traces"
+      traceparent:
+        type: string
+        description: |
+            Opentelemetry traceparent. Format is described in https://medium.com/@mesutatasoy/understanding-traceparent-and-microservices-in-opentelemetry-notepad-series-7-de5c16bf6462
+            Generally, 00-<trace_id 32 chars>-<span_id 16 chars>-01
+      otel_resource_attributes:
+        type: string
+        description: |
+          Comma-separated key=value pairs used for storing additional "tags" to better identify data
+      shared_actions_repo:
+        type: string
+        description: git repo for rapidsai/shared-actions code
+        default: rapidsai/shared-actions
+      shared_actions_ref:
+        type: string
+        description: git ref of branch/tag/sha for rapidsai/shared-actions repo
+        default: main
+      file_to_upload:
+        type: string
+        default: "gh-status.json"
 
 defaults:
   run:
@@ -44,6 +67,13 @@ permissions:
   security-events: none
   statuses: none
 
+env:
+  # TODO: this should be set as an org-wide variable
+  OTEL_EXPORTER_OTLP_ENDPOINT: "${{ inputs.default_endpoint }}"
+  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
+  OTEL_PYTHON_DISABLED_INSTRUMENTATIONS: "jinja2"
+  OTEL_RESOURCE_ATTRIBUTES: ${{inputs.otel_resource_attributes}}
+
 jobs:
   build:
     strategy:
@@ -55,8 +85,6 @@ jobs:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
     steps:
-      - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
@@ -67,6 +95,13 @@ jobs:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}
           fetch-depth: 0
+      - name: Checkout actions
+        uses: actions/checkout@v4
+        if: always()
+        with:
+            repository: ${{inputs.shared_actions_repo}}
+            ref: ${{inputs.shared_actions_ref}}
+            path: ./shared-actions
       - name: Get PR Info
         if: startsWith(github.ref_name, 'pull-request/')
         id: get-pr-info
@@ -93,9 +128,12 @@ jobs:
           path: ${{ inputs.file_to_upload }}
           if-no-files-found: ignore
 
-      - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
-        continue-on-error: true
+      - name: Telemetry summary
+        id: telemetry-summary
         if: always()
+        uses: ./shared-actions/telemetry-summarize
         with:
-          cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
+          traceparent: "${{ inputs.traceparent }}"
+          ca_cert: "${{secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE}}"
+          client_cert: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}}"
+          client_key: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY}}"

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -44,6 +44,26 @@ on:
         required: false
         type: string
         default: ''
+      default_endpoint:
+        type: string
+        description: "Destination to send telemetry to, not including path like /v1/traces"
+      traceparent:
+        type: string
+        description: |
+            Opentelemetry traceparent. Format is described in https://medium.com/@mesutatasoy/understanding-traceparent-and-microservices-in-opentelemetry-notepad-series-7-de5c16bf6462
+            Generally, 00-<trace_id 32 chars>-<span_id 16 chars>-01
+      otel_resource_attributes:
+        type: string
+        description: |
+          Comma-separated key=value pairs used for storing additional "tags" to better identify data
+      shared_actions_repo:
+        type: string
+        description: git repo for rapidsai/shared-actions code
+        default: rapidsai/shared-actions
+      shared_actions_ref:
+        type: string
+        description: git ref of branch/tag/sha for rapidsai/shared-actions repo
+        default: main
 
 defaults:
   run:
@@ -63,6 +83,13 @@ permissions:
   repository-projects: none
   security-events: none
   statuses: none
+
+env:
+  # TODO: this should be set as an org-wide variable
+  OTEL_EXPORTER_OTLP_ENDPOINT: "${{ inputs.default_endpoint }}"
+  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
+  OTEL_PYTHON_DISABLED_INSTRUMENTATIONS: "jinja2"
+  # OTEL_RESOURCE_ATTRIBUTES is set inside the matrix
 
 jobs:
   compute-matrix:
@@ -110,14 +137,14 @@ jobs:
     runs-on: "linux-${{ matrix.ARCH }}-${{ inputs.node_type }}"
     env:
       RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
+      # TODO: set operation name somehow # rapids.operation=${{inputs.OTEL_SERVICE_NAME_PREFIX}}
+      OTEL_RESOURCE_ATTRIBUTES: "${{inputs.otel_resource_attributes}},rapids.operation=build,rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}}"
     container:
       image: "rapidsai/ci-wheel:cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
 
     steps:
-      - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
@@ -132,8 +159,16 @@ jobs:
           fetch-depth: 0 # unshallow fetch for setuptools-scm
           persist-credentials: false
 
+      - name: Checkout actions
+        uses: actions/checkout@v4
+        if: always()
+        with:
+            repository: ${{inputs.shared_actions_repo}}
+            ref: ${{inputs.shared_actions_ref}}
+            path: ./shared-actions
+
       - name: Standardize repository information
-        uses: rapidsai/shared-actions/rapids-github-info@main
+        uses: ./shared-actions/rapids-github-info
         with:
           repo: ${{ inputs.repo }}
           branch: ${{ inputs.branch }}
@@ -157,6 +192,21 @@ jobs:
           ssh-key: ${{ secrets[inputs.extra-repo-deploy-key] }}
           persist-credentials: false
 
+      - name: Get GitHub job info, to obtain machine info
+        uses: ./shared-actions/github-actions-job-info
+        if: always()
+        id: job-info
+      - name: Add machine details to attributes metadata
+        if: always()
+        run: |
+          labels=$(echo "${{steps.job-info.outputs.job-info}}" | jq -r '.labels | join(" ")')
+          echo OTEL_RESOURCE_ATTRIBUTES="${OTEL_RESOURCE_ATTRIBUTES},rapids.labels=${labels}"  >> ${GITHUB_ENV}
+
+      - name: Telemetry setup
+        id: job-traceparent
+        if: always()
+        uses: ./shared-actions/telemetry-traceparent
+
       - name: Build and repair the wheel
         run: |
           ${{ inputs.script }}
@@ -167,11 +217,12 @@ jobs:
       - name: Upload additional artifacts
         if: "!cancelled()"
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
-
-      - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
-        continue-on-error: true
+      - name: Telemetry summary
+        id: telemetry-summary
         if: always()
+        uses: ./shared-actions/telemetry-summarize
         with:
-          cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
-          extra_attributes: "rapids.operation=build,rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}}"
+          traceparent: "${{ inputs.traceparent }}"
+          ca_cert: "${{secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE}}"
+          client_cert: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}}"
+          client_key: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY}}"

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -28,6 +28,27 @@ on:
         required: false
         type: boolean
         default: false
+      # telemetry
+      default_endpoint:
+        type: string
+        description: "Destination to send telemetry to, not including path like /v1/traces"
+      traceparent:
+        type: string
+        description: |
+            Opentelemetry traceparent. Format is described in https://medium.com/@mesutatasoy/understanding-traceparent-and-microservices-in-opentelemetry-notepad-series-7-de5c16bf6462
+            Generally, 00-<trace_id 32 chars>-<span_id 16 chars>-01
+      otel_resource_attributes:
+        type: string
+        description: |
+          Comma-separated key=value pairs used for storing additional "tags" to better identify data
+      shared_actions_repo:
+        type: string
+        description: git repo for rapidsai/shared-actions code
+        default: rapidsai/shared-actions
+      shared_actions_ref:
+        type: string
+        description: git ref of branch/tag/sha for rapidsai/shared-actions repo
+        default: main
 
 permissions:
   actions: read
@@ -55,8 +76,6 @@ jobs:
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:
-    - name: Telemetry setup
-      uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
     - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ vars.AWS_ROLE_ARN }}
@@ -71,8 +90,16 @@ jobs:
         fetch-depth: 0 # unshallow fetch for setuptools-scm
         persist-credentials: false
 
+    - name: Checkout actions
+      uses: actions/checkout@v4
+      if: always()
+      with:
+        repository: ${{inputs.shared_actions_repo}}
+        ref: ${{inputs.shared_actions_ref}}
+        path: ./shared-actions
+
     - name: Standardize repository information
-      uses: rapidsai/shared-actions/rapids-github-info@main
+      uses: ./shared-actions/rapids-github-info
       with:
         repo: ${{ inputs.repo }}
         branch: ${{ inputs.branch }}
@@ -101,9 +128,12 @@ jobs:
       with:
         password: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
 
-    - name: Telemetry summarize
-      uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
-      continue-on-error: true
+    - name: Telemetry summary
+      id: telemetry-summary
       if: always()
+      uses: ./shared-actions/telemetry-summarize
       with:
-        cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
+        traceparent: "${{ inputs.traceparent }}"
+        ca_cert: "${{secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE}}"
+        client_cert: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}}"
+        client_key: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY}}"

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -29,6 +29,26 @@ on:
         required: false
         type: string
         default: "fail"
+      default_endpoint:
+        type: string
+        description: "Destination to send telemetry to, not including path like /v1/traces"
+      traceparent:
+        type: string
+        description: |
+            Opentelemetry traceparent. Format is described in https://medium.com/@mesutatasoy/understanding-traceparent-and-microservices-in-opentelemetry-notepad-series-7-de5c16bf6462
+            Generally, 00-<trace_id 32 chars>-<span_id 16 chars>-01
+      otel_resource_attributes:
+        type: string
+        description: |
+          Comma-separated key=value pairs used for storing additional "tags" to better identify data
+      shared_actions_repo:
+        type: string
+        description: git repo for rapidsai/shared-actions code
+        default: rapidsai/shared-actions
+      shared_actions_ref:
+        type: string
+        description: git ref of branch/tag/sha for rapidsai/shared-actions repo
+        default: main
     # the use of secrets in shared-workflows is discouraged, especially for public repositories.
     # these values were added for situations where the use of secrets is unavoidable.
     secrets:
@@ -53,6 +73,12 @@ permissions:
   repository-projects: none
   security-events: none
   statuses: none
+
+env:
+  # TODO: this should be set as an org-wide variable
+  OTEL_EXPORTER_OTLP_ENDPOINT: "${{ inputs.default_endpoint }}"
+  OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf"
+  OTEL_PYTHON_DISABLED_INSTRUMENTATIONS: "jinja2"
 
 jobs:
   compute-matrix:
@@ -111,6 +137,7 @@ jobs:
       RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
       RAPIDS_DEPENDENCIES: ${{ matrix.DEPENDENCIES }}
       RAPIDS_TESTS_DIR: ${{ github.workspace }}/test-results
+      OTEL_RESOURCE_ATTRIBUTES: "${{inputs.otel_resource_attributes}},rapids.operation=wheels-test,rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}},rapids.gpu=${{matrix.GPU}},rapids.driver=${{matrix.DRIVER}},rapids.deps=${{matrix.DEPENDENCIES}}"
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
@@ -122,8 +149,6 @@ jobs:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }} # GPU jobs must set this container env variable
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:
-    - name: Telemetry setup
-      uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
     - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ vars.AWS_ROLE_ARN }}
@@ -140,8 +165,16 @@ jobs:
         fetch-depth: 0 # unshallow fetch for setuptools-scm
         persist-credentials: false
 
+    - name: Checkout actions
+      uses: actions/checkout@v4
+      if: always()
+      with:
+        repository: ${{inputs.shared_actions_repo}}
+        ref: ${{inputs.shared_actions_ref}}
+        path: ./shared-actions
+
     - name: Standardize repository information
-      uses: rapidsai/shared-actions/rapids-github-info@main
+      uses: ./shared-actions/rapids-github-info
       with:
         repo: ${{ inputs.repo }}
         branch: ${{ inputs.branch }}
@@ -164,11 +197,20 @@ jobs:
     - name: Upload additional artifacts
       if: "!cancelled()"
       run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
+    - name: Get GitHub job info, to obtain machine info
+      uses: ./shared-actions/github-actions-job-info
+      id: job-info
+    - name: Add machine details to attributes metadata
+      run: |
+        labels=$(echo "${{steps.job-info.outputs.job-info}}" | jq -r '.labels | join(" ")')
+        echo OTEL_RESOURCE_ATTRIBUTES="${OTEL_RESOURCE_ATTRIBUTES},rapids.labels=${labels}" >> ${GITHUB_ENV}
 
-    - name: Telemetry summarize
-      uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
-      continue-on-error: true
+    - name: Telemetry summary
+      id: telemetry-summary
       if: always()
+      uses: ./shared-actions/telemetry-summarize
       with:
-        cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
-        extra_attributes: "rapids.operation=wheels-test,rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}},rapids.gpu=${{matrix.GPU}},rapids.driver=${{matrix.DRIVER}},rapids.deps=${{matrix.DEPENDENCIES}}"
+        traceparent: "${{ inputs.traceparent }}"
+        ca_cert: "${{secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE}}"
+        client_cert: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE}}"
+        client_key: "${{secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY}}"


### PR DESCRIPTION
Reverts rapidsai/shared-workflows#262

This does not handle repos that are not yet set up with the telemetry setup. Reverting until that can be fixed.