### PR TITLE
add continue-on-error for telemetry-setup steps

### DIFF
--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -70,6 +70,7 @@ jobs:
 
       - name: Telemetry setup
         uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+        continue-on-error: true
 
       - name: Check if repo has devcontainer
         run: |

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -49,6 +49,7 @@ jobs:
     steps:
       - name: Telemetry setup
         uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+        continue-on-error: true
       - name: Get PR info
         id: get-pr-info
         uses: nv-gha-runners/get-pr-info@main

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -46,6 +46,7 @@ jobs:
     steps:
       - name: Telemetry setup
         uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+        continue-on-error: true
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Get PR Info
@@ -77,6 +78,7 @@ jobs:
     steps:
       - name: Telemetry setup
         uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+        continue-on-error: true
       - name: Checkout code
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -88,6 +88,7 @@ jobs:
     steps:
       - name: Telemetry setup
         uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+        continue-on-error: true
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}

--- a/.github/workflows/conda-cpp-post-build-checks.yaml
+++ b/.github/workflows/conda-cpp-post-build-checks.yaml
@@ -49,6 +49,7 @@ jobs:
     steps:
       - name: Telemetry setup
         uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+        continue-on-error: true
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -113,6 +113,7 @@ jobs:
     steps:
       - name: Telemetry setup
         uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+        continue-on-error: true
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -95,6 +95,7 @@ jobs:
     steps:
       - name: Telemetry setup
         uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+        continue-on-error: true
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -117,6 +117,7 @@ jobs:
     steps:
       - name: Telemetry setup
         uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+        continue-on-error: true
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -48,6 +48,7 @@ jobs:
     steps:
       - name: Telemetry setup
         uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+        continue-on-error: true
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -57,6 +57,7 @@ jobs:
     steps:
       - name: Telemetry setup
         uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+        continue-on-error: true
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -118,6 +118,7 @@ jobs:
     steps:
       - name: Telemetry setup
         uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+        continue-on-error: true
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -57,6 +57,7 @@ jobs:
     steps:
     - name: Telemetry setup
       uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+      continue-on-error: true
     - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ vars.AWS_ROLE_ARN }}

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -124,6 +124,7 @@ jobs:
     steps:
     - name: Telemetry setup
       uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+      continue-on-error: true
     - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ vars.AWS_ROLE_ARN }}


### PR DESCRIPTION
Alternative to #263 - this is a placeholder to allow telemetry to fail gracefully while it is not rolled out to a given repo.