### PR TITLE
make matrix type configurable

### DIFF
--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -2,6 +2,7 @@ on:
   workflow_call:
     inputs:
       build_type:
+        description: "One of: [branch, nightly, pull-request]"
         required: true
         type: string
       branch:

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -3,11 +3,7 @@ on:
     inputs:
       build_type:
         required: true
-        type: choice
-        options:
-          - branch
-          - nightly
-          - pull-request
+        type: string
       branch:
         type: string
       date:

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -3,7 +3,11 @@ on:
     inputs:
       build_type:
         required: true
-        type: string
+        type: choice
+        options:
+          - branch
+          - nightly
+          - pull-request
       branch:
         type: string
       date:

--- a/.github/workflows/conda-cpp-post-build-checks.yaml
+++ b/.github/workflows/conda-cpp-post-build-checks.yaml
@@ -2,6 +2,7 @@ on:
   workflow_call:
     inputs:
       build_type:
+        description: "One of: [branch, nightly, pull-request]"
         required: true
         type: string
       branch:

--- a/.github/workflows/conda-cpp-post-build-checks.yaml
+++ b/.github/workflows/conda-cpp-post-build-checks.yaml
@@ -3,11 +3,7 @@ on:
     inputs:
       build_type:
         required: true
-        type: choice
-        options:
-          - branch
-          - nightly
-          - pull-request
+        type: string
       branch:
         type: string
       date:

--- a/.github/workflows/conda-cpp-post-build-checks.yaml
+++ b/.github/workflows/conda-cpp-post-build-checks.yaml
@@ -3,7 +3,11 @@ on:
     inputs:
       build_type:
         required: true
-        type: string
+        type: choice
+        options:
+          - branch
+          - nightly
+          - pull-request
       branch:
         type: string
       date:

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -2,21 +2,14 @@ on:
   workflow_call:
     inputs:
       build_type:
+        description: "One of: [branch, nightly, pull-request]"
         required: true
-        type: choice
-        options:
-          - branch
-          - nightly
-          - pull-request
+        type: string
       matrix_type:
-        required: true
-        type: choice
-        options:
-          # "auto" = choose a value based on what's provided via 'build_type'
-          - auto
-          - nightly
-          - pull-request
-        default: auto
+        description: "One of: [auto, nightly, pull-request]. 'auto' means 'choose a value based on what's provided via build_type'."
+        required: false
+        type: string
+        default: "auto"
       branch:
         type: string
       date:
@@ -64,6 +57,16 @@ jobs:
     outputs:
       MATRIX: ${{ steps.compute-matrix.outputs.MATRIX }}
     steps:
+      - name: Validate Inputs
+        run: |
+          if [[ "$BUILD_TYPE" != "branch" ]] && [[ "$BUILD_TYPE" != "nightly" ]] && [[ "$BUILD_TYPE" != "pull-request" ]]; then
+              echo "Invalid build_type! Must be one of 'branch', 'nightly', or 'pull-request'."
+              exit 1
+          fi
+          if [[ "$MATRIX_TYPE" != "auto" ]] && [[ "$MATRIX_TYPE" != "nightly" ]] && [[ "$MATRIX_TYPE" != "pull-request" ]]; then
+              echo "Invalid matrix_type! Must be one of 'auto', 'nightly', or 'pull-request'."
+              exit 1
+          fi
       - name: Compute C++ Test Matrix
         id: compute-matrix
         run: |

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -3,7 +3,20 @@ on:
     inputs:
       build_type:
         required: true
-        type: string
+        type: choice
+        options:
+          - branch
+          - nightly
+          - pull-request
+      matrix_type:
+        required: true
+        type: choice
+        options:
+          # "auto" = choose a value based on what's provided via 'build_type'
+          - auto
+          - nightly
+          - pull-request
+        default: auto
       branch:
         type: string
       date:
