### PR TITLE
Use the variable `package-name` for Distribution name in wheel builds

### DIFF
--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -19,6 +19,10 @@ on:
       script:
         required: true
         type: string
+      package-name:
+        required: false
+        type: string
+        description: "Distribution name, without any other qualifiers (e.g. 'pylibcudf', not 'pylibcudf-cu12-cp311-manylinux_2_24_aarch64')"
       package-type:
         description: "One of: [cpp, python]"
         required: false
@@ -26,7 +30,7 @@ on:
       wheel-name:
         required: false
         type: string
-        description: "Distribution name, without any other qualifiers (e.g. 'pylibcudf', not 'pylibcudf-cu12-cp311-manylinux_2_24_aarch64')"
+        description: "DEPRECATED: Use package-name instead"
       pure-wheel:
         required: false
         type: boolean
@@ -199,7 +203,7 @@ jobs:
         if: inputs.package-type != ''
         env:
           PACKAGE_TYPE: ${{ inputs.package-type }}
-          WHEEL_NAME: ${{ inputs.wheel-name }}
+          WHEEL_NAME: ${{ inputs.package-name != '' && inputs.package-name || inputs.wheel-name }}
           PURE_WHEEL: ${{ inputs.pure-wheel }}
           APPEND_CUDA_SUFFIX: ${{ inputs.append-cuda-suffix }}
         run: |


### PR DESCRIPTION
Currently for wheel builds, we are using the variable `wheel-name` in `wheels-build.yaml` but other workflows like `wheel-publish.yaml` use the variable `package-name` for the exact same purpose.

This PR introduces a backward-compatible change to use `package-name` in the place of `wheel-name` for uniformity across different workflows. 