### PR TITLE
[WIP] Add token for private repo Github access

### DIFF
--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -22,10 +22,9 @@ on:
       matrix_filter:
         type: string
         default: "."
-      use-private-token:
+      artifact-token-name:
         required: false
-        type: boolean
-        default: false
+        type: string
 
 defaults:
   run:
@@ -127,7 +126,8 @@ jobs:
         run: ${{ inputs.script }}
         env:
           STEP_NAME: "C++ build"
-          GH_TOKEN: ${{ inputs.use-private-token && secrets.PRIVATE_GH_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_TOKEN: ${{ secrets[inputs.artifact-token-name] }}
       - name: Get Package Name and Location
         run: | 
           echo "RAPIDS_PACKAGE_NAME=$(RAPIDS_NO_PKG_EXTENSION=true rapids-package-name conda_cpp)" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -22,6 +22,10 @@ on:
       matrix_filter:
         type: string
         default: "."
+      use-private-token:
+        required: false
+        type: boolean
+        default: false
 
 defaults:
   run:
@@ -123,7 +127,7 @@ jobs:
         run: ${{ inputs.script }}
         env:
           STEP_NAME: "C++ build"
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ inputs.use-private-token && secrets.PRIVATE_GH_TOKEN || github.token }}
       - name: Get Package Name and Location
         run: | 
           echo "RAPIDS_PACKAGE_NAME=$(RAPIDS_NO_PKG_EXTENSION=true rapids-package-name conda_cpp)" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -28,10 +28,9 @@ on:
         required: false
         type: string
         default: "-e _NOOP"
-      use-private-token:
+      artifact-token-name:
         required: false
-        type: boolean
-        default: false
+        type: string
 
 defaults:
   run:
@@ -172,7 +171,8 @@ jobs:
       - name: C++ tests
         run: ${{ inputs.script }}
         env:
-          GH_TOKEN: ${{ inputs.use-private-token && secrets.PRIVATE_GH_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_TOKEN: ${{ secrets[inputs.artifact-token-name] }}
       - name: Generate test report
         uses: test-summary/action@v2.4
         with:

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -28,6 +28,10 @@ on:
         required: false
         type: string
         default: "-e _NOOP"
+      use-private-token:
+        required: false
+        type: boolean
+        default: false
 
 defaults:
   run:
@@ -170,7 +174,7 @@ jobs:
       - name: C++ tests
         run: ${{ inputs.script }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ inputs.use-private-token && secrets.PRIVATE_GH_TOKEN || github.token }}
       - name: Generate test report
         uses: test-summary/action@v2.4
         with:

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -22,6 +22,10 @@ on:
       matrix_filter:
         type: string
         default: "."
+      use-private-token:
+        required: false
+        type: boolean
+        default: false
 
 defaults:
   run:
@@ -123,7 +127,7 @@ jobs:
       - name: Python build
         run: ${{ inputs.script }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ inputs.use-private-token && secrets.PRIVATE_GH_TOKEN || github.token }}
       - name: Get Package Name and Location
         run: | 
           echo "RAPIDS_PACKAGE_NAME=$(RAPIDS_NO_PKG_EXTENSION=true rapids-package-name conda_python)" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -22,10 +22,9 @@ on:
       matrix_filter:
         type: string
         default: "."
-      use-private-token:
+      artifact-token-name:
         required: false
-        type: boolean
-        default: false
+        type: string
 
 defaults:
   run:
@@ -127,7 +126,8 @@ jobs:
       - name: Python build
         run: ${{ inputs.script }}
         env:
