### PR TITLE
gate telemetry summarize behind TELEMETRY_ENABLED env

### DIFF
--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -133,6 +133,6 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: "${{ vars.TELEMETRY_ENABLED == 'true' }} && !cancelled()"
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -69,7 +69,7 @@ jobs:
           fetch-depth: 0
 
       - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
         continue-on-error: true
 
       - name: Check if repo has devcontainer
@@ -130,7 +130,7 @@ jobs:
             ${{ inputs.build_command }}
 
       - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
         if: always()
         with:

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -69,7 +69,7 @@ jobs:
           fetch-depth: 0
 
       - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
+        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
         if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
         continue-on-error: true
 
@@ -131,7 +131,7 @@ jobs:
             ${{ inputs.build_command }}
 
       - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
         continue-on-error: true
         if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
         with:

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -133,6 +133,6 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: always() && ${{ vars.TELEMETRY_ENABLED == 'true' }}
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' }} && always()
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -70,6 +70,7 @@ jobs:
 
       - name: Telemetry setup
         uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
         continue-on-error: true
 
       - name: Check if repo has devcontainer
@@ -132,6 +133,6 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: always()
+        if: always() && ${{ vars.TELEMETRY_ENABLED == 'true' }}
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -133,6 +133,6 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: ${{ vars.TELEMETRY_ENABLED == 'true' }} && always()
+        if: "${{ vars.TELEMETRY_ENABLED == 'true' }} && !cancelled()"
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -50,6 +50,7 @@ jobs:
       - name: Telemetry setup
         uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
         continue-on-error: true
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
       - name: Get PR info
         id: get-pr-info
         uses: nv-gha-runners/get-pr-info@main
@@ -89,6 +90,6 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: always()
+        if: always() && ${{ vars.TELEMETRY_ENABLED == 'true' }}
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -90,6 +90,6 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: "${{ vars.TELEMETRY_ENABLED == 'true' }} && !cancelled()"
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -90,6 +90,6 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: always() && ${{ vars.TELEMETRY_ENABLED == 'true' }}
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' }} && always()
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -48,7 +48,7 @@ jobs:
       transformed_output: ${{ steps.transform-changed-files.outputs.transformed-output }}
     steps:
       - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
+        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
         continue-on-error: true
         if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
       - name: Get PR info
@@ -88,7 +88,7 @@ jobs:
           (echo -n "transformed-output="; jq -c -n "\$ARGS.named | to_entries | map({"key": .key, "value": .value[]}) | from_entries | $TRANSFORM_EXPR" "${file_args[@]}") | tee --append "$GITHUB_OUTPUT"
 
       - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
         continue-on-error: true
         if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
         with:

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -48,7 +48,7 @@ jobs:
       transformed_output: ${{ steps.transform-changed-files.outputs.transformed-output }}
     steps:
       - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
         continue-on-error: true
       - name: Get PR info
         id: get-pr-info
@@ -87,7 +87,7 @@ jobs:
           (echo -n "transformed-output="; jq -c -n "\$ARGS.named | to_entries | map({"key": .key, "value": .value[]}) | from_entries | $TRANSFORM_EXPR" "${file_args[@]}") | tee --append "$GITHUB_OUTPUT"
 
       - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
         if: always()
         with:

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -90,6 +90,6 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: ${{ vars.TELEMETRY_ENABLED == 'true' }} && always()
+        if: "${{ vars.TELEMETRY_ENABLED == 'true' }} && !cancelled()"
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -45,7 +45,7 @@ jobs:
         RAPIDS_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
+        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
         continue-on-error: true
         if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
       - name: Checkout code
@@ -65,7 +65,7 @@ jobs:
           IGNORED_JOBS: ${{ inputs.ignored_pr_jobs }}
 
       - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
         continue-on-error: true
         if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
         with:
@@ -78,7 +78,7 @@ jobs:
       image: rapidsai/ci-conda:latest
     steps:
       - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
+        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
         continue-on-error: true
         if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
       - name: Checkout code
@@ -98,7 +98,7 @@ jobs:
           RAPIDS_BASE_BRANCH: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}
 
       - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
         continue-on-error: true
         if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
         with:

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: always() && ${{ vars.TELEMETRY_ENABLED == 'true' }}
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' }} && always()
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
 
