### PR TITLE
add mkdir -p to devcontainer setup

### DIFF
--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Check if repo has devcontainer
         run: |
-          echo "REPOSITORY=$(basename $(pwd))" | tee -a "${GITHUB_ENV}";
+          echo "REPOSITORY=$(basename "$(pwd)")" | tee -a "${GITHUB_ENV}";
           if test -f .devcontainer/cuda${{ matrix.CUDA_VER }}-${{ matrix.PACKAGER }}/devcontainer.json; then
             echo "HAS_DEVCONTAINER=true" >> "${GITHUB_ENV}";
           else
@@ -144,6 +144,7 @@ jobs:
             fi
 
             cd ~/"${REPOSITORY}";
+            mkdir -p telemetry-artifacts;
             ${{ inputs.build_command }}
       - name: Telemetry upload attributes
         uses: rapidsai/shared-actions/telemetry-dispatch-stash-job-artifacts@main


### PR DESCRIPTION
Lots of devcontainers jobs have been silently failing because this folder did not exist. We never properly set up devcontainers for telemetry. In https://github.com/rapidsai/rmm/pull/1883, @bdice had recently set bash error behavior flags, adding pipefail. That made this silent failure into a cryptic, blocking error.

This is set here and not in `rapids-telemetry-record` because we do not have gha-tools at this point.