### PR TITLE
Switch to a self-hosted runner for publishing

### DIFF
--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -47,7 +47,9 @@ permissions:
 jobs:
   wheel-publish:
     name: wheels publish
-    runs-on: ubuntu-latest
+    # Use a self-hosted runner to ensure we have sufficient disk space. Using
+    # cpu8 since we shouldn't need much CPU horsepower.
+    runs-on: "linux-amd64-cpu8"
     container:
       # CUDA toolkit version of the container is irrelevant in the publish step.
       # This just uploads already-built wheels to remote storage.


### PR DESCRIPTION
Our ci-wheel images appear to be too large for the GH-hosted runners now, see https://github.com/rapidsai/cudf/actions/runs/13823613886/job/38675672535. We should shrink them, but in the meantime using our self-hosted runners should resolve the issue.