### PR TITLE
Add 'build_workflow_name' input, to allow overriding where scripts look for artifacts

### DIFF
--- a/.github/workflows/conda-cpp-post-build-checks.yaml
+++ b/.github/workflows/conda-cpp-post-build-checks.yaml
@@ -71,7 +71,7 @@ jobs:
           echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
       - name: Download conda C++ build artifacts
         run: |
-          CPP_DIR=$(rapids-download-conda-from-s3 cpp)
+          CPP_DIR=$(rapids-download-conda-from-github cpp)
           EXTRACTED_DIR=$(rapids-extract-conda-files "${CPP_DIR}")
           echo "RAPIDS_EXTRACTED_DIR=${EXTRACTED_DIR}" >> "${GITHUB_ENV}"
       - name: Get weak detection tool

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -28,8 +28,8 @@ on:
         required: false
         type: string
         default: "-e _NOOP"
-      nightly_build_repo:
-        description: 'Custom workflow file name (other than build.yaml) to download artifacts from for nightly tests'
+      build_workflow_name:
+        description: 'Custom workflow file name (defaults to build.yaml) to download artifacts from for tests'
         required: false
         type: string
 
@@ -166,7 +166,7 @@ jobs:
           branch: ${{ inputs.branch }}
           date: ${{ inputs.date }}
           sha: ${{ inputs.sha }}
-          nightly_build_repo: ${{ inputs.nightly_build_repo }}
+          build_workflow_name: ${{ inputs.build_workflow_name }}
 
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -28,6 +28,10 @@ on:
         required: false
         type: string
         default: "-e _NOOP"
+      nightly_build_repo:
+        description: 'Custom workflow file name (other than build.yaml) to download artifacts from for nightly tests'
+        required: false
+        type: string
 
 defaults:
   run:
@@ -154,12 +158,15 @@ jobs:
         if: ${{ vars.TELEMETRY_ENABLED == 'true' && github.run_attempt == '1'}}
         with:
           extra_attributes: "rapids.PACKAGER=conda,rapids.CUDA_VER=${{ matrix.CUDA_VER }},rapids.PY_VER=${{ matrix.PY_VER }},rapids.ARCH=${{ matrix.ARCH }},rapids.LINUX_VER=${{ matrix.LINUX_VER }},rapids.GPU=${{ matrix.GPU }},rapids.DRIVER=${{ matrix.DRIVER }},rapids.DEPENDENCIES=${{ matrix.DEPENDENCIES }}"
+
       - name: Standardize repository information
-        run: |
-          echo "RAPIDS_REPOSITORY=${{ inputs.repo || github.repository }}" >> "${GITHUB_ENV}"
-          echo "RAPIDS_SHA=$(git rev-parse HEAD)" >> "${GITHUB_ENV}"
-          echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" >> "${GITHUB_ENV}"
-          echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
+        uses: rapidsai/shared-actions/rapids-github-info@main
+        with:
+          repo: ${{ inputs.repo }}
+          branch: ${{ inputs.branch }}
+          date: ${{ inputs.date }}
+          sha: ${{ inputs.sha }}
+          nightly_build_repo: ${{ inputs.nightly_build_repo }}
 
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -30,7 +30,9 @@ on:
         type: string
         default: "-e _NOOP"
       build_workflow_name:
-        description: 'Custom workflow file name (defaults to build.yaml) to download artifacts from for tests'
+        description: |
+          Name of a workflow file that produced artifacts to be downloaded in this run.
+          If not set (the default), artifact-handling scripts use RAPIDS-conventional defaults (like "build.yaml" when "build_type == nightly").
         required: false
         type: string
 

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -31,8 +31,8 @@ on:
         required: false
         type: string
         default: "-e _NOOP"
-      nightly_build_repo:
-        description: 'Custom workflow file name (other than build.yaml) to download artifacts from for nightly tests'
+      build_workflow_name:
+        description: 'Custom workflow file name (defaults to build.yaml) to download artifacts from for tests'
         required: false
         type: string
 
