### PR TITLE
make `RAPIDS_AUX_SECRET_1` be an input variable secret name, not the secret itself

### DIFF
--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -30,11 +30,11 @@ on:
         required: false
         type: string
         default: ''
-    # the use of secrets in shared-workflows is discouraged, especially for public repositories.
-    # these values were added for situations where the use of secrets is unavoidable.
-    secrets:
-      RAPIDS_AUX_SECRET_1:
+      # Note that this is the _name_ of a secret containing the key, not the key itself.
+      rapids-aux-secret-1:
         required: false
+        type: string
+        default: ''
 
 permissions:
   actions: read
@@ -115,7 +115,7 @@ jobs:
             AWS_ACCESS_KEY_ID=${{ env.AWS_ACCESS_KEY_ID }}
             AWS_SESSION_TOKEN=${{ env.AWS_SESSION_TOKEN }}
             AWS_SECRET_ACCESS_KEY=${{ env.AWS_SECRET_ACCESS_KEY }}
-            RAPIDS_AUX_SECRET_1=${{ secrets.RAPIDS_AUX_SECRET_1 }}
+            RAPIDS_AUX_SECRET_1=${{ inputs.rapids-aux-secret-1 != '' && secrets[inputs.rapids-aux-secret-1] || '' }}
             TRACEPARENT=${{ env.TRACEPARENT }}
             OTEL_SERVICE_NAME=${{ env.OTEL_SERVICE_NAME }}
             OTEL_EXPORTER_OTLP_ENDPOINT=${{ env.OTEL_EXPORTER_OTLP_ENDPOINT }}

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -35,11 +35,11 @@ on:
         required: false
         type: string
         default: "fail"
-    # the use of secrets in shared-workflows is discouraged, especially for public repositories.
-    # these values were added for situations where the use of secrets is unavoidable.
-    secrets:
-      RAPIDS_AUX_SECRET_1:
+      # Note that this is the _name_ of a secret containing the key, not the key itself.
+      rapids-aux-secret-1:
         required: false
+        type: string
+        default: ''
 
 defaults:
   run:
@@ -186,7 +186,7 @@ jobs:
       run: ${{ inputs.script }}
       env:
         GH_TOKEN: ${{ github.token }}
-        RAPIDS_AUX_SECRET_1: ${{ secrets.RAPIDS_AUX_SECRET_1 }}
+        RAPIDS_AUX_SECRET_1: ${{ inputs.rapids-aux-secret-1 != '' && secrets[inputs.rapids-aux-secret-1] || '' }}
 
     - name: Generate test report
       uses: test-summary/action@v2.4


### PR DESCRIPTION
Switches the `RAPIDS_AUX_SECRET_1` value to an input of a secret name, then defines the `RAPIDS_AUX_SECRET_1` envvar from the `secrets` context to align with the way we're passing in other secrets.

Without this change, it isn't possible for a calling workflow to define both `inputs.extra-repo-deploy-key` and `secrets.RAPIDS_AUX_SECRET_1` -- the caller has to choose either:
1. `{ secrets: inherit, with: { extra-repo-deploy-key: 'KEY_NAME' } }`, or
2. `{ secrets: { RAPIDS_AUX_SECRET_1: ${{ secrets.SECRET }} } }`

In the second case, the shared workflow's `secrets` context only contains `RAPIDS_AUX_SECRET_1`, not `KEY_NAME`, because we had to pass it instead of `secrets: inherit`.