@@ -47,15 +60,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BUILD_TYPE: ${{ inputs.build_type }}
+      MATRIX_TYPE: ${{ inputs.matrix_type }}
     outputs:
       MATRIX: ${{ steps.compute-matrix.outputs.MATRIX }}
     steps:
-      - name: Validate Test Type
-        run: |
-          if [[ "$BUILD_TYPE" != "pull-request" ]] && [[ "$BUILD_TYPE" != "nightly" ]] && [[ "$BUILD_TYPE" != "branch" ]]; then
-              echo "Invalid build type! Must be one of 'nightly', 'pull-request', or 'branch'."
-              exit 1
-          fi
       - name: Compute C++ Test Matrix
         id: compute-matrix
         run: |
@@ -84,10 +92,13 @@ jobs:
               - { ARCH: 'arm64', PY_VER: '3.12', CUDA_VER: '12.8.0', LINUX_VER: 'rockylinux8', GPU: 'a100', DRIVER: 'latest',   DEPENDENCIES: 'latest' }
           "
 
-          # Use the nightly matrix for branch tests
-          MATRIX_TYPE="${BUILD_TYPE}"
-          if [[ "${MATRIX_TYPE}" == "branch" ]]; then
-            MATRIX_TYPE="nightly"
+          # only overwrite MATRIX_TYPE if it was set to 'auto'
+          if [[ "${MATRIX_TYPE}" == "auto" ]]; then
+            MATRIX_TYPE="${BUILD_TYPE}"
+            # Use the nightly matrix for branch tests
+            if [[ "${BUILD_TYPE}" == "branch" ]]; then
+              MATRIX_TYPE="nightly"
+            fi
           fi
           export MATRIX_TYPE
           TEST_MATRIX=$(yq -n 'env(MATRICES) | .[strenv(MATRIX_TYPE)]')

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -100,10 +100,11 @@ jobs:
 
           # only overwrite MATRIX_TYPE if it was set to 'auto'
           if [[ "${MATRIX_TYPE}" == "auto" ]]; then
-            MATRIX_TYPE="${BUILD_TYPE}"
-            # Use the nightly matrix for branch tests
             if [[ "${BUILD_TYPE}" == "branch" ]]; then
+              # Use the nightly matrix for branch tests
               MATRIX_TYPE="nightly"
+            else
+              MATRIX_TYPE="${BUILD_TYPE}"
             fi
           fi
           export MATRIX_TYPE

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -2,6 +2,7 @@ on:
   workflow_call:
     inputs:
       build_type:
+        description: "One of: [branch, nightly, pull-request]"
         required: true
         type: string
       branch:

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -3,11 +3,7 @@ on:
     inputs:
       build_type:
         required: true
-        type: choice
-        options:
-          - branch
-          - nightly
-          - pull-request
+        type: string
       branch:
         type: string
       date:

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -3,7 +3,11 @@ on:
     inputs:
       build_type:
         required: true
-        type: string
+        type: choice
+        options:
+          - branch
+          - nightly
+          - pull-request
       branch:
         type: string
       date:

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -3,7 +3,20 @@ on:
     inputs:
       build_type:
         required: true
-        type: string
+        type: choice
+        options:
+          - branch
+          - nightly
+          - pull-request
+      matrix_type:
+        required: true
+        type: choice
+        options:
+          # "auto" = choose a value based on what's provided via 'build_type'
+          - auto
+          - nightly
+          - pull-request
+        default: auto
       branch:
         type: string
       date:
@@ -50,15 +63,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BUILD_TYPE: ${{ inputs.build_type }}
+      MATRIX_TYPE: ${{ inputs.matrix_type }}
     outputs:
       MATRIX: ${{ steps.compute-matrix.outputs.MATRIX }}
     steps:
-      - name: Validate Test Type
-        run: |
-          if [[ "$BUILD_TYPE" != "pull-request" ]] && [[ "$BUILD_TYPE" != "nightly" ]] && [[ "$BUILD_TYPE" != "branch" ]]; then
-              echo "Invalid build type! Must be one of 'nightly', 'pull-request', or 'branch'."
-              exit 1
-          fi
       - name: Compute Python Test Matrix
         id: compute-matrix
         run: |
