### PR TITLE
make artifact uploads optional

### DIFF
--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -19,6 +19,11 @@ on:
       script:
         type: string
         default: "ci/build_cpp.sh"
+      upload-artifacts:
+        type: boolean
+        default: true
+        required: false
+        description: "One of [true, false], true if artifacts should be uploaded to GitHub's artifact store"
       matrix_filter:
         type: string
         default: "."
@@ -125,15 +130,18 @@ jobs:
           STEP_NAME: "C++ build"
           GH_TOKEN: ${{ github.token }}
       - name: Get Package Name and Location
+        if: ${{ inputs.upload-artifacts }}
         run: | 
           echo "RAPIDS_PACKAGE_NAME=$(RAPIDS_NO_PKG_EXTENSION=true rapids-package-name conda_cpp)" >> "${GITHUB_OUTPUT}"
           echo "CONDA_OUTPUT_DIR=${RAPIDS_CONDA_BLD_OUTPUT_DIR}" >> "${GITHUB_OUTPUT}"
         id: package-name
       - name: Show files to be uploaded
+        if: ${{ inputs.upload-artifacts }}
         run: |
           echo "Contents of directory to be uploaded:"
           ls -R ${{ steps.package-name.outputs.CONDA_OUTPUT_DIR }}
       - uses: actions/upload-artifact@v4
+        if: ${{ inputs.upload-artifacts }}
         with:
           name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
           path: ${{ steps.package-name.outputs.CONDA_OUTPUT_DIR }}

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -19,6 +19,11 @@ on:
       script:
         type: string
         default: "ci/build_python.sh"
+      upload-artifacts:
+        type: boolean
+        default: true
+        required: false
+        description: "One of [true, false], true if artifacts should be uploaded to GitHub's artifact store"
       matrix_filter:
         type: string
         default: "."
@@ -125,15 +130,18 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Get Package Name and Location
+        if: ${{ inputs.upload-artifacts }}
         run: | 
           echo "RAPIDS_PACKAGE_NAME=$(RAPIDS_NO_PKG_EXTENSION=true rapids-package-name conda_python)" >> "${GITHUB_OUTPUT}"
           echo "CONDA_OUTPUT_DIR=${RAPIDS_CONDA_BLD_OUTPUT_DIR}" >> "${GITHUB_OUTPUT}"
         id: package-name
       - name: Show files to be uploaded
+        if: ${{ inputs.upload-artifacts }}
         run: |
           echo "Contents of directory to be uploaded:"
           ls -R ${{ steps.package-name.outputs.CONDA_OUTPUT_DIR }}
       - uses: actions/upload-artifact@v4
+        if: ${{ inputs.upload-artifacts }}
         with:
           name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
           path: ${{ steps.package-name.outputs.CONDA_OUTPUT_DIR }}

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -25,7 +25,7 @@ on:
         description: "Distribution name, without any other qualifiers (e.g. 'pylibcudf', not 'pylibcudf-cu12-cp311-manylinux_2_24_aarch64')"
       package-type:
         description: "One of: [cpp, python]"
-        required: false
+        required: true
         type: string
       wheel-name:
         required: false
@@ -52,6 +52,11 @@ on:
       matrix_filter:
         type: string
         default: "."
+      upload-artifacts:
+        type: boolean
+        default: true
+        required: false
+        description: "One of [true, false], true if artifacts should be uploaded to GitHub's artifact store"
 
       # Extra repository that will be cloned into the project directory.
       extra-repo:
@@ -200,7 +205,7 @@ jobs:
         shell: bash -leo pipefail {0}
 
       - name: Get package name
-        if: inputs.package-type != ''
+        if: ${{ inputs.upload-artifacts }}
         env:
           PACKAGE_TYPE: ${{ inputs.package-type }}
           WHEEL_NAME: ${{ inputs.package-name != '' && inputs.package-name || inputs.wheel-name }}
@@ -224,13 +229,13 @@ jobs:
         id: package-name
 
       - name: Show files to be uploaded
-        if: inputs.package-type != ''
+        if: ${{ inputs.upload-artifacts }}
         run: |
           echo "Contents of directory to be uploaded:"
           ls -R ${{ steps.package-name.outputs.WHEEL_OUTPUT_DIR }}
       
       - uses: actions/upload-artifact@v4
-        if: inputs.package-type != ''
+        if: ${{ inputs.upload-artifacts }}
         with:
           name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
           path: ${{ steps.package-name.outputs.WHEEL_OUTPUT_DIR }}


### PR DESCRIPTION
Contributes to #336
Contributes to https://github.com/rapidsai/build-infra/issues/237

Proposes the following for `{conda-cpp, conda-python, wheel}-build.yaml` workflows:

* adds boolean input `upload-artifacts`, to opt out of uploading GitHub Actions artifacts (see #336 for reasoning)
* makes `package-type` input required
* removes conditions that skipped artifact uploads if `package-type` was an empty string

## Notes for Reviewers

### Why are these `package-type` changes part of this? Are the safe?

Stuff like this...

https://github.com/rapidsai/shared-workflows/blob/18279eccc4f4280d26385668a37536b893d7dc4f/.github/workflows/wheels-build.yaml#L232-L233

... was added early on in the effort to support GitHub Actions artifact uploads in these workflows (#297), and made optional so those changes could be merged prior to all repos being migrated.

It's now safe to make this stricter. I searched all of the GitHub orgs I have read access to ([GitHub search](https://github.com/search?q=%22rapidsai%2Fshared-workflows%2F.github%2Fworkflows%2Fwheels-build.yaml%40branch-25.06%22+AND+NOT+is%3Aarchived&type=code&p=3)), and the only place where `package-type` is NOT provided is in `cuspatial`: https://github.com/rapidsai/cuspatial/blob/c0f92e5b95f21ccc58d187689bb06adb2fd2bc56/.github/workflows/pr.yaml#L152-L160

`cuspatial` support is getting dropped right now (https://github.com/rapidsai/docs/pull/600), so we probably don't even need to update that one.

### How I tested this

https://github.com/rapidsai/integration/pull/760