### PR TITLE
Fix type mismatch for graphQL on single selects

### DIFF
--- a/.github/workflows/project-get-set-single-select-field.yaml
+++ b/.github/workflows/project-get-set-single-select-field.yaml
@@ -102,7 +102,7 @@ jobs:
                         ... on ProjectV2 {
                         field(name: $fieldName) {
                             ... on ProjectV2SingleSelectField {
-                            options(names: $optionName) {id}
+                            options(names: [$optionName]) {id}
                               }
                             }
                           }


### PR DESCRIPTION
This pull request includes a small but important fix to the GraphQL query in the `.github/workflows/project-get-set-single-select-field.yaml` file. The change ensures that the `options` field correctly accepts an array of option names instead of a single string.

* [`.github/workflows/project-get-set-single-select-field.yaml`](diffhunk://#diff-d45100b06985e94f86e4180d682f0f3aa17bd366899a62e1c3117bf5080621e7L105-R105): Updated the `options` field in the GraphQL query to use an array syntax (`[optionName]`) for compatibility with the expected input type.