@@ -87,10 +95,13 @@ jobs:
               - { ARCH: 'arm64', PY_VER: '3.12', CUDA_VER: '12.8.0', LINUX_VER: 'rockylinux8', GPU: 'a100', DRIVER: 'latest',   DEPENDENCIES: 'latest' }
           "
 
-          # Use the nightly matrix for branch tests
-          MATRIX_TYPE="${BUILD_TYPE}"
-          if [[ "${MATRIX_TYPE}" == "branch" ]]; then
-            MATRIX_TYPE="nightly"
+          # only overwrite MATRIX_TYPE if it was set to 'auto'
+          if [[ "${MATRIX_TYPE}" == "auto" ]]; then
+            MATRIX_TYPE="${BUILD_TYPE}"
+            # Use the nightly matrix for branch tests
+            if [[ "${BUILD_TYPE}" == "branch" ]]; then
+              MATRIX_TYPE="nightly"
+            fi
           fi
           export MATRIX_TYPE
           TEST_MATRIX=$(yq -n 'env(MATRICES) | .[strenv(MATRIX_TYPE)]')

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -103,10 +103,11 @@ jobs:
 
           # only overwrite MATRIX_TYPE if it was set to 'auto'
           if [[ "${MATRIX_TYPE}" == "auto" ]]; then
-            MATRIX_TYPE="${BUILD_TYPE}"
-            # Use the nightly matrix for branch tests
             if [[ "${BUILD_TYPE}" == "branch" ]]; then
+              # Use the nightly matrix for branch tests
               MATRIX_TYPE="nightly"
+            else
+              MATRIX_TYPE="${BUILD_TYPE}"
             fi
           fi
           export MATRIX_TYPE

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -2,21 +2,14 @@ on:
   workflow_call:
     inputs:
       build_type:
+        description: "One of: [branch, nightly, pull-request]"
         required: true
-        type: choice
-        options:
-          - branch
-          - nightly
-          - pull-request
+        type: string
       matrix_type:
-        required: true
-        type: choice
-        options:
-          # "auto" = choose a value based on what's provided via 'build_type'
-          - auto
-          - nightly
-          - pull-request
-        default: auto
+        description: "One of: [auto, nightly, pull-request]. 'auto' means 'choose a value based on what's provided via build_type'."
+        required: false
+        type: string
+        default: "auto"
       branch:
         type: string
       date:
@@ -67,6 +60,16 @@ jobs:
     outputs:
       MATRIX: ${{ steps.compute-matrix.outputs.MATRIX }}
     steps:
+      - name: Validate Inputs
+        run: |
+          if [[ "$BUILD_TYPE" != "branch" ]] && [[ "$BUILD_TYPE" != "nightly" ]] && [[ "$BUILD_TYPE" != "pull-request" ]]; then
+              echo "Invalid build_type! Must be one of 'branch', 'nightly', or 'pull-request'."
+              exit 1
+          fi
+          if [[ "$MATRIX_TYPE" != "auto" ]] && [[ "$MATRIX_TYPE" != "nightly" ]] && [[ "$MATRIX_TYPE" != "pull-request" ]]; then
+              echo "Invalid matrix_type! Must be one of 'auto', 'nightly', or 'pull-request'."
+              exit 1
+          fi
       - name: Compute Python Test Matrix
         id: compute-matrix
         run: |

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -2,6 +2,7 @@ on:
   workflow_call:
     inputs:
       build_type:
+        description: "One of: [branch, nightly, pull-request]"
         required: true
         type: string
       branch:

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -3,11 +3,7 @@ on:
     inputs:
       build_type:
         required: true
-        type: choice
-        options:
-          - branch
-          - nightly
-          - pull-request
+        type: string
       branch:
         type: string
       date:

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -3,7 +3,11 @@ on:
     inputs:
       build_type:
         required: true
