### PR TITLE
Revert "turn off package proxy cache on conda-based jobs"

### DIFF
--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -143,11 +143,11 @@ jobs:
           echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" >> "${GITHUB_ENV}"
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
 
-      # - name: Setup proxy cache
-      #   uses: nv-gha-runners/setup-proxy-cache@main
-      #   continue-on-error: true
-      #   # Skip the cache on RDS Lab nodes
-      #   if: ${{ matrix.GPU != 'v100' && matrix.GPU != 'a100' }}
+      - name: Setup proxy cache
+        uses: nv-gha-runners/setup-proxy-cache@main
+        continue-on-error: true
+        # Skip the cache on RDS Lab nodes
+        if: ${{ matrix.GPU != 'v100' && matrix.GPU != 'a100' }}
 
       - name: C++ tests
         run: ${{ inputs.script }}

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -149,11 +149,11 @@ jobs:
         with:
           extra_attributes:  "rapids.PACKAGER=conda,rapids.CUDA_VER=${{ matrix.CUDA_VER }},rapids.PY_VER=${{ matrix.PY_VER }},rapids.ARCH=${{ matrix.ARCH }},rapids.LINUX_VER=${{ matrix.LINUX_VER }},rapids.GPU=${{ matrix.GPU }},rapids.DRIVER=${{ matrix.DRIVER }},rapids.DEPENDENCIES=${{ matrix.DEPENDENCIES }}"
 
-      # - name: Setup proxy cache
-      #   uses: nv-gha-runners/setup-proxy-cache@main
-      #   continue-on-error: true
-      #   # Skip the cache on RDS Lab nodes
-      #   if: ${{ matrix.GPU != 'v100' && matrix.GPU != 'a100' }}
+      - name: Setup proxy cache
+        uses: nv-gha-runners/setup-proxy-cache@main
+        continue-on-error: true
+        # Skip the cache on RDS Lab nodes
+        if: ${{ matrix.GPU != 'v100' && matrix.GPU != 'a100' }}
 
       - name: Python tests
         run: ${{ inputs.script }}


### PR DESCRIPTION
Reverts rapidsai/shared-workflows#282.

The cache issues should be resolved now as described in https://github.com/nv-gha-runners/roadmap/issues/192#issuecomment-2679032806.