@@ -100,6 +100,6 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: always() && ${{ vars.TELEMETRY_ENABLED == 'true' }}
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' }} && always()
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: ${{ vars.TELEMETRY_ENABLED == 'true' }} && always()
+        if: "${{ vars.TELEMETRY_ENABLED == 'true' }} && !cancelled()"
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
 
@@ -100,6 +100,6 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: ${{ vars.TELEMETRY_ENABLED == 'true' }} && always()
+        if: "${{ vars.TELEMETRY_ENABLED == 'true' }} && !cancelled()"
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -47,6 +47,7 @@ jobs:
       - name: Telemetry setup
         uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
         continue-on-error: true
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Get PR Info
@@ -66,7 +67,7 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: always()
+        if: always() && ${{ vars.TELEMETRY_ENABLED == 'true' }}
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
 
@@ -79,6 +80,7 @@ jobs:
       - name: Telemetry setup
         uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
         continue-on-error: true
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -98,6 +100,6 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: always()
+        if: always() && ${{ vars.TELEMETRY_ENABLED == 'true' }}
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -45,7 +45,7 @@ jobs:
         RAPIDS_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
         continue-on-error: true
       - name: Checkout code
         uses: actions/checkout@v4
@@ -64,7 +64,7 @@ jobs:
           IGNORED_JOBS: ${{ inputs.ignored_pr_jobs }}
 
       - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
         if: always()
         with:
@@ -77,7 +77,7 @@ jobs:
       image: rapidsai/ci-conda:latest
     steps:
       - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
         continue-on-error: true
       - name: Checkout code
         uses: actions/checkout@v4
@@ -96,7 +96,7 @@ jobs:
           RAPIDS_BASE_BRANCH: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}
 
       - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
         if: always()
         with:

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -67,7 +67,7 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: "${{ vars.TELEMETRY_ENABLED == 'true' }} && !cancelled()"
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
 
@@ -100,6 +100,6 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: "${{ vars.TELEMETRY_ENABLED == 'true' }} && !cancelled()"
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -120,7 +120,7 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: always() && if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
+        if: always() && ${{ vars.TELEMETRY_ENABLED == 'true' }}
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
           extra_attributes: "rapids.operation=test-cpp,rapids.package_type=conda,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}}"

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -120,7 +120,7 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: "${{ vars.TELEMETRY_ENABLED == 'true' }} && !cancelled()"
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
           extra_attributes: "rapids.operation=test-cpp,rapids.package_type=conda,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}}"

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -120,7 +120,7 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: always() && ${{ vars.TELEMETRY_ENABLED == 'true' }}
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' }} && always()
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
           extra_attributes: "rapids.operation=test-cpp,rapids.package_type=conda,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}}"

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -120,7 +120,7 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: ${{ vars.TELEMETRY_ENABLED == 'true' }} && always()
+        if: "${{ vars.TELEMETRY_ENABLED == 'true' }} && !cancelled()"
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
           extra_attributes: "rapids.operation=test-cpp,rapids.package_type=conda,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}}"

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -87,7 +87,7 @@ jobs:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:
       - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
+        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
         continue-on-error: true
         if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
       - uses: aws-actions/configure-aws-credentials@v4
@@ -118,7 +118,7 @@ jobs:
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)
 
       - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
         continue-on-error: true
         if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
         with:

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -89,6 +89,7 @@ jobs:
       - name: Telemetry setup
         uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
         continue-on-error: true
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
@@ -119,7 +120,7 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: always()
+        if: always() && if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
           extra_attributes: "rapids.operation=test-cpp,rapids.package_type=conda,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}}"

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -87,7 +87,7 @@ jobs:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:
       - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
         continue-on-error: true
       - uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -117,7 +117,7 @@ jobs:
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)
 
       - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
         if: always()
         with:

--- a/.github/workflows/conda-cpp-post-build-checks.yaml
+++ b/.github/workflows/conda-cpp-post-build-checks.yaml
@@ -94,6 +94,6 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: "${{ vars.TELEMETRY_ENABLED == 'true' }} && !cancelled()"
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/conda-cpp-post-build-checks.yaml
+++ b/.github/workflows/conda-cpp-post-build-checks.yaml
@@ -48,7 +48,7 @@ jobs:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:
       - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
         continue-on-error: true
 
       - uses: aws-actions/configure-aws-credentials@v4
