### PR TITLE
Add optional `continue-on-error` input to CI jobs

### DIFF
--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -27,6 +27,10 @@ on:
       file_to_upload:
         type: string
         default: "gh-status.json"
+      continue-on-error:
+        type: boolean
+        required: false
+        default: false
 
 defaults:
   run:
@@ -52,6 +56,7 @@ jobs:
     strategy:
       fail-fast: false
     runs-on: "linux-${{ inputs.arch }}-${{ inputs.node_type }}"
+    continue-on-error: ${{ inputs.continue-on-error }}
     container:
       image: ${{ inputs.container_image }}
       env:


### PR DESCRIPTION
Occasionally we want the ability to not block merging PRs even if one of the CI jobs is failing. xref https://github.com/rapidsai/cudf/pull/17987. This pr add the `continue-on-error` input so that this is possible.