### PR TITLE
Use `twine` to upload wheels

### DIFF
--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -47,7 +47,7 @@ permissions:
 jobs:
   wheel-publish:
     name: wheels publish
-    runs-on: linux-amd64-cpu4
+    runs-on: ubuntu-latest
     container:
       # CUDA toolkit version of the container is irrelevant in the publish step.
       # This just uploads already-built wheels to remote storage.

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -100,9 +100,11 @@ jobs:
 
     - name: Publish the downloaded wheels to PyPI
       if: ${{ inputs.publish_to_pypi && steps.check_if_release.outputs.is_release_build == 'true' }}
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
+      run: |
+        python3 -m pip install twine
+        python3 -m twine upload -u __token__ dist/*
+      env:
+        TWINE_PASSWORD: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
     - name: Telemetry upload attributes
       uses: rapidsai/shared-actions/telemetry-dispatch-stash-job-artifacts@main
       continue-on-error: true


### PR DESCRIPTION
The `gh-action-pypi-publish` action is having problems with some repos. Try uploading with `twine` instead.