@@ -162,7 +162,7 @@ jobs:
           branch: ${{ inputs.branch }}
           date: ${{ inputs.date }}
           sha: ${{ inputs.sha }}
-          nightly_build_repo: ${{ inputs.nightly_build_repo }}
+          build_workflow_name: ${{ inputs.build_workflow_name }}
 
       # This has to be AFTER the checkout step. It creates a telemetry-artifacts directory,
       # and the checkout step would destroy it.

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -33,7 +33,9 @@ on:
         type: string
         default: "-e _NOOP"
       build_workflow_name:
-        description: 'Custom workflow file name (defaults to build.yaml) to download artifacts from for tests'
+        description: |
+          Name of a workflow file that produced artifacts to be downloaded in this run.
+          If not set (the default), artifact-handling scripts use RAPIDS-conventional defaults (like "build.yaml" when "build_type == nightly").
         required: false
         type: string
 

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -31,6 +31,10 @@ on:
         required: false
         type: string
         default: "-e _NOOP"
+      nightly_build_repo:
+        description: 'Custom workflow file name (other than build.yaml) to download artifacts from for nightly tests'
+        required: false
+        type: string
 
 defaults:
   run:
@@ -152,11 +156,13 @@ jobs:
           fetch-depth: 0
 
       - name: Standardize repository information
-        run: |
-          echo "RAPIDS_REPOSITORY=${{ inputs.repo || github.repository }}" >> "${GITHUB_ENV}"
-          echo "RAPIDS_SHA=$(git rev-parse HEAD)" >> "${GITHUB_ENV}"
-          echo "RAPIDS_REF_NAME=${{ inputs.branch || github.ref_name }}" >> "${GITHUB_ENV}"
-          echo "RAPIDS_NIGHTLY_DATE=${{ inputs.date }}" >> "${GITHUB_ENV}"
+        uses: rapidsai/shared-actions/rapids-github-info@main
+        with:
+          repo: ${{ inputs.repo }}
+          branch: ${{ inputs.branch }}
+          date: ${{ inputs.date }}
+          sha: ${{ inputs.sha }}
+          nightly_build_repo: ${{ inputs.nightly_build_repo }}
 
       # This has to be AFTER the checkout step. It creates a telemetry-artifacts directory,
       # and the checkout step would destroy it.

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -33,6 +33,12 @@ on:
         type: boolean
         required: false
         default: false
+      build_workflow_name:
+        description: |
+          Name of a workflow file that produced artifacts to be downloaded in this run.
+          If not set (the default), artifact-handling scripts use RAPIDS-conventional defaults (like "build.yaml" when "build_type == nightly").
+        required: false
+        type: string
 
 defaults:
   run:
@@ -88,17 +94,13 @@ jobs:
         run: |
           echo "RAPIDS_BASE_BRANCH=${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}" >> "${GITHUB_ENV}"
       - name: Standardize repository information
-        env:
-          RAPIDS_REPOSITORY: ${{ inputs.repo || github.repository }}
-          RAPIDS_REF_NAME: ${{ inputs.branch || github.ref_name }}
-          RAPIDS_NIGHTLY_DATE: ${{ inputs.date }}
-        run: |
-          {
-            echo "RAPIDS_REPOSITORY=${RAPIDS_REPOSITORY}"
-            echo "RAPIDS_SHA=$(git rev-parse HEAD)"
-            echo "RAPIDS_REF_NAME=${RAPIDS_REF_NAME}"
-            echo "RAPIDS_NIGHTLY_DATE=${RAPIDS_NIGHTLY_DATE}"
-          } >> "${GITHUB_ENV}"
+        uses: rapidsai/shared-actions/rapids-github-info@main
+        with:
+          repo: ${{ inputs.repo }}
+          branch: ${{ inputs.branch }}
+          date: ${{ inputs.date }}
+          sha: ${{ inputs.sha }}
+          build_workflow_name: ${{ inputs.build_workflow_name }}
       # Per the docs at https://docs.github.com/en/rest/rate-limit/rate-limit?apiVersion=2022-11-28#get-rate-limit-status-for-the-authenticated-user,
       # checking '/rate_limit | jq .' should not itself count against any rate limits.
       - name: Check GitHub API rate limits

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -42,7 +42,9 @@ on:
         type: string
         default: ''
       build_workflow_name:
