### PR TITLE
Remove usage of tj-actions/changed-files

### DIFF
--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -4,19 +4,6 @@ on:
       files_yaml:
         type: string
         required: true
-      transform_expr:
-        type: string
-        required: false
-        default: |
-          to_entries |
-          map(
-            select(.key | endswith("_any_changed")) |
-            {
-              "key": (.key | rtrimstr("_any_changed")),
-              "value": .value,
-            }
-          ) |
-          from_entries
     outputs:
       changed_file_groups:
         value: ${{ jobs.changed-files.outputs.transformed_output }}
@@ -51,41 +38,14 @@ jobs:
         uses: rapidsai/shared-actions/telemetry-dispatch-setup@main
         continue-on-error: true
         if: ${{ vars.TELEMETRY_ENABLED == 'true' && github.run_attempt == '1' }}
-      - name: Get PR info
-        id: get-pr-info
-        uses: nv-gha-runners/get-pr-info@main
-      - name: Checkout code repo
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Calculate merge base
-        id: calculate-merge-base
-        env:
-          PR_SHA: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).head.sha }}
-          BASE_SHA: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.sha }}
-        run: |
-          (echo -n "merge-base="; git merge-base "$BASE_SHA" "$PR_SHA") | tee --append "$GITHUB_OUTPUT"
-      - name: Get changed files
-        id: changed-files
-        uses: tj-actions/changed-files@v45
-        with:
-          base_sha: ${{ steps.calculate-merge-base.outputs.merge-base }}
-          sha: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).head.sha }}
-          files_yaml: ${{ inputs.files_yaml }}
-          write_output_files: true
-          json: true
+      # TODO: Rewrite this logic once we have a way to get the changed files without tj-actions/changed-files
+      # See https://github.com/rapidsai/shared-workflows/issues/302
       - name: Transform changed files into output
         id: transform-changed-files
         env:
-          TRANSFORM_EXPR: ${{ inputs.transform_expr }}
+          FILES_YAML: ${{ inputs.files_yaml }}
         run: |
-          file_args=()
-          for file in .github/outputs/*.json; do
-            key="$(echo "$file" | sed -E 's/^\.github\/outputs\/(.*)\.json$/\1/g')"
-            file_args=("${file_args[@]}" --slurpfile "$key" "$file")
-          done
-          (echo -n "transformed-output="; jq -c -n "\$ARGS.named | to_entries | map({"key": .key, "value": .value[]}) | from_entries | $TRANSFORM_EXPR" "${file_args[@]}") | tee --append "$GITHUB_OUTPUT"
+          (echo -n "transformed-output="; echo ${FILES_YAML} | yq -o=json '.' - | jq -c 'map_values(true)') | tee --append "$GITHUB_OUTPUT"
       - name: Telemetry upload attributes
         uses: rapidsai/shared-actions/telemetry-dispatch-stash-job-artifacts@main
         continue-on-error: true


### PR DESCRIPTION
This PR removes the usage of `tj-actions/changed-files`, as a temporary solution for https://github.com/rapidsai/shared-workflows/issues/302.
