### PR TITLE
Remove deprecated wheel-name variable and make inputs required

### DIFF
--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -27,10 +27,6 @@ on:
         description: "One of: [cpp, python]"
         required: false
         type: string
-      wheel-name:
-        required: false
-        type: string
-        description: "DEPRECATED: Use package-name instead"
       pure-wheel:
         required: false
         type: boolean
@@ -203,7 +199,7 @@ jobs:
         if: inputs.package-type != ''
         env:
           PACKAGE_TYPE: ${{ inputs.package-type }}
-          WHEEL_NAME: ${{ inputs.package-name != '' && inputs.package-name || inputs.wheel-name }}
+          WHEEL_NAME: ${{ inputs.package-name }}
           PURE_WHEEL: ${{ inputs.pure-wheel }}
           APPEND_CUDA_SUFFIX: ${{ inputs.append-cuda-suffix }}
         run: |

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -20,12 +20,12 @@ on:
         required: true
         type: string
       package-name:
-        required: false
+        required: true
         type: string
         description: "Distribution name, without any other qualifiers (e.g. 'pylibcudf', not 'pylibcudf-cu12-cp311-manylinux_2_24_aarch64')"
       package-type:
         description: "One of: [cpp, python]"
-        required: false
+        required: true
         type: string
       pure-wheel:
         required: false
@@ -196,7 +196,6 @@ jobs:
         shell: bash -leo pipefail {0}
 
       - name: Get package name
-        if: inputs.package-type != ''
         env:
           PACKAGE_TYPE: ${{ inputs.package-type }}
           WHEEL_NAME: ${{ inputs.package-name }}
@@ -220,13 +219,11 @@ jobs:
         id: package-name
 
       - name: Show files to be uploaded
-        if: inputs.package-type != ''
         run: |
           echo "Contents of directory to be uploaded:"
           ls -R ${{ steps.package-name.outputs.WHEEL_OUTPUT_DIR }}
       
       - uses: actions/upload-artifact@v4
-        if: inputs.package-type != ''
         with:
           name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
           path: ${{ steps.package-name.outputs.WHEEL_OUTPUT_DIR }}


### PR DESCRIPTION
This PR is part of the changes to move Build Artifact storage from S3 (`downloads.rapids.ai`) to the Github Artifact Store (see https://github.com/rapidsai/build-infra/issues/237). 

This PR removes the deprecated `wheel-name` variable (also refer https://github.com/rapidsai/shared-workflows/pull/330), and makes optional inputs required as changes have been made across RAPIDS repos. 