-          GH_TOKEN: ${{ inputs.use-private-token && secrets.PRIVATE_GH_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_TOKEN: ${{ secrets[inputs.artifact-token-name] }}
       - name: Get Package Name and Location
         run: | 
           echo "RAPIDS_PACKAGE_NAME=$(RAPIDS_NO_PKG_EXTENSION=true rapids-package-name conda_python)" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -31,6 +31,10 @@ on:
         required: false
         type: string
         default: "-e _NOOP"
+      use-private-token:
+        required: false
+        type: boolean
+        default: false
 
 defaults:
   run:
@@ -176,7 +180,7 @@ jobs:
       - name: Python tests
         run: ${{ inputs.script }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ inputs.use-private-token && secrets.PRIVATE_GH_TOKEN || github.token }}
       - name: Generate test report
         uses: test-summary/action@v2.4
         with:

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -31,10 +31,9 @@ on:
         required: false
         type: string
         default: "-e _NOOP"
-      use-private-token:
+      artifact-token-name:
         required: false
-        type: boolean
-        default: false
+        type: string
 
 defaults:
   run:
@@ -178,7 +177,8 @@ jobs:
       - name: Python tests
         run: ${{ inputs.script }}
         env:
-          GH_TOKEN: ${{ inputs.use-private-token && secrets.PRIVATE_GH_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_TOKEN: ${{ secrets[inputs.artifact-token-name] }}
       - name: Generate test report
         uses: test-summary/action@v2.4
         with:

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -32,6 +32,10 @@ on:
         type: boolean
         required: false
         default: false
+      use-private-token:
+        required: false
+        type: boolean
+        default: false
 
 defaults:
   run:
@@ -96,7 +100,7 @@ jobs:
       - name: Run script
         run: ${{ inputs.run_script }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ inputs.use-private-token && secrets.PRIVATE_GH_TOKEN || github.token }}
       - name: Upload file to GitHub Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -32,10 +32,9 @@ on:
         type: boolean
         required: false
         default: false
-      use-private-token:
+      artifact-token-name:
         required: false
-        type: boolean
-        default: false
+        type: string
 
 defaults:
   run:
@@ -100,7 +99,8 @@ jobs:
       - name: Run script
         run: ${{ inputs.run_script }}
         env:
-          GH_TOKEN: ${{ inputs.use-private-token && secrets.PRIVATE_GH_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_TOKEN: ${{ secrets[inputs.artifact-token-name] }}
       - name: Upload file to GitHub Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -22,9 +22,9 @@ jobs:
           NEEDS: ${{ inputs.needs }}
           ERROR_MSG: "PR validation failed: Private token access is not allowed to be merged onto the development branch"
         run: |
-          if jq -en 'env.NEEDS | fromjson | to_entries[] | select(.value.inputs?.use_private_token == true) | length > 0'; then
+          if jq -en 'env.NEEDS | fromjson | to_entries[] | select(.value.inputs.artifact_token_name and .value.inputs.artifact_token_name != "") | length > 0'; then
             echo "::error::$ERROR_MSG"
             echo "Jobs using private token:"
-            jq -en 'env.NEEDS | fromjson | to_entries[] | select(.value.inputs?.use_private_token == true) | "- " + .key'
+            jq -en 'env.NEEDS | fromjson | to_entries[] | select(.value.inputs.artifact_token_name and .value.inputs.artifact_token_name != "") | "- " + .key'
             exit 1
           fi

--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -10,6 +10,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
+      # This reusable workflow should depend on all other jobs in the calling workflow.
       - name: "Check all dependent jobs"
         env:
           NEEDS: ${{ inputs.needs }}

--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -10,8 +10,20 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-      # This reusable workflow should depend on all other jobs in the calling workflow.
       - name: "Check all dependent jobs"
         env:
           NEEDS: ${{ inputs.needs }}
         run: jq -en 'env.NEEDS | fromjson | all(.result as $result | ["success", "skipped"] | any($result == .))'
+      
+      - name: "Check for private token usage"
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          NEEDS: ${{ inputs.needs }}
+          ERROR_MSG: "PR validation failed: Private token access is not allowed to be merged onto the development branch"
+        run: |
+          if jq -en 'env.NEEDS | fromjson | to_entries[] | select(.value.inputs?.use_private_token == true) | length > 0'; then
+            echo "::error::$ERROR_MSG"
+            echo "Jobs using private token:"
+            jq -en 'env.NEEDS | fromjson | to_entries[] | select(.value.inputs?.use_private_token == true) | "- " + .key'
+            exit 1
+          fi

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -59,10 +59,9 @@ on:
         required: false
         type: string
         default: ''
-      use-private-token:
+      artifact-token-name:
         required: false
-        type: boolean
-        default: false
+        type: string
 
 defaults:
   run:
@@ -191,7 +190,8 @@ jobs:
         run: |
           ${{ inputs.script }}
         env:
-          GH_TOKEN: ${{ inputs.use-private-token && secrets.PRIVATE_GH_TOKEN || github.token }}
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_TOKEN: ${{ secrets[inputs.artifact-token-name] }}
         # Use a shell that loads the rc file so that we get the compiler settings
         shell: bash -leo pipefail {0}
 

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -59,6 +59,10 @@ on:
         required: false
         type: string
         default: ''
+      use-private-token:
+        required: false
+        type: boolean
+        default: false
 
 defaults:
   run:
@@ -187,7 +191,7 @@ jobs:
         run: |
           ${{ inputs.script }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ inputs.use-private-token && secrets.PRIVATE_GH_TOKEN || github.token }}
         # Use a shell that loads the rc file so that we get the compiler settings
         shell: bash -leo pipefail {0}
 

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -35,10 +35,9 @@ on:
         required: false
         type: string
         default: "fail"
-      use-private-token:
+      artifact-token-name:
         required: false
-        type: boolean
-        default: false
+        type: string
     # the use of secrets in shared-workflows is discouraged, especially for public repositories.
     # these values were added for situations where the use of secrets is unavoidable.
     secrets:
@@ -187,7 +186,8 @@ jobs:
     - name: Run tests
       run: ${{ inputs.script }}
       env:
-        GH_TOKEN: ${{ inputs.use-private-token && secrets.PRIVATE_GH_TOKEN || github.token }}
+        GH_TOKEN: ${{ github.token }}
+        ARTIFACT_TOKEN: ${{ secrets[inputs.artifact-token-name] }}
         RAPIDS_AUX_SECRET_1: ${{ secrets.RAPIDS_AUX_SECRET_1 }}
 
     - name: Generate test report

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -35,6 +35,10 @@ on:
         required: false
         type: string
         default: "fail"
+      use-private-token:
+        required: false
+        type: boolean
+        default: false
     # the use of secrets in shared-workflows is discouraged, especially for public repositories.
     # these values were added for situations where the use of secrets is unavoidable.
     secrets:
@@ -185,7 +189,7 @@ jobs:
     - name: Run tests
       run: ${{ inputs.script }}
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ inputs.use-private-token && secrets.PRIVATE_GH_TOKEN || github.token }}
         RAPIDS_AUX_SECRET_1: ${{ secrets.RAPIDS_AUX_SECRET_1 }}
 
     - name: Generate test report


### PR DESCRIPTION
This PR adds functionality to control and validate the use of private GitHub tokens to download build artifacts from private repositories. It also includes changes to pr-builder to prevent PRs from being merged if they use the token to download artifacts from private repositories

## Implementation Details
- Each workflow now accepts an optional string input `artifact-token-name` (defaults to empty string)
- When set, the workflow uses the specified secret name to access private repositories instead of default `github.token`
  - The secret should be set on the repository calling the shared-workflows file
  - Usually inherited from the pr.yaml repository of the caller repository
- Token fallback mechanism using `${ARTIFACT_TOKEN:-$GH_TOKEN}` ensures default token is used when no custom token is provided
- The pr-builder workflow inspects all jobs' inputs to detect private token usage
- PRs using private tokens (indicated by setting `artifact-token-name`) will fail with the message: "PR validation failed: Private token access is not allowed to be merged onto the development branch"