-        type: string
+        type: choice
+        options:
+          - branch
+          - nightly
+          - pull-request
       branch:
         type: string
       date:

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -2,6 +2,7 @@ on:
   workflow_call:
     inputs:
       build_type:
+        description: "One of: [branch, nightly, pull-request]"
         required: true
         type: string
       branch:

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -3,11 +3,7 @@ on:
     inputs:
       build_type:
         required: true
-        type: choice
-        options:
-          - branch
-          - nightly
-          - pull-request
+        type: string
       branch:
         type: string
       date:

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -3,7 +3,11 @@ on:
     inputs:
       build_type:
         required: true
-        type: string
+        type: choice
+        options:
+          - branch
+          - nightly
+          - pull-request
       branch:
         type: string
       date:

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -13,6 +13,7 @@ on:
       sha:
         type: string
       build_type:
+        description: "One of: [branch, nightly, pull-request]"
         required: true
         type: string
       script:

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -14,7 +14,11 @@ on:
         type: string
       build_type:
         required: true
-        type: string
+        type: choice
+        options:
+          - branch
+          - nightly
+          - pull-request
       script:
         required: true
         type: string

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -14,11 +14,7 @@ on:
         type: string
       build_type:
         required: true
-        type: choice
-        options:
-          - branch
-          - nightly
-          - pull-request
+        type: string
       script:
         required: true
         type: string

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -13,6 +13,7 @@ on:
       sha:
         type: string
       build_type:
+        description: "One of: [branch, nightly, pull-request]"
         required: true
         type: string
 
@@ -21,6 +22,7 @@ on:
         required: true
         type: string
       package-type:
+        description: "One of: [cpp, python]"
         required: false
         default: python
         type: string

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -14,11 +14,7 @@ on:
         type: string
       build_type:
         required: true
-        type: choice
-        options:
-          - branch
-          - nightly
-          - pull-request
+        type: string
 
       # general settings
       package-name:
@@ -26,11 +22,8 @@ on:
         type: string
       package-type:
         required: false
-        type: choice
-        options:
-          - cpp
-          - python
         default: python
+        type: string
       publish_to_pypi:
         required: false
         type: boolean

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -14,7 +14,11 @@ on:
         type: string
       build_type:
         required: true
-        type: string
+        type: choice
+        options:
+          - branch
+          - nightly
+          - pull-request
 
       # general settings
       package-name:
@@ -22,8 +26,11 @@ on:
         type: string
       package-type:
         required: false
+        type: choice
+        options:
+          - cpp
+          - python
         default: python
-        type: string
       publish_to_pypi:
         required: false
         type: boolean

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -13,21 +13,14 @@ on:
       sha:
         type: string
       build_type:
+        description: "One of: [branch, nightly, pull-request]"
         required: true
-        type: choice
-        options:
-          - branch
-          - nightly
-          - pull-request
+        type: string
       matrix_type:
-        required: true
-        type: choice
-        options:
-          # "auto" = choose a value based on what's provided via 'build_type'
-          - auto
-          - nightly
-          - pull-request
-        default: auto
+        description: "One of: [auto, nightly, pull-request]. 'auto' means 'choose a value based on what's provided via build_type'."
+        required: false
+        type: string
+        default: "auto"
       script:
         type: string
         default: "ci/test_wheel.sh"
@@ -76,6 +69,16 @@ jobs:
     outputs:
       MATRIX: ${{ steps.compute-matrix.outputs.MATRIX }}
     steps:
