### PR TITLE
add gha-tools checkout in devcontainer workflow for recording telemetry

### DIFF
--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -101,6 +101,16 @@ jobs:
         uses: nv-gha-runners/setup-proxy-cache@main
         continue-on-error: true
 
+      - name: Checkout gha-tools
+        uses: actions/checkout@v4
+        with:
+          repository: rapidsai/gha-tools
+          path: gha-tools
+
+      - name: Add gha-tools to PATH
+        run: |
+          export PATH="${{ github.workspace }}/gha-tools:${PATH}"
+
       - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
         name: Run build in devcontainer
         uses: devcontainers/ci@v0.3

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -101,16 +101,6 @@ jobs:
         uses: nv-gha-runners/setup-proxy-cache@main
         continue-on-error: true
 
-      - name: Checkout gha-tools
-        uses: actions/checkout@v4
-        with:
-          repository: rapidsai/gha-tools
-          path: gha-tools
-
-      - name: Add gha-tools to PATH
-        run: |
-          export PATH="${{ github.workspace }}/gha-tools:${PATH}"
-
       - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
         name: Run build in devcontainer
         uses: devcontainers/ci@v0.3
@@ -152,6 +142,8 @@ jobs:
               fi
               devcontainer-utils-init-ssh-deploy-keys || true;
             fi
+
+            source rapids-telemetry-setup;
 
             cd ~/"${REPOSITORY}";
             ${{ inputs.build_command }}


### PR DESCRIPTION
gha-tools is baked into our ci images, but not seemingly available for devcontainer builds (https://github.com/rapidsai/cuml/actions/runs/13722695785/job/38381682615?pr=6360#step:9:9160)

This adds gha-tools to PATH so that we have access to rapids-telemetry-setup for setting up the telemetry artifacts folder.