-        description: 'Custom workflow file name (defaults to build.yaml) to download artifacts from for tests'
+        description: |
+          Name of a workflow file that produced artifacts to be downloaded in this run.
+          If not set (the default), artifact-handling scripts use RAPIDS-conventional defaults (like "build.yaml" when "build_type == nightly").
         required: false
         type: string
 

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -40,6 +40,10 @@ on:
         required: false
         type: string
         default: ''
+      nightly_build_repo:
+        description: 'Custom workflow file name (other than build.yaml) to download artifacts from for nightly tests'
+        required: false
+        type: string
 
 defaults:
   run:
@@ -175,6 +179,7 @@ jobs:
         branch: ${{ inputs.branch }}
         date: ${{ inputs.date }}
         sha: ${{ inputs.sha }}
+        nightly_build_repo: ${{ inputs.nightly_build_repo }}
 
     - name: Setup proxy cache
       uses: nv-gha-runners/setup-proxy-cache@main

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -40,8 +40,8 @@ on:
         required: false
         type: string
         default: ''
-      nightly_build_repo:
-        description: 'Custom workflow file name (other than build.yaml) to download artifacts from for nightly tests'
+      build_workflow_name:
+        description: 'Custom workflow file name (defaults to build.yaml) to download artifacts from for tests'
         required: false
         type: string
 
@@ -179,7 +179,7 @@ jobs:
         branch: ${{ inputs.branch }}
         date: ${{ inputs.date }}
         sha: ${{ inputs.sha }}
-        nightly_build_repo: ${{ inputs.nightly_build_repo }}
+        build_workflow_name: ${{ inputs.build_workflow_name }}
 
     - name: Setup proxy cache
       uses: nv-gha-runners/setup-proxy-cache@main


### PR DESCRIPTION
Uniquely identifying an artifact from the GitHub Actions artifact store requires identifying the workflow run that produced it.

In PR CI, this is trivial because the uploading-artifacts and downloading-artifacts jobs are all running as part of the same workflow.

In other setups though, that isn't true. For example, RAPIDS uses 2 separate nightly workloads:

* `build.yaml` = build packages and publish the package artifacts
* `test.yaml` = pull those artifacts and run tests with them

For this case, in the relevant `gha-tools` scripts we default to assuming that `branch` or `nightly` runs want to pull artifacts from runs of a workflow literally called `build.yaml`:

```shell
run_id=$(
  RAPIDS_RETRY_SLEEP=30 \
    rapids-retry --quiet gh run list \
      ... \
      --workflow "${RAPIDS_BUILD_WORKFLOW_NAME:-build.yaml}" \
      ...
)
```

ref: https://github.com/rapidsai/gha-tools/blob/570fc211e6bf1bfb91098aa1bc4823ef7bb71fc2/tools/rapids-github-run-id#L66

There might be cases in the future where that assumption doesn't hold, and people want to pull artifacts in one workflow run from some other workflow which is NOT called `build.yaml`.

This PR + https://github.com/rapidsai/shared-actions/pull/52 add support for specifying the name of that "some other workflow" as an input, overriding the `build.yaml` default.

For more context, see https://github.com/rapidsai/gha-tools/pull/162#issuecomment-2831561646

## How I tested this

Tested with an `rmm` PR: https://github.com/rapidsai/rmm/pull/1909

* does not break existing repos CI: https://github.com/rapidsai/rmm/pull/1909#issuecomment-2917107512
* correctly threads this input through to the `RAPIDS_BUILD_WORKFLOW_NAME` variable: https://github.com/rapidsai/rmm/pull/1909#issuecomment-2917186610