### PR TITLE
make input validation, upload logic in build workflows stricter

### DIFF
--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -143,6 +143,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ inputs.upload-artifacts }}
         with:
+          if-no-files-found: 'error'
           name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
           path: ${{ steps.package-name.outputs.CONDA_OUTPUT_DIR }}
       - name: Upload additional artifacts

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -147,6 +147,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ inputs.upload-artifacts }}
         with:
+          if-no-files-found: 'error'
           name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
           path: ${{ steps.package-name.outputs.CONDA_OUTPUT_DIR }}
       - name: Upload additional artifacts

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -20,17 +20,13 @@ on:
         required: true
         type: string
       package-name:
-        required: false
+        required: true
         type: string
         description: "Distribution name, without any other qualifiers (e.g. 'pylibcudf', not 'pylibcudf-cu12-cp311-manylinux_2_24_aarch64')"
       package-type:
         description: "One of: [cpp, python]"
         required: true
         type: string
-      wheel-name:
-        required: false
-        type: string
-        description: "DEPRECATED: Use package-name instead"
       pure-wheel:
         required: false
         type: boolean
@@ -211,19 +207,19 @@ jobs:
       - name: Get package name
         if: ${{ inputs.upload-artifacts }}
         env:
-          PACKAGE_TYPE: ${{ inputs.package-type }}
-          WHEEL_NAME: ${{ inputs.package-name != '' && inputs.package-name || inputs.wheel-name }}
-          PURE_WHEEL: ${{ inputs.pure-wheel }}
           APPEND_CUDA_SUFFIX: ${{ inputs.append-cuda-suffix }}
+          PACKAGE_NAME: ${{ inputs.package-name }}
+          PACKAGE_TYPE: ${{ inputs.package-type }}
+          PURE_WHEEL: ${{ inputs.pure-wheel }}
         run: |
-          if [ -z "${WHEEL_NAME}" ]; then
-            WHEEL_NAME="${RAPIDS_REPOSITORY#*/}"
+          if [ -z "${PACKAGE_NAME}" ]; then
+            PACKAGE_NAME="${RAPIDS_REPOSITORY#*/}"
           fi
           export "RAPIDS_PY_CUDA_SUFFIX=$(rapids-wheel-ctk-name-gen ${RAPIDS_CUDA_VERSION})"
           if [ "${APPEND_CUDA_SUFFIX}" = "true" ]; then
-            export "RAPIDS_PY_WHEEL_NAME=${WHEEL_NAME}_${RAPIDS_PY_CUDA_SUFFIX}"
+            export "RAPIDS_PY_WHEEL_NAME=${PACKAGE_NAME}_${RAPIDS_PY_CUDA_SUFFIX}"
           else
-            export "RAPIDS_PY_WHEEL_NAME=${WHEEL_NAME}"
+            export "RAPIDS_PY_WHEEL_NAME=${PACKAGE_NAME}"
           fi
           if [ "${PURE_WHEEL}" = "true" ]; then
             export "RAPIDS_PY_WHEEL_PURE=1"

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -237,6 +237,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: ${{ inputs.upload-artifacts }}
         with:
+          if-no-files-found: 'error'
           name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
           path: ${{ steps.package-name.outputs.WHEEL_OUTPUT_DIR }}
       


### PR DESCRIPTION
Replaces #334

Contributes to https://github.com/rapidsai/build-infra/issues/237

Makes the following changes in the `wheels-build` workflow:

* removes input `wheel-name`
* makes input `package-name` required
* configures `actions/upload-artifact` to **ERROR** if no files are found to upload

## Notes for Reviewers

### Why, and why now?

When the work to transition artifact-handling from `downloads.rapids.ai` to GitHub Actions artifacts started, this input referring to the name of the project was called `wheel-name`.

We later decided that `package-name` was more appropriate, for consistency with other workflows:

https://github.com/rapidsai/shared-workflows/blob/1ddf09797c78c158f23af3d4ef8a0df5801fcd07/.github/workflows/wheels-publish.yaml#L21

https://github.com/rapidsai/shared-workflows/blob/1ddf09797c78c158f23af3d4ef8a0df5801fcd07/.github/workflows/conda-cpp-build.yaml#L137

But by that time, some PRs calling it `wheel-name` had already been merged downstream. So both names were kept around for a bit.

Now, there are 0 remaining uses of `wheel-name` across the `rapidsai` org: https://github.com/search?q=org%3Arapidsai+%22wheel-name%22&type=code

### How I tested this

Searched for `wheel-name` uses across the `rapidsai` org and found none remaining: https://github.com/search?q=org%3Arapidsai+%22wheel-name%22&type=code

Searched for `wheels-build.yaml` across the `rapidsai` org and found that every use of it was also explicitly supplying a value for input `package-name:`: https://github.com/search?q=org%3Arapidsai+%22wheels-build.yaml%22+AND+NOT+is%3Aarchived&type=code

Except these repos which are not being actively maintained, and which we've agreed not to worry about for this migration:

* https://github.com/rapidsai/cuspatial/blob/c0f92e5b95f21ccc58d187689bb06adb2fd2bc56/.github/workflows/pr.yaml#L155