@@ -91,7 +91,7 @@ jobs:
           fi
 
       - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
         if: always()
         with:

--- a/.github/workflows/conda-cpp-post-build-checks.yaml
+++ b/.github/workflows/conda-cpp-post-build-checks.yaml
@@ -94,6 +94,6 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: ${{ vars.TELEMETRY_ENABLED == 'true' }} && always()
+        if: "${{ vars.TELEMETRY_ENABLED == 'true' }} && !cancelled()"
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/conda-cpp-post-build-checks.yaml
+++ b/.github/workflows/conda-cpp-post-build-checks.yaml
@@ -94,6 +94,6 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: always() && ${{ vars.TELEMETRY_ENABLED == 'true' }}
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' }} && always()
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/conda-cpp-post-build-checks.yaml
+++ b/.github/workflows/conda-cpp-post-build-checks.yaml
@@ -48,7 +48,7 @@ jobs:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:
       - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
+        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
         continue-on-error: true
         if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
 
@@ -92,7 +92,7 @@ jobs:
           fi
 
       - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
         continue-on-error: true
         if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
         with:

--- a/.github/workflows/conda-cpp-post-build-checks.yaml
+++ b/.github/workflows/conda-cpp-post-build-checks.yaml
@@ -50,6 +50,7 @@ jobs:
       - name: Telemetry setup
         uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
         continue-on-error: true
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
 
       - uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -93,6 +94,6 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: always()
+        if: always() && ${{ vars.TELEMETRY_ENABLED == 'true' }}
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -112,7 +112,7 @@ jobs:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
     steps:
       - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
+        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
         continue-on-error: true
         if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
       - uses: aws-actions/configure-aws-credentials@v4
@@ -148,7 +148,7 @@ jobs:
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)
 
       - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
         continue-on-error: true
         if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
         with:

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -112,7 +112,7 @@ jobs:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
     steps:
       - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
         continue-on-error: true
       - uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -147,7 +147,7 @@ jobs:
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)
 
       - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
         if: always()
         with:

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -150,7 +150,7 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: always() && ${{ vars.TELEMETRY_ENABLED == 'true' }}
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' }} && always()
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
           extra_attributes: "rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}},rapids.gpu=${{matrix.GPU}},rapids.driver=${{matrix.DRIVER}},rapids.deps=${{matrix.DEPENDENCIES}}"

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -150,7 +150,7 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: "${{ vars.TELEMETRY_ENABLED == 'true' }} && !cancelled()"
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
           extra_attributes: "rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}},rapids.gpu=${{matrix.GPU}},rapids.driver=${{matrix.DRIVER}},rapids.deps=${{matrix.DEPENDENCIES}}"

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -150,7 +150,7 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: ${{ vars.TELEMETRY_ENABLED == 'true' }} && always()
+        if: "${{ vars.TELEMETRY_ENABLED == 'true' }} && !cancelled()"
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
           extra_attributes: "rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}},rapids.gpu=${{matrix.GPU}},rapids.driver=${{matrix.DRIVER}},rapids.deps=${{matrix.DEPENDENCIES}}"

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -114,6 +114,7 @@ jobs:
       - name: Telemetry setup
         uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
         continue-on-error: true
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
@@ -149,7 +150,7 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: always()
+        if: always() && ${{ vars.TELEMETRY_ENABLED == 'true' }}
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
           extra_attributes: "rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}},rapids.gpu=${{matrix.GPU}},rapids.driver=${{matrix.DRIVER}},rapids.deps=${{matrix.DEPENDENCIES}}"

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -125,7 +125,7 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: ${{ vars.TELEMETRY_ENABLED == 'true' }} && always()
+        if: "${{ vars.TELEMETRY_ENABLED == 'true' }} && !cancelled()"
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
           extra_attributes: "rapids.operation=build-python,rapids.package_type=conda,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}}"

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -125,7 +125,7 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: "${{ vars.TELEMETRY_ENABLED == 'true' }} && !cancelled()"
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
           extra_attributes: "rapids.operation=build-python,rapids.package_type=conda,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}}"

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -94,7 +94,7 @@ jobs:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:
       - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
         continue-on-error: true
       - uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -122,7 +122,7 @@ jobs:
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
 
       - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
         if: always()
         with:

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -125,7 +125,7 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: always() && ${{ vars.TELEMETRY_ENABLED == 'true' }}
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' }} && always()
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
           extra_attributes: "rapids.operation=build-python,rapids.package_type=conda,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}}"

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -94,7 +94,7 @@ jobs:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:
       - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