+      - name: Validate Inputs
+        run: |
+          if [[ "$BUILD_TYPE" != "branch" ]] && [[ "$BUILD_TYPE" != "nightly" ]] && [[ "$BUILD_TYPE" != "pull-request" ]]; then
+              echo "Invalid build_type! Must be one of 'branch', 'nightly', or 'pull-request'."
+              exit 1
+          fi
+          if [[ "$MATRIX_TYPE" != "auto" ]] && [[ "$MATRIX_TYPE" != "nightly" ]] && [[ "$MATRIX_TYPE" != "pull-request" ]]; then
+              echo "Invalid matrix_type! Must be one of 'auto', 'nightly', or 'pull-request'."
+              exit 1
+          fi
       - name: Compute test matrix
         id: compute-matrix
         run: |

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -110,10 +110,11 @@ jobs:
 
           # only overwrite MATRIX_TYPE if it was set to 'auto'
           if [[ "${MATRIX_TYPE}" == "auto" ]]; then
-            MATRIX_TYPE="${BUILD_TYPE}"
-            # Use the nightly matrix for branch tests
             if [[ "${BUILD_TYPE}" == "branch" ]]; then
+              # Use the nightly matrix for branch tests
               MATRIX_TYPE="nightly"
+            else
+              MATRIX_TYPE="${BUILD_TYPE}"
             fi
           fi
           export MATRIX_TYPE

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -14,7 +14,20 @@ on:
         type: string
       build_type:
         required: true
-        type: string
+        type: choice
+        options:
+          - branch
+          - nightly
+          - pull-request
+      matrix_type:
+        required: true
+        type: choice
+        options:
+          # "auto" = choose a value based on what's provided via 'build_type'
+          - auto
+          - nightly
+          - pull-request
+        default: auto
       script:
         type: string
         default: "ci/test_wheel.sh"
@@ -59,15 +72,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BUILD_TYPE: ${{ inputs.build_type }}
+      MATRIX_TYPE: ${{ inputs.matrix_type }}
     outputs:
       MATRIX: ${{ steps.compute-matrix.outputs.MATRIX }}
     steps:
-      - name: Validate test type
-        run: |
-          if [[ "$BUILD_TYPE" != "pull-request" ]] && [[ "$BUILD_TYPE" != "nightly" ]] && [[ "$BUILD_TYPE" != "branch" ]]; then
-              echo "Invalid build type! Must be one of 'nightly', 'pull-request', or 'branch'."
-              exit 1
-          fi
       - name: Compute test matrix
         id: compute-matrix
         run: |
@@ -95,10 +103,13 @@ jobs:
               - { ARCH: 'arm64', PY_VER: '3.12', CUDA_VER: '12.8.0', LINUX_VER: 'ubuntu24.04', GPU: 'a100', DRIVER: 'latest',   DEPENDENCIES: 'latest' }
           "
 
-          # Use the nightly matrix for branch tests
-          MATRIX_TYPE="${BUILD_TYPE}"
-          if [[ "${MATRIX_TYPE}" == "branch" ]]; then
-            MATRIX_TYPE="nightly"
+          # only overwrite MATRIX_TYPE if it was set to 'auto'
+          if [[ "${MATRIX_TYPE}" == "auto" ]]; then
+            MATRIX_TYPE="${BUILD_TYPE}"
+            # Use the nightly matrix for branch tests
+            if [[ "${BUILD_TYPE}" == "branch" ]]; then
+              MATRIX_TYPE="nightly"
+            fi
           fi
           export MATRIX_TYPE
           TEST_MATRIX=$(yq -n 'env(MATRICES) | .[strenv(MATRIX_TYPE)]')


### PR DESCRIPTION
Closes https://github.com/rapidsai/build-planning/issues/158

Today, the matrix (combinations of job variants) for testing workflows is determined by the "`build_type`" (one of "branch", "nightly", or "pull-request").

This proposes:

* making the matrix selection configurable
  - *so you could for example achieve behavior like "run the nightly test matrix in PR CI"*
* adding descriptions on the enum-like inputs, listing the valid values
* expanding input validation
  - *to ensure unexpected values result in an immediate, clear, loud error*

## Notes for Reviewers

### How I tested this

See the comments on this PR I used to test: https://github.com/rapidsai/rmm/pull/1865