### PR TITLE
Replace all `-F` usage with `-f`

### DIFF
--- a/.github/workflows/project-get-item-id.yaml
+++ b/.github/workflows/project-get-item-id.yaml
@@ -50,8 +50,12 @@ jobs:
             # Query up to 10 projects for the PR
             # There's no graphQL filter configured to query by a specific project
             # So we need to query all projects and filter the result ourselves
+<<<<<<< HEAD
             # shellcheck disable=SC2016
             gh api graphql -F nodeId="$ENV_ITEM_NODE_ID" -f query='
+=======
+            gh api graphql -f nodeId="$ENV_ITEM_NODE_ID" -f query='
+>>>>>>> 861fe12 (Replace all `-F` usage with `-f`)
               query($nodeId: ID!) {
                 node(id: $nodeId) {
                   ... on PullRequest {

--- a/.github/workflows/project-get-item-id.yaml
+++ b/.github/workflows/project-get-item-id.yaml
@@ -50,12 +50,7 @@ jobs:
             # Query up to 10 projects for the PR
             # There's no graphQL filter configured to query by a specific project
             # So we need to query all projects and filter the result ourselves
-<<<<<<< HEAD
-            # shellcheck disable=SC2016
-            gh api graphql -F nodeId="$ENV_ITEM_NODE_ID" -f query='
-=======
             gh api graphql -f nodeId="$ENV_ITEM_NODE_ID" -f query='
->>>>>>> 861fe12 (Replace all `-F` usage with `-f`)
               query($nodeId: ID!) {
                 node(id: $nodeId) {
                   ... on PullRequest {

--- a/.github/workflows/project-get-item-id.yaml
+++ b/.github/workflows/project-get-item-id.yaml
@@ -50,6 +50,7 @@ jobs:
             # Query up to 10 projects for the PR
             # There's no graphQL filter configured to query by a specific project
             # So we need to query all projects and filter the result ourselves
+            # shellcheck disable=SC2016
             gh api graphql -f nodeId="$ENV_ITEM_NODE_ID" -f query='
               query($nodeId: ID!) {
                 node(id: $nodeId) {

--- a/.github/workflows/project-get-set-iteration-field.yaml
+++ b/.github/workflows/project-get-set-iteration-field.yaml
@@ -69,12 +69,7 @@ jobs:
         run: |
             # Get current iteration iteration id
             # The current iteration is always the first element in the returned list
-<<<<<<< HEAD
-            # shellcheck disable=SC2016
-            gh api graphql -F projectId="$ENV_PROJECT_ID" -F fieldName="$ENV_ITERATION_FIELD_NAME" -f query='
-=======
             gh api graphql -f projectId="$ENV_PROJECT_ID" -f fieldName="$ENV_ITERATION_FIELD_NAME" -f query='
->>>>>>> 861fe12 (Replace all `-F` usage with `-f`)
             query($projectId: ID!, $fieldName: String!) {
                 node(id: $projectId) {
                     ... on ProjectV2 {
@@ -109,18 +104,10 @@ jobs:
           ENV_ITERATION_FIELD_ID: ${{ inputs.ITERATION_FIELD_ID }}
           ENV_ITERATION_OPTION_ID: ${{ steps.get_iteration_option_id.outputs.ITERATION_OPTION_ID }}
         run: |
-<<<<<<< HEAD
-            # shellcheck disable=SC2016
-            gh api graphql -F projectId="$ENV_PROJECT_ID" \
-                          -F itemId="$ENV_ITEM_PROJECT_ID" \
-                          -F fieldId="$ENV_ITERATION_FIELD_ID" \
-                          -F iterationId="$ENV_ITERATION_OPTION_ID" \
-=======
             gh api graphql -f projectId="$ENV_PROJECT_ID" \
                           -f itemId="$ENV_ITEM_PROJECT_ID" \
                           -f fieldId="$ENV_ITERATION_FIELD_ID" \
                           -f iterationId="$ENV_ITERATION_OPTION_ID" \
->>>>>>> 861fe12 (Replace all `-F` usage with `-f`)
                           -f query='
               mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $iterationId: String!) {
                 updateProjectV2ItemFieldValue(

--- a/.github/workflows/project-get-set-iteration-field.yaml
+++ b/.github/workflows/project-get-set-iteration-field.yaml
@@ -69,6 +69,7 @@ jobs:
         run: |
             # Get current iteration iteration id
             # The current iteration is always the first element in the returned list
+            # shellcheck disable=SC2016
             gh api graphql -f projectId="$ENV_PROJECT_ID" -f fieldName="$ENV_ITERATION_FIELD_NAME" -f query='
             query($projectId: ID!, $fieldName: String!) {
                 node(id: $projectId) {
@@ -104,6 +105,7 @@ jobs:
           ENV_ITERATION_FIELD_ID: ${{ inputs.ITERATION_FIELD_ID }}
           ENV_ITERATION_OPTION_ID: ${{ steps.get_iteration_option_id.outputs.ITERATION_OPTION_ID }}
         run: |
+            # shellcheck disable=SC2016
             gh api graphql -f projectId="$ENV_PROJECT_ID" \
                           -f itemId="$ENV_ITEM_PROJECT_ID" \
                           -f fieldId="$ENV_ITERATION_FIELD_ID" \

--- a/.github/workflows/project-get-set-iteration-field.yaml
+++ b/.github/workflows/project-get-set-iteration-field.yaml
@@ -69,8 +69,12 @@ jobs:
         run: |
             # Get current iteration iteration id
             # The current iteration is always the first element in the returned list
+<<<<<<< HEAD
             # shellcheck disable=SC2016
             gh api graphql -F projectId="$ENV_PROJECT_ID" -F fieldName="$ENV_ITERATION_FIELD_NAME" -f query='
+=======
+            gh api graphql -f projectId="$ENV_PROJECT_ID" -f fieldName="$ENV_ITERATION_FIELD_NAME" -f query='
+>>>>>>> 861fe12 (Replace all `-F` usage with `-f`)
             query($projectId: ID!, $fieldName: String!) {
                 node(id: $projectId) {
                     ... on ProjectV2 {
@@ -105,11 +109,18 @@ jobs:
           ENV_ITERATION_FIELD_ID: ${{ inputs.ITERATION_FIELD_ID }}
           ENV_ITERATION_OPTION_ID: ${{ steps.get_iteration_option_id.outputs.ITERATION_OPTION_ID }}
         run: |
+<<<<<<< HEAD
             # shellcheck disable=SC2016
             gh api graphql -F projectId="$ENV_PROJECT_ID" \
                           -F itemId="$ENV_ITEM_PROJECT_ID" \
                           -F fieldId="$ENV_ITERATION_FIELD_ID" \
                           -F iterationId="$ENV_ITERATION_OPTION_ID" \
+=======
+            gh api graphql -f projectId="$ENV_PROJECT_ID" \
+                          -f itemId="$ENV_ITEM_PROJECT_ID" \
+                          -f fieldId="$ENV_ITERATION_FIELD_ID" \
+                          -f iterationId="$ENV_ITERATION_OPTION_ID" \
+>>>>>>> 861fe12 (Replace all `-F` usage with `-f`)
                           -f query='
               mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $iterationId: String!) {
                 updateProjectV2ItemFieldValue(

--- a/.github/workflows/project-get-set-single-select-field.yaml
+++ b/.github/workflows/project-get-set-single-select-field.yaml
@@ -77,9 +77,14 @@ jobs:
             # Get single_select option id
             if [ -z "$ENV_SINGLE_SELECT_OPTION_VALUE" ]; then
               # No option specified, get first option in list
+<<<<<<< HEAD
               # shellcheck disable=SC2016
               gh api graphql -F projectId="$ENV_PROJECT_ID" \
                            -F fieldName="$ENV_SINGLE_SELECT_FIELD_NAME" \
+=======
+              gh api graphql -f projectId="$ENV_PROJECT_ID" \
+                           -f fieldName="$ENV_SINGLE_SELECT_FIELD_NAME" \
+>>>>>>> 861fe12 (Replace all `-F` usage with `-f`)
                            -f query='
                 query($projectId: ID!, $fieldName: String!) {
                     node(id: $projectId) {
@@ -94,10 +99,16 @@ jobs:
                       }' > single_select_option_data.json
             else
               # Get specific value
+<<<<<<< HEAD
               # shellcheck disable=SC2016
               gh api graphql -F projectId="$ENV_PROJECT_ID" \
                            -F fieldName="$ENV_SINGLE_SELECT_FIELD_NAME" \
                            -F optionName="$ENV_SINGLE_SELECT_OPTION_VALUE" \
+=======
+              gh api graphql -f projectId="$ENV_PROJECT_ID" \
+                           -f fieldName="$ENV_SINGLE_SELECT_FIELD_NAME" \
+                           -f optionName="$ENV_SINGLE_SELECT_OPTION_VALUE" \
+>>>>>>> 861fe12 (Replace all `-F` usage with `-f`)
                            -f query='
                 query($projectId: ID!, $fieldName: String!, $optionName: String!) {
                     node(id: $projectId) {
@@ -127,11 +138,18 @@ jobs:
           ENV_SINGLE_SELECT_FIELD_ID: ${{ inputs.SINGLE_SELECT_FIELD_ID }}
           ENV_SINGLE_SELECT_OPTION_ID: ${{ steps.get_single_select_option_id.outputs.SINGLE_SELECT_OPTION_ID }}
         run: |
+<<<<<<< HEAD
             # shellcheck disable=SC2016
             gh api graphql -F projectId="$ENV_PROJECT_ID" \
                          -F itemId="$ENV_ITEM_PROJECT_ID" \
                          -F fieldId="$ENV_SINGLE_SELECT_FIELD_ID" \
                          -F optionId="$ENV_SINGLE_SELECT_OPTION_ID" \
+=======
+            gh api graphql -f projectId="$ENV_PROJECT_ID" \
+                         -f itemId="$ENV_ITEM_PROJECT_ID" \
+                         -f fieldId="$ENV_SINGLE_SELECT_FIELD_ID" \
+                         -f optionId="$ENV_SINGLE_SELECT_OPTION_ID" \
+>>>>>>> 861fe12 (Replace all `-F` usage with `-f`)
                          -f query='
               mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
                 updateProjectV2ItemFieldValue(

--- a/.github/workflows/project-get-set-single-select-field.yaml
+++ b/.github/workflows/project-get-set-single-select-field.yaml
@@ -77,6 +77,7 @@ jobs:
             # Get single_select option id
             if [ -z "$ENV_SINGLE_SELECT_OPTION_VALUE" ]; then
               # No option specified, get first option in list
+              # shellcheck disable=SC2016
               gh api graphql -f projectId="$ENV_PROJECT_ID" \
                            -f fieldName="$ENV_SINGLE_SELECT_FIELD_NAME" \
                            -f query='
@@ -93,6 +94,7 @@ jobs:
                       }' > single_select_option_data.json
             else
               # Get specific value
+              # shellcheck disable=SC2016
               gh api graphql -f projectId="$ENV_PROJECT_ID" \
                            -f fieldName="$ENV_SINGLE_SELECT_FIELD_NAME" \
                            -f optionName="$ENV_SINGLE_SELECT_OPTION_VALUE" \
@@ -125,6 +127,7 @@ jobs:
           ENV_SINGLE_SELECT_FIELD_ID: ${{ inputs.SINGLE_SELECT_FIELD_ID }}
           ENV_SINGLE_SELECT_OPTION_ID: ${{ steps.get_single_select_option_id.outputs.SINGLE_SELECT_OPTION_ID }}
         run: |
+            # shellcheck disable=SC2016
             gh api graphql -f projectId="$ENV_PROJECT_ID" \
                          -f itemId="$ENV_ITEM_PROJECT_ID" \
                          -f fieldId="$ENV_SINGLE_SELECT_FIELD_ID" \

--- a/.github/workflows/project-get-set-single-select-field.yaml
+++ b/.github/workflows/project-get-set-single-select-field.yaml
@@ -77,14 +77,8 @@ jobs:
             # Get single_select option id
             if [ -z "$ENV_SINGLE_SELECT_OPTION_VALUE" ]; then
               # No option specified, get first option in list
-<<<<<<< HEAD
-              # shellcheck disable=SC2016
-              gh api graphql -F projectId="$ENV_PROJECT_ID" \
-                           -F fieldName="$ENV_SINGLE_SELECT_FIELD_NAME" \
-=======
               gh api graphql -f projectId="$ENV_PROJECT_ID" \
                            -f fieldName="$ENV_SINGLE_SELECT_FIELD_NAME" \
->>>>>>> 861fe12 (Replace all `-F` usage with `-f`)
                            -f query='
                 query($projectId: ID!, $fieldName: String!) {
                     node(id: $projectId) {
@@ -99,16 +93,9 @@ jobs:
                       }' > single_select_option_data.json
             else
               # Get specific value
-<<<<<<< HEAD
-              # shellcheck disable=SC2016
-              gh api graphql -F projectId="$ENV_PROJECT_ID" \
-                           -F fieldName="$ENV_SINGLE_SELECT_FIELD_NAME" \
-                           -F optionName="$ENV_SINGLE_SELECT_OPTION_VALUE" \
-=======
               gh api graphql -f projectId="$ENV_PROJECT_ID" \
                            -f fieldName="$ENV_SINGLE_SELECT_FIELD_NAME" \
                            -f optionName="$ENV_SINGLE_SELECT_OPTION_VALUE" \
->>>>>>> 861fe12 (Replace all `-F` usage with `-f`)
                            -f query='
                 query($projectId: ID!, $fieldName: String!, $optionName: String!) {
                     node(id: $projectId) {
@@ -138,18 +125,10 @@ jobs:
           ENV_SINGLE_SELECT_FIELD_ID: ${{ inputs.SINGLE_SELECT_FIELD_ID }}
           ENV_SINGLE_SELECT_OPTION_ID: ${{ steps.get_single_select_option_id.outputs.SINGLE_SELECT_OPTION_ID }}
         run: |
-<<<<<<< HEAD
-            # shellcheck disable=SC2016
-            gh api graphql -F projectId="$ENV_PROJECT_ID" \
-                         -F itemId="$ENV_ITEM_PROJECT_ID" \
-                         -F fieldId="$ENV_SINGLE_SELECT_FIELD_ID" \
-                         -F optionId="$ENV_SINGLE_SELECT_OPTION_ID" \
-=======
             gh api graphql -f projectId="$ENV_PROJECT_ID" \
                          -f itemId="$ENV_ITEM_PROJECT_ID" \
                          -f fieldId="$ENV_SINGLE_SELECT_FIELD_ID" \
                          -f optionId="$ENV_SINGLE_SELECT_OPTION_ID" \
->>>>>>> 861fe12 (Replace all `-F` usage with `-f`)
                          -f query='
               mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
                 updateProjectV2ItemFieldValue(

--- a/.github/workflows/project-set-text-date-numeric-field.yaml
+++ b/.github/workflows/project-set-text-date-numeric-field.yaml
@@ -65,12 +65,20 @@ jobs:
         run: |
             # Set the field based on the inputted desired value
             if [ "$ENV_FIELD_TYPE" == "date" ] || [ "$ENV_FIELD_TYPE" == "text" ]; then
+<<<<<<< HEAD
               # shellcheck disable=SC2016
               gh api graphql -F projectId="$ENV_PROJECT_ID" \
                            -F itemId="$ENV_ITEM_PROJECT_ID" \
                            -F fieldId="$ENV_FIELD_ID" \
                            -F value="$ENV_SET_VALUE" \
                            -F fieldType="$ENV_FIELD_TYPE" \
+=======
+              gh api graphql -f projectId="$ENV_PROJECT_ID" \
+                           -f itemId="$ENV_ITEM_PROJECT_ID" \
+                           -f fieldId="$ENV_FIELD_ID" \
+                           -f value="$ENV_SET_VALUE" \
+                           -f fieldType="$ENV_FIELD_TYPE" \
+>>>>>>> 861fe12 (Replace all `-F` usage with `-f`)
                            -f query='
                 mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!, $fieldType: String!) {
                   updateProjectV2ItemFieldValue(
@@ -88,11 +96,18 @@ jobs:
                 }'
 
             elif [ "$ENV_FIELD_TYPE" == "number" ]; then
+<<<<<<< HEAD
               # shellcheck disable=SC2016
               gh api graphql -F projectId="$ENV_PROJECT_ID" \
                            -F itemId="$ENV_ITEM_PROJECT_ID" \
                            -F fieldId="$ENV_FIELD_ID" \
                            -F value="$ENV_SET_VALUE" \
+=======
+              gh api graphql -f projectId="$ENV_PROJECT_ID" \
+                           -f itemId="$ENV_ITEM_PROJECT_ID" \
+                           -f fieldId="$ENV_FIELD_ID" \
+                           -f value="$ENV_SET_VALUE" \
+>>>>>>> 861fe12 (Replace all `-F` usage with `-f`)
                            -f query='
                 mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: Float!) {
                   updateProjectV2ItemFieldValue(

--- a/.github/workflows/project-set-text-date-numeric-field.yaml
+++ b/.github/workflows/project-set-text-date-numeric-field.yaml
@@ -65,6 +65,7 @@ jobs:
         run: |
             # Set the field based on the inputted desired value
             if [ "$ENV_FIELD_TYPE" == "date" ] || [ "$ENV_FIELD_TYPE" == "text" ]; then
+              # shellcheck disable=SC2016
               gh api graphql -f projectId="$ENV_PROJECT_ID" \
                            -f itemId="$ENV_ITEM_PROJECT_ID" \
                            -f fieldId="$ENV_FIELD_ID" \
@@ -87,6 +88,7 @@ jobs:
                 }'
 
             elif [ "$ENV_FIELD_TYPE" == "number" ]; then
+              # shellcheck disable=SC2016
               gh api graphql -f projectId="$ENV_PROJECT_ID" \
                            -f itemId="$ENV_ITEM_PROJECT_ID" \
                            -f fieldId="$ENV_FIELD_ID" \

--- a/.github/workflows/project-set-text-date-numeric-field.yaml
+++ b/.github/workflows/project-set-text-date-numeric-field.yaml
@@ -65,20 +65,11 @@ jobs:
         run: |
             # Set the field based on the inputted desired value
             if [ "$ENV_FIELD_TYPE" == "date" ] || [ "$ENV_FIELD_TYPE" == "text" ]; then
-<<<<<<< HEAD
-              # shellcheck disable=SC2016
-              gh api graphql -F projectId="$ENV_PROJECT_ID" \
-                           -F itemId="$ENV_ITEM_PROJECT_ID" \
-                           -F fieldId="$ENV_FIELD_ID" \
-                           -F value="$ENV_SET_VALUE" \
-                           -F fieldType="$ENV_FIELD_TYPE" \
-=======
               gh api graphql -f projectId="$ENV_PROJECT_ID" \
                            -f itemId="$ENV_ITEM_PROJECT_ID" \
                            -f fieldId="$ENV_FIELD_ID" \
                            -f value="$ENV_SET_VALUE" \
                            -f fieldType="$ENV_FIELD_TYPE" \
->>>>>>> 861fe12 (Replace all `-F` usage with `-f`)
                            -f query='
                 mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!, $fieldType: String!) {
                   updateProjectV2ItemFieldValue(
@@ -96,18 +87,10 @@ jobs:
                 }'
 
             elif [ "$ENV_FIELD_TYPE" == "number" ]; then
-<<<<<<< HEAD
-              # shellcheck disable=SC2016
-              gh api graphql -F projectId="$ENV_PROJECT_ID" \
-                           -F itemId="$ENV_ITEM_PROJECT_ID" \
-                           -F fieldId="$ENV_FIELD_ID" \
-                           -F value="$ENV_SET_VALUE" \
-=======
               gh api graphql -f projectId="$ENV_PROJECT_ID" \
                            -f itemId="$ENV_ITEM_PROJECT_ID" \
                            -f fieldId="$ENV_FIELD_ID" \
                            -f value="$ENV_SET_VALUE" \
->>>>>>> 861fe12 (Replace all `-F` usage with `-f`)
                            -f query='
                 mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: Float!) {
                   updateProjectV2ItemFieldValue(

--- a/.github/workflows/project-update-linked-issues.yaml
+++ b/.github/workflows/project-update-linked-issues.yaml
@@ -61,6 +61,7 @@ jobs:
             ENV_UPDATE_FIELD_VALUE: ${{ inputs.UPDATE_FIELD_VALUE }}
           run: |
             # Find the linked issues to the PR
+            # shellcheck disable=SC2016
             gh api graphql -f prNodeId="$ENV_PR_NODE_ID" -f query='
               query($prNodeId: ID!) {
                 node(id: $prNodeId) {

--- a/.github/workflows/project-update-linked-issues.yaml
+++ b/.github/workflows/project-update-linked-issues.yaml
@@ -61,8 +61,12 @@ jobs:
             ENV_UPDATE_FIELD_VALUE: ${{ inputs.UPDATE_FIELD_VALUE }}
           run: |
             # Find the linked issues to the PR
+<<<<<<< HEAD
             # shellcheck disable=SC2016
             gh api graphql -F prNodeId="$ENV_PR_NODE_ID" -f query='
+=======
+            gh api graphql -f prNodeId="$ENV_PR_NODE_ID" -f query='
+>>>>>>> 861fe12 (Replace all `-F` usage with `-f`)
               query($prNodeId: ID!) {
                 node(id: $prNodeId) {
                   ... on PullRequest {
@@ -102,11 +106,18 @@ jobs:
 
               case "$ENV_UPDATE_FIELD_TYPE" in
                 "iteration")
+<<<<<<< HEAD
                   # shellcheck disable=SC2016
                   gh api graphql -F projectId="$ENV_PROJECT_ID" \
                                -F itemId="$issue_id" \
                                -F fieldId="$ENV_UPDATE_FIELD_ID" \
                                -F iterationId="$ENV_UPDATE_FIELD_VALUE" \
+=======
+                  gh api graphql -f projectId="$ENV_PROJECT_ID" \
+                               -f itemId="$issue_id" \
+                               -f fieldId="$ENV_UPDATE_FIELD_ID" \
+                               -f iterationId="$ENV_UPDATE_FIELD_VALUE" \
+>>>>>>> 861fe12 (Replace all `-F` usage with `-f`)
                                -f query='
                     mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $iterationId: String!) {
                       updateProjectV2ItemFieldValue(
@@ -123,11 +134,18 @@ jobs:
                   ;;
 
                 "single_select")
+<<<<<<< HEAD
                   # shellcheck disable=SC2016
                   gh api graphql -F projectId="$ENV_PROJECT_ID" \
                                -F itemId="$issue_id" \
                                -F fieldId="$ENV_UPDATE_FIELD_ID" \
                                -F optionId="$ENV_UPDATE_FIELD_VALUE" \
+=======
+                  gh api graphql -f projectId="$ENV_PROJECT_ID" \
+                               -f itemId="$issue_id" \
+                               -f fieldId="$ENV_UPDATE_FIELD_ID" \
+                               -f optionId="$ENV_UPDATE_FIELD_VALUE" \
+>>>>>>> 861fe12 (Replace all `-F` usage with `-f`)
                                -f query='
                     mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
                       updateProjectV2ItemFieldValue(
@@ -144,12 +162,20 @@ jobs:
                   ;;
 
                 "date"|"text")
+<<<<<<< HEAD
                   # shellcheck disable=SC2016
                   gh api graphql -F projectId="$ENV_PROJECT_ID" \
                                -F itemId="$issue_id" \
                                -F fieldId="$ENV_UPDATE_FIELD_ID" \
                                -F value="$ENV_UPDATE_FIELD_VALUE" \
                                -F fieldType="$ENV_UPDATE_FIELD_TYPE" \
+=======
+                  gh api graphql -f projectId="$ENV_PROJECT_ID" \
+                               -f itemId="$issue_id" \
+                               -f fieldId="$ENV_UPDATE_FIELD_ID" \
+                               -f value="$ENV_UPDATE_FIELD_VALUE" \
+                               -f fieldType="$ENV_UPDATE_FIELD_TYPE" \
+>>>>>>> 861fe12 (Replace all `-F` usage with `-f`)
                                -f query='
                     mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!, $fieldType: String!) {
                       updateProjectV2ItemFieldValue(
@@ -166,11 +192,18 @@ jobs:
                   ;;
 
                 "number")
+<<<<<<< HEAD
                   # shellcheck disable=SC2016
                   gh api graphql -F projectId="$ENV_PROJECT_ID" \
                                -F itemId="$issue_id" \
                                -F fieldId="$ENV_UPDATE_FIELD_ID" \
                                -F value="$ENV_UPDATE_FIELD_VALUE" \
+=======
+                  gh api graphql -f projectId="$ENV_PROJECT_ID" \
+                               -f itemId="$issue_id" \
+                               -f fieldId="$ENV_UPDATE_FIELD_ID" \
+                               -f value="$ENV_UPDATE_FIELD_VALUE" \
+>>>>>>> 861fe12 (Replace all `-F` usage with `-f`)
                                -f query='
                     mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: Float!) {
                       updateProjectV2ItemFieldValue(

--- a/.github/workflows/project-update-linked-issues.yaml
+++ b/.github/workflows/project-update-linked-issues.yaml
@@ -61,12 +61,7 @@ jobs:
             ENV_UPDATE_FIELD_VALUE: ${{ inputs.UPDATE_FIELD_VALUE }}
           run: |
             # Find the linked issues to the PR
-<<<<<<< HEAD
-            # shellcheck disable=SC2016
-            gh api graphql -F prNodeId="$ENV_PR_NODE_ID" -f query='
-=======
             gh api graphql -f prNodeId="$ENV_PR_NODE_ID" -f query='
->>>>>>> 861fe12 (Replace all `-F` usage with `-f`)
               query($prNodeId: ID!) {
                 node(id: $prNodeId) {
                   ... on PullRequest {
@@ -106,18 +101,10 @@ jobs:
 
               case "$ENV_UPDATE_FIELD_TYPE" in
                 "iteration")
-<<<<<<< HEAD
-                  # shellcheck disable=SC2016
-                  gh api graphql -F projectId="$ENV_PROJECT_ID" \
-                               -F itemId="$issue_id" \
-                               -F fieldId="$ENV_UPDATE_FIELD_ID" \
-                               -F iterationId="$ENV_UPDATE_FIELD_VALUE" \
-=======
                   gh api graphql -f projectId="$ENV_PROJECT_ID" \
                                -f itemId="$issue_id" \
                                -f fieldId="$ENV_UPDATE_FIELD_ID" \
                                -f iterationId="$ENV_UPDATE_FIELD_VALUE" \
->>>>>>> 861fe12 (Replace all `-F` usage with `-f`)
                                -f query='
                     mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $iterationId: String!) {
                       updateProjectV2ItemFieldValue(
@@ -134,18 +121,10 @@ jobs:
                   ;;
 
                 "single_select")
-<<<<<<< HEAD
-                  # shellcheck disable=SC2016
-                  gh api graphql -F projectId="$ENV_PROJECT_ID" \
-                               -F itemId="$issue_id" \
-                               -F fieldId="$ENV_UPDATE_FIELD_ID" \
-                               -F optionId="$ENV_UPDATE_FIELD_VALUE" \
-=======
                   gh api graphql -f projectId="$ENV_PROJECT_ID" \
                                -f itemId="$issue_id" \
                                -f fieldId="$ENV_UPDATE_FIELD_ID" \
                                -f optionId="$ENV_UPDATE_FIELD_VALUE" \
->>>>>>> 861fe12 (Replace all `-F` usage with `-f`)
                                -f query='
                     mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
                       updateProjectV2ItemFieldValue(
@@ -162,20 +141,11 @@ jobs:
                   ;;
 
                 "date"|"text")
-<<<<<<< HEAD
-                  # shellcheck disable=SC2016
-                  gh api graphql -F projectId="$ENV_PROJECT_ID" \
-                               -F itemId="$issue_id" \
-                               -F fieldId="$ENV_UPDATE_FIELD_ID" \
-                               -F value="$ENV_UPDATE_FIELD_VALUE" \
-                               -F fieldType="$ENV_UPDATE_FIELD_TYPE" \
-=======
                   gh api graphql -f projectId="$ENV_PROJECT_ID" \
                                -f itemId="$issue_id" \
                                -f fieldId="$ENV_UPDATE_FIELD_ID" \
                                -f value="$ENV_UPDATE_FIELD_VALUE" \
                                -f fieldType="$ENV_UPDATE_FIELD_TYPE" \
->>>>>>> 861fe12 (Replace all `-F` usage with `-f`)
                                -f query='
                     mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: String!, $fieldType: String!) {
                       updateProjectV2ItemFieldValue(
@@ -192,18 +162,10 @@ jobs:
                   ;;
 
                 "number")
-<<<<<<< HEAD
-                  # shellcheck disable=SC2016
-                  gh api graphql -F projectId="$ENV_PROJECT_ID" \
-                               -F itemId="$issue_id" \
-                               -F fieldId="$ENV_UPDATE_FIELD_ID" \
-                               -F value="$ENV_UPDATE_FIELD_VALUE" \
-=======
                   gh api graphql -f projectId="$ENV_PROJECT_ID" \
                                -f itemId="$issue_id" \
                                -f fieldId="$ENV_UPDATE_FIELD_ID" \
                                -f value="$ENV_UPDATE_FIELD_VALUE" \
->>>>>>> 861fe12 (Replace all `-F` usage with `-f`)
                                -f query='
                     mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $value: Float!) {
                       updateProjectV2ItemFieldValue(

--- a/.github/workflows/project-update-linked-issues.yaml
+++ b/.github/workflows/project-update-linked-issues.yaml
@@ -101,6 +101,7 @@ jobs:
 
               case "$ENV_UPDATE_FIELD_TYPE" in
                 "iteration")
+                  # shellcheck disable=SC2016
                   gh api graphql -f projectId="$ENV_PROJECT_ID" \
                                -f itemId="$issue_id" \
                                -f fieldId="$ENV_UPDATE_FIELD_ID" \
@@ -121,6 +122,7 @@ jobs:
                   ;;
 
                 "single_select")
+                  # shellcheck disable=SC2016
                   gh api graphql -f projectId="$ENV_PROJECT_ID" \
                                -f itemId="$issue_id" \
                                -f fieldId="$ENV_UPDATE_FIELD_ID" \
@@ -141,6 +143,7 @@ jobs:
                   ;;
 
                 "date"|"text")
+                  # shellcheck disable=SC2016
                   gh api graphql -f projectId="$ENV_PROJECT_ID" \
                                -f itemId="$issue_id" \
                                -f fieldId="$ENV_UPDATE_FIELD_ID" \
@@ -162,6 +165,7 @@ jobs:
                   ;;
 
                 "number")
+                  # shellcheck disable=SC2016
                   gh api graphql -f projectId="$ENV_PROJECT_ID" \
                                -f itemId="$issue_id" \
                                -f fieldId="$ENV_UPDATE_FIELD_ID" \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,10 +9,10 @@ repos:
       - id: check-added-large-files
       - id: check-yaml
       - id: end-of-file-fixer
-  - repo: https://github.com/rhysd/actionlint
-    rev: v1.7.7
-    hooks:
-      - id: actionlint-docker
+  # - repo: https://github.com/rhysd/actionlint
+  #   rev: v1.7.7
+  #   hooks:
+  #     - id: actionlint-docker
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.9
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,9 @@
 ---
 # Copyright (c) 2025, NVIDIA CORPORATION.
 
+ci:
+  skip: [actionlint-docker]
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
@@ -9,10 +12,10 @@ repos:
       - id: check-added-large-files
       - id: check-yaml
       - id: end-of-file-fixer
-  # - repo: https://github.com/rhysd/actionlint
-  #   rev: v1.7.7
-  #   hooks:
-  #     - id: actionlint-docker
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.7
+    hooks:
+      - id: actionlint-docker
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.9
     hooks:


### PR DESCRIPTION
This pull request updates multiple GitHub Actions workflows to standardize the usage of the `gh api graphql` command by replacing the `-F` flag with the `-f` flag for all GraphQL variable inputs. This change ensures consistency and aligns with best practices for the `gh` CLI.

From GitHub

> [Using variables](https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/using-the-api-to-manage-projects?#using-variables)
> In all of the following examples, you can use variables to simplify your scripts. **Use -F to pass a variable that is a number, Boolean, or null. Use -f for other variables.** For example,
> ```shell
> my_org="octo-org"
> my_num=5
> gh api graphql -f query='
>   query($organization: String! $number: Int!){
>     organization(login: $organization){
>       projectV2(number: $number) {
>         id
>       }
>     }
>   }' -f organization=$my_org -F number=$my_num
> ```
> For more information, see [Forming calls with GraphQL](https://docs.github.com/en/graphql/guides/forming-calls-with-graphql#working-with-variables).

I'm unsure if this is a recent change, but [we hit the failure](https://github.com/rapidsai/cudf/actions/runs/14986563348/job/42101512121#step:3:33) when attempting to convert an integer into a string. GitHub may silently fix string-likes.

targeting python3.13 as cuDF found the failure; can merge to main after confirmation of resolution.