### PR TITLE
Allow `branch` option for `$BUILD_TYPE`

### DIFF
--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -52,8 +52,8 @@ jobs:
     steps:
       - name: Validate Test Type
         run: |
-          if [[ "$BUILD_TYPE" != "pull-request" ]] && [[ "$BUILD_TYPE" != "nightly" ]]; then
-              echo "Invalid build type! Must be 'nightly' or 'pull-request'."
+          if [[ "$BUILD_TYPE" != "pull-request" ]] && [[ "$BUILD_TYPE" != "nightly" ]] && [[ "$BUILD_TYPE" != "branch" ]]; then
+              echo "Invalid build type! Must be one of 'nightly', 'pull-request', or 'branch'."
               exit 1
           fi
       - name: Compute C++ Test Matrix

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -55,8 +55,8 @@ jobs:
     steps:
       - name: Validate Test Type
         run: |
-          if [[ "$BUILD_TYPE" != "pull-request" ]] && [[ "$BUILD_TYPE" != "nightly" ]]; then
-              echo "Invalid build type! Must be 'nightly' or 'pull-request'."
+          if [[ "$BUILD_TYPE" != "pull-request" ]] && [[ "$BUILD_TYPE" != "nightly" ]] && [[ "$BUILD_TYPE" != "branch" ]]; then
+              echo "Invalid build type! Must be one of 'nightly', 'pull-request', or 'branch'."
               exit 1
           fi
       - name: Compute Python Test Matrix

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -64,8 +64,8 @@ jobs:
     steps:
       - name: Validate test type
         run: |
-          if [[ "$BUILD_TYPE" != "pull-request" ]] && [[ "$BUILD_TYPE" != "nightly" ]]; then
-              echo "Invalid build type! Must be 'nightly' or 'pull-request'."
+          if [[ "$BUILD_TYPE" != "pull-request" ]] && [[ "$BUILD_TYPE" != "nightly" ]] && [[ "$BUILD_TYPE" != "branch" ]]; then
+              echo "Invalid build type! Must be one of 'nightly', 'pull-request', or 'branch'."
               exit 1
           fi
       - name: Compute test matrix


### PR DESCRIPTION
Adds an additional option for the `*test.yaml` files for a specified `branch` option.

xref rapidsai/gha-tools#138

