### PR TITLE
Add pipefail to devcontainer builds.

### DIFF
--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -122,7 +122,7 @@ jobs:
             OTEL_EXPORTER_OTLP_PROTOCOL=${{ env.OTEL_EXPORTER_OTLP_PROTOCOL }}
             OTEL_RESOURCE_ATTRIBUTES=${{ env.OTEL_RESOURCE_ATTRIBUTES }}
           runCmd: |
-            set -e;
+            set -euo pipefail;
             mkdir -p ~/.config/pip/;
             cat <<EOF >> ~/.config/pip/pip.conf
             [global]


### PR DESCRIPTION
I saw that CMake errors in devcontainer build jobs weren't working because some logs were being piped for telemetry reasons. This adds `-u` and `-o pipefail` to align with the usual set of flags that we enable in CI jobs.

xref: https://github.com/rapidsai/rmm/actions/runs/14454832919/job/40535620748?pr=1883#step:9:674