+        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
         continue-on-error: true
         if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
       - uses: aws-actions/configure-aws-credentials@v4
@@ -123,7 +123,7 @@ jobs:
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
 
       - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
         continue-on-error: true
         if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
         with:

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -96,6 +96,7 @@ jobs:
       - name: Telemetry setup
         uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
         continue-on-error: true
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
@@ -124,7 +125,7 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: always()
+        if: always() && ${{ vars.TELEMETRY_ENABLED == 'true' }}
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
           extra_attributes: "rapids.operation=build-python,rapids.package_type=conda,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}}"

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -165,7 +165,7 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: "${{ vars.TELEMETRY_ENABLED == 'true' }} && !cancelled()"
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
           extra_attributes:  "rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}},rapids.gpu=${{matrix.GPU}},rapids.driver=${{matrix.DRIVER}},rapids.deps=${{matrix.DEPENDENCIES}}"

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -116,7 +116,7 @@ jobs:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
     steps:
       - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
+        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
         continue-on-error: true
         if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
       - uses: aws-actions/configure-aws-credentials@v4
@@ -163,7 +163,7 @@ jobs:
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
 
       - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
         continue-on-error: true
         if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
         with:

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -116,7 +116,7 @@ jobs:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
     steps:
       - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
         continue-on-error: true
       - uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -162,7 +162,7 @@ jobs:
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
 
       - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
         if: always()
         with:

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -165,7 +165,7 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: ${{ vars.TELEMETRY_ENABLED == 'true' }} && always()
+        if: "${{ vars.TELEMETRY_ENABLED == 'true' }} && !cancelled()"
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
           extra_attributes:  "rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}},rapids.gpu=${{matrix.GPU}},rapids.driver=${{matrix.DRIVER}},rapids.deps=${{matrix.DEPENDENCIES}}"

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -118,6 +118,7 @@ jobs:
       - name: Telemetry setup
         uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
         continue-on-error: true
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
@@ -164,7 +165,7 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: always()
+        if: always() && ${{ vars.TELEMETRY_ENABLED == 'true' }}
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
           extra_attributes:  "rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}},rapids.gpu=${{matrix.GPU}},rapids.driver=${{matrix.DRIVER}},rapids.deps=${{matrix.DEPENDENCIES}}"

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -165,7 +165,7 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: always() && ${{ vars.TELEMETRY_ENABLED == 'true' }}
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' }} && always()
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
           extra_attributes:  "rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}},rapids.gpu=${{matrix.GPU}},rapids.driver=${{matrix.DRIVER}},rapids.deps=${{matrix.DEPENDENCIES}}"

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -84,6 +84,6 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: "${{ vars.TELEMETRY_ENABLED == 'true' }} && !cancelled()"
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -84,6 +84,6 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: ${{ vars.TELEMETRY_ENABLED == 'true' }} && always()
+        if: "${{ vars.TELEMETRY_ENABLED == 'true' }} && !cancelled()"
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -47,7 +47,7 @@ jobs:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:
       - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
         continue-on-error: true
       - uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -81,7 +81,7 @@ jobs:
           RAPIDS_CONDA_UPLOAD_LABEL: ${{ inputs.upload_to_label }}
 
       - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
         if: always()
         with:

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -49,6 +49,7 @@ jobs:
       - name: Telemetry setup
         uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
         continue-on-error: true
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
@@ -83,6 +84,6 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: always()
+        if: always() && ${{ vars.TELEMETRY_ENABLED == 'true' }}
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -47,7 +47,7 @@ jobs:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:
       - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
+        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
         continue-on-error: true
         if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
       - uses: aws-actions/configure-aws-credentials@v4
