### PR TITLE
Remove `a100` conditional for proxy cache

### DIFF
--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -147,7 +147,7 @@ jobs:
         uses: nv-gha-runners/setup-proxy-cache@main
         continue-on-error: true
         # Skip the cache on RDS Lab nodes
-        if: ${{ matrix.GPU != 'v100' && matrix.GPU != 'a100' }}
+        if: ${{ matrix.GPU != 'v100' }}
 
       - name: C++ tests
         run: ${{ inputs.script }}

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -153,7 +153,7 @@ jobs:
         uses: nv-gha-runners/setup-proxy-cache@main
         continue-on-error: true
         # Skip the cache on RDS Lab nodes
-        if: ${{ matrix.GPU != 'v100' && matrix.GPU != 'a100' }}
+        if: ${{ matrix.GPU != 'v100' }}
 
       - name: Python tests
         run: ${{ inputs.script }}

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -163,7 +163,7 @@ jobs:
       uses: nv-gha-runners/setup-proxy-cache@main
       continue-on-error: true
       # Skip the cache on RDS Lab nodes
-      if: ${{ matrix.GPU != 'v100' && matrix.GPU != 'a100' }}
+      if: ${{ matrix.GPU != 'v100' }}
 
     - name: Run tests
       run: ${{ inputs.script }}


### PR DESCRIPTION
We recently migrated the A100 machines to NVKS. Therefore the A100 runners now have the capability to use the proxy cache. This PR removes the conditional statement that prevented the A100s from using the proxy cache.