### PR TITLE
restore file_to_upload input that was accidentally removed

### DIFF
--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -24,6 +24,9 @@ on:
       run_script:
         required: true
         type: string
+      file_to_upload:
+        type: string
+        default: "gh-status.json"
 
 defaults:
   run:


### PR DESCRIPTION
This was unintentionally removed in #262. It causes errors that look like: https://github.com/rapidsai/rmm/actions/runs/11826113829/job/32952337051#step:11:29