### PR TITLE
Enable proxy cache on NVKS V100 nodes.

### DIFF
--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -164,8 +164,6 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         continue-on-error: true
-        # Skip the cache on RDS Lab nodes
-        if: ${{ matrix.GPU != 'v100' }}
 
       - name: C++ tests
         run: ${{ inputs.script }}

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -170,8 +170,6 @@ jobs:
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         continue-on-error: true
-        # Skip the cache on RDS Lab nodes
-        if: ${{ matrix.GPU != 'v100' }}
 
       - name: Python tests
         run: ${{ inputs.script }}

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -179,8 +179,6 @@ jobs:
     - name: Setup proxy cache
       uses: nv-gha-runners/setup-proxy-cache@main
       continue-on-error: true
-      # Skip the cache on RDS Lab nodes
-      if: ${{ matrix.GPU != 'v100' }}
 
     - name: Run tests
       run: ${{ inputs.script }}


### PR DESCRIPTION
NVKS is migrating V100 nodes. Once this is complete, we can add proxy cache support to V100 jobs.
