### PR TITLE
Publish packages from Github Artifact Store

### DIFF
--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -81,6 +81,7 @@ jobs:
         env:
           SKIP_UPLOAD_PKGS: ${{ inputs.skip_upload_pkgs }}
           RAPIDS_CONDA_UPLOAD_LABEL: ${{ inputs.upload_to_label }}
+          GH_TOKEN: ${{ github.token }}
       - name: Telemetry upload attributes
         uses: rapidsai/shared-actions/telemetry-dispatch-stash-job-artifacts@main
         continue-on-error: true

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -77,7 +77,7 @@ jobs:
           fi
           echo "RAPIDS_CONDA_TOKEN=${RAPIDS_CONDA_TOKEN}" >> "${GITHUB_ENV}"
       - name: Upload packages
-        run: rapids-upload-to-anaconda
+        run: rapids-upload-to-anaconda-github
         env:
           SKIP_UPLOAD_PKGS: ${{ inputs.skip_upload_pkgs }}
           RAPIDS_CONDA_UPLOAD_LABEL: ${{ inputs.upload_to_label }}

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -87,7 +87,7 @@ jobs:
         sha: ${{ inputs.sha }}
 
     - name: Download wheels from downloads.rapids.ai and publish to anaconda repository
-      run: rapids-wheels-anaconda "${{ inputs.package-name }}" "${{ inputs.package-type }}"
+      run: rapids-wheels-anaconda-github "${{ inputs.package-name }}" "${{ inputs.package-type }}"
       env:
         RAPIDS_CONDA_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
 

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -90,6 +90,7 @@ jobs:
       run: rapids-wheels-anaconda-github "${{ inputs.package-name }}" "${{ inputs.package-type }}"
       env:
         RAPIDS_CONDA_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
+        GH_TOKEN: ${{ github.token }}
 
     - name: Check if build is release
       id: check_if_release

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -86,7 +86,7 @@ jobs:
         date: ${{ inputs.date }}
         sha: ${{ inputs.sha }}
 
-    - name: Download wheels from downloads.rapids.ai and publish to anaconda repository
+    - name: Download wheels from Github Artifacts and publish to anaconda repository
       run: rapids-wheels-anaconda-github "${{ inputs.package-name }}" "${{ inputs.package-type }}"
       env:
         RAPIDS_CONDA_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}


### PR DESCRIPTION
Uses the new wheel and conda package publishing scripts (https://github.com/rapidsai/gha-tools/pull/159) to upload packages from Github Artifact Store to Anaconda and Pypi instead of using packages from `downloads.rapids.ai` 

These changes are part of switching over artifact storage from S3 to Github (https://github.com/rapidsai/build-infra/issues/237)

A test run on `rmm` has already been made for these changes: https://github.com/rapidsai/rmm/actions/runs/14653762244

