### PR TITLE
Optional Input for CUDA suffix in wheel name

### DIFF
--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -29,7 +29,7 @@ on:
         required: false
         type: boolean
         default: false
-      append-cuda-version:
+      append-cuda-suffix:
         required: false
         type: boolean
         default: true
@@ -197,6 +197,7 @@ jobs:
           PACKAGE_TYPE: ${{ inputs.package-type }}
           WHEEL_NAME: ${{ inputs.wheel-name }}
           PURE_WHEEL: ${{ inputs.pure-wheel }}
+          APPEND_CUDA_SUFFIX: ${{ inputs.append-cuda-suffix }}
         run: |
           if [ -z "${WHEEL_NAME}" ]; then
             WHEEL_NAME="${RAPIDS_REPOSITORY#*/}"

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -29,6 +29,10 @@ on:
         required: false
         type: boolean
         default: false
+      append-cuda-version:
+        required: false
+        type: boolean
+        default: true
 
       # allow a bigger runner instance
       node_type:
@@ -198,7 +202,11 @@ jobs:
             WHEEL_NAME="${RAPIDS_REPOSITORY#*/}"
           fi
           export "RAPIDS_PY_CUDA_SUFFIX=$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
-          export "RAPIDS_PY_WHEEL_NAME=${WHEEL_NAME}_${RAPIDS_PY_CUDA_SUFFIX}"
+          if [ "${APPEND_CUDA_SUFFIX}" = "true" ]; then
+            export "RAPIDS_PY_WHEEL_NAME=${WHEEL_NAME}_${RAPIDS_PY_CUDA_SUFFIX}"
+          else
+            export "RAPIDS_PY_WHEEL_NAME=${WHEEL_NAME}"
+          fi
           if [ "${PURE_WHEEL}" = "true" ]; then
             export "RAPIDS_PY_WHEEL_PURE=1"
           fi


### PR DESCRIPTION
Added an optional input for the CUDA version included in the wheel name, allowing `dask-cuda`, `rapids-dask-dependency` and `cuopt` repositories to upload wheels without the cuda suffix for non-cuda wheels