@@ -82,7 +82,7 @@ jobs:
           RAPIDS_CONDA_UPLOAD_LABEL: ${{ inputs.upload_to_label }}
 
       - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
         continue-on-error: true
         if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
         with:

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -84,6 +84,6 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: always() && ${{ vars.TELEMETRY_ENABLED == 'true' }}
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' }} && always()
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -101,6 +101,6 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: ${{ vars.TELEMETRY_ENABLED == 'true' }} && always()
+        if: "${{ vars.TELEMETRY_ENABLED == 'true' }} && !cancelled()"
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -101,6 +101,6 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: "${{ vars.TELEMETRY_ENABLED == 'true' }} && !cancelled()"
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -61,6 +61,7 @@ jobs:
       - name: Telemetry setup
         uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
         continue-on-error: true
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
@@ -100,6 +101,6 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: always()
+        if: always() && ${{ vars.TELEMETRY_ENABLED == 'true' }}
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -101,6 +101,6 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: always() && ${{ vars.TELEMETRY_ENABLED == 'true' }}
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' }} && always()
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -59,7 +59,7 @@ jobs:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
     steps:
       - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
         continue-on-error: true
       - uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -98,7 +98,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
         if: always()
         with:

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -59,7 +59,7 @@ jobs:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
     steps:
       - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
+        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
         continue-on-error: true
         if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
       - uses: aws-actions/configure-aws-credentials@v4
@@ -99,7 +99,7 @@ jobs:
           if-no-files-found: ignore
 
       - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
         continue-on-error: true
         if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
         with:

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -173,7 +173,7 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: always() && ${{ vars.TELEMETRY_ENABLED == 'true' }}
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' }} && always()
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
           extra_attributes: "rapids.operation=build,rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}}"

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -119,6 +119,7 @@ jobs:
       - name: Telemetry setup
         uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
         continue-on-error: true
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
       - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
@@ -172,7 +173,7 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: always()
+        if: always() && ${{ vars.TELEMETRY_ENABLED == 'true' }}
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
           extra_attributes: "rapids.operation=build,rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}}"

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -173,7 +173,7 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: "${{ vars.TELEMETRY_ENABLED == 'true' }} && !cancelled()"
+        if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
           extra_attributes: "rapids.operation=build,rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}}"

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -117,7 +117,7 @@ jobs:
 
     steps:
       - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
+        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
         continue-on-error: true
         if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
       - uses: aws-actions/configure-aws-credentials@v4
@@ -171,7 +171,7 @@ jobs:
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
 
       - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
         continue-on-error: true
         if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
         with:

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -117,7 +117,7 @@ jobs:
 
     steps:
       - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+        uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
         continue-on-error: true
       - uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -170,7 +170,7 @@ jobs:
         run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
 
       - name: Telemetry summarize
-        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
+        uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
         if: always()
         with:

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -173,7 +173,7 @@ jobs:
       - name: Telemetry summarize
         uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
         continue-on-error: true
-        if: ${{ vars.TELEMETRY_ENABLED == 'true' }} && always()
+        if: "${{ vars.TELEMETRY_ENABLED == 'true' }} && !cancelled()"
         with:
           cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
           extra_attributes: "rapids.operation=build,rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}}"

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -58,6 +58,7 @@ jobs:
     - name: Telemetry setup
       uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
       continue-on-error: true
+      if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
     - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ vars.AWS_ROLE_ARN }}
@@ -105,6 +106,6 @@ jobs:
     - name: Telemetry summarize
       uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
       continue-on-error: true
-      if: always()
+      if: always() && ${{ vars.TELEMETRY_ENABLED == 'true' }}
       with:
         cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -106,6 +106,6 @@ jobs:
     - name: Telemetry summarize
       uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
       continue-on-error: true
-      if: "${{ vars.TELEMETRY_ENABLED == 'true' }} && !cancelled()"
+      if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
       with:
         cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -56,7 +56,7 @@ jobs:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:
     - name: Telemetry setup
-      uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+      uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
       continue-on-error: true
     - uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -103,7 +103,7 @@ jobs:
         password: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
 
     - name: Telemetry summarize
-      uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
+      uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
       continue-on-error: true
       if: always()
       with:

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -106,6 +106,6 @@ jobs:
     - name: Telemetry summarize
       uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
       continue-on-error: true
-      if: always() && ${{ vars.TELEMETRY_ENABLED == 'true' }}
+      if: ${{ vars.TELEMETRY_ENABLED == 'true' }} && always()
       with:
         cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -106,6 +106,6 @@ jobs:
     - name: Telemetry summarize
       uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
       continue-on-error: true
-      if: ${{ vars.TELEMETRY_ENABLED == 'true' }} && always()
+      if: "${{ vars.TELEMETRY_ENABLED == 'true' }} && !cancelled()"
       with:
         cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -56,7 +56,7 @@ jobs:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:
     - name: Telemetry setup
