### PR TITLE
chore: add cuda 11.4 to pull-request testing

### DIFF
--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -68,6 +68,7 @@ jobs:
           export MATRICES="
             pull-request:
               # amd64
+              - { ARCH: 'amd64', PY_VER: '3.10', CUDA_VER: '11.4.3', LINUX_VER: 'rockylinux8', GPU: 'l4',   DRIVER: 'earliest', DEPENDENCIES: 'oldest' }
               - { ARCH: 'amd64', PY_VER: '3.10', CUDA_VER: '11.8.0', LINUX_VER: 'rockylinux8', GPU: 'l4',   DRIVER: 'earliest', DEPENDENCIES: 'oldest' }
               - { ARCH: 'amd64', PY_VER: '3.12', CUDA_VER: '12.8.0', LINUX_VER: 'ubuntu24.04', GPU: 'h100', DRIVER: 'latest',   DEPENDENCIES: 'latest' }
               # arm64

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -71,6 +71,7 @@ jobs:
           export MATRICES="
             pull-request:
               # amd64
+              - { ARCH: 'amd64', PY_VER: '3.10', CUDA_VER: '11.4.3', LINUX_VER: 'rockylinux8', GPU: 'l4',   DRIVER: 'earliest', DEPENDENCIES: 'oldest' }
               - { ARCH: 'amd64', PY_VER: '3.10', CUDA_VER: '11.8.0', LINUX_VER: 'rockylinux8', GPU: 'l4',   DRIVER: 'earliest', DEPENDENCIES: 'oldest' }
               - { ARCH: 'amd64', PY_VER: '3.12', CUDA_VER: '12.8.0', LINUX_VER: 'ubuntu24.04', GPU: 'h100', DRIVER: 'latest',   DEPENDENCIES: 'latest' }
               # arm64


### PR DESCRIPTION
Resolves rapidsai/build-planning#164

This adds a CUDA 11.4 entry to the pull request matrix for `conda-cpp-tests` and `conda-python-tests`.

For now, I've just copied the entry from the nightly matrix.

PRs have been merged in raft, cuml, and cugraph to pre-filter this new job out to avoid breaking their CI.

rapidsai/raft#2608
rapidsai/cuml#6447
rapidsai/cugraph#4975