-      uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
+      uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
       continue-on-error: true
       if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
     - uses: aws-actions/configure-aws-credentials@v4
@@ -104,7 +104,7 @@ jobs:
         password: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
 
     - name: Telemetry summarize
-      uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
+      uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
       continue-on-error: true
       if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
       with:

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -123,7 +123,7 @@ jobs:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:
     - name: Telemetry setup
-      uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
+      uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
       continue-on-error: true
       if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
     - uses: aws-actions/configure-aws-credentials@v4
@@ -168,7 +168,7 @@ jobs:
       run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
 
     - name: Telemetry summarize
-      uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
+      uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
       continue-on-error: true
       if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
       with:

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -170,7 +170,7 @@ jobs:
     - name: Telemetry summarize
       uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
       continue-on-error: true
-      if: "${{ vars.TELEMETRY_ENABLED == 'true' }} && !cancelled()"
+      if: ${{ vars.TELEMETRY_ENABLED == 'true' && !cancelled() }}
       with:
         cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
         extra_attributes: "rapids.operation=wheels-test,rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}},rapids.gpu=${{matrix.GPU}},rapids.driver=${{matrix.DRIVER}},rapids.deps=${{matrix.DEPENDENCIES}}"

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -125,6 +125,7 @@ jobs:
     - name: Telemetry setup
       uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
       continue-on-error: true
+      if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
     - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ vars.AWS_ROLE_ARN }}
@@ -169,7 +170,7 @@ jobs:
     - name: Telemetry summarize
       uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
       continue-on-error: true
-      if: always()
+      if: always() && ${{ vars.TELEMETRY_ENABLED == 'true' }}
       with:
         cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
         extra_attributes: "rapids.operation=wheels-test,rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}},rapids.gpu=${{matrix.GPU}},rapids.driver=${{matrix.DRIVER}},rapids.deps=${{matrix.DEPENDENCIES}}"

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -170,7 +170,7 @@ jobs:
     - name: Telemetry summarize
       uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
       continue-on-error: true
-      if: always() && ${{ vars.TELEMETRY_ENABLED == 'true' }}
+      if: ${{ vars.TELEMETRY_ENABLED == 'true' }} && always()
       with:
         cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
         extra_attributes: "rapids.operation=wheels-test,rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}},rapids.gpu=${{matrix.GPU}},rapids.driver=${{matrix.DRIVER}},rapids.deps=${{matrix.DEPENDENCIES}}"

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -170,7 +170,7 @@ jobs:
     - name: Telemetry summarize
       uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
       continue-on-error: true
-      if: ${{ vars.TELEMETRY_ENABLED == 'true' }} && always()
+      if: "${{ vars.TELEMETRY_ENABLED == 'true' }} && !cancelled()"
       with:
         cert_concat: "${{ secrets.OTEL_EXPORTER_OTLP_CA_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE }};${{ secrets.OTEL_EXPORTER_OTLP_CLIENT_KEY }}"
         extra_attributes: "rapids.operation=wheels-test,rapids.package_type=wheel,rapids.cuda=${{matrix.CUDA_VER}},rapids.py=${{matrix.PY_VER}},rapids.arch=${{matrix.ARCH}},rapids.linux=${{matrix.LINUX_VER}},rapids.gpu=${{matrix.GPU}},rapids.driver=${{matrix.DRIVER}},rapids.deps=${{matrix.DEPENDENCIES}}"

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -123,7 +123,7 @@ jobs:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:
     - name: Telemetry setup
-      uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@main
+      uses: rapidsai/shared-actions/telemetry-dispatch-load-base-env-vars@fluentbit-default-endpoint
       continue-on-error: true
     - uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -167,7 +167,7 @@ jobs:
       run: rapids-upload-artifacts-dir cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}
 
     - name: Telemetry summarize
-      uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@main
+      uses: rapidsai/shared-actions/telemetry-dispatch-write-summary@fluentbit-default-endpoint
       continue-on-error: true
       if: always()
       with:


### PR DESCRIPTION
Repos that haven't been set up with telemetry stuff have been noisy with errors. The errors don't break jobs, but they are noise, and they are costing developers time with their confusion about it.

This PR is a stopgap for #269, but it should clear the errors from most repos.