### PR TITLE
custom-job: deprecate 'run_script' input, in favor of 'script'

### DIFF
--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -19,6 +19,7 @@ on:
       script:
         type: string
         default: "ci/build_cpp.sh"
+        description: "Shell code to be executed in a step. Ideally this should just invoke a script managed in the repo the workflow runs from, like 'ci/build_cpp.sh'."
       upload-artifacts:
         type: boolean
         default: true

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -21,6 +21,7 @@ on:
       script:
         type: string
         default: "ci/test_cpp.sh"
+        description: "Shell code to be executed in a step. Ideally this should just invoke a script managed in the repo the workflow runs from, like 'ci/test_cpp.sh'."
       matrix_filter:
         type: string
         default: "."

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -19,6 +19,7 @@ on:
       script:
         type: string
         default: "ci/build_python.sh"
+        description: "Shell code to be executed in a step. Ideally this should just invoke a script managed in the repo the workflow runs from, like 'ci/build_python.sh'."
       upload-artifacts:
         type: boolean
         default: true

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -21,6 +21,7 @@ on:
       script:
         type: string
         default: "ci/test_python.sh"
+        description: "Shell code to be executed in a step. Ideally this should just invoke a script managed in the repo the workflow runs from, like 'ci/test_python.sh'."
       run_codecov:
         type: boolean
         default: true

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -23,8 +23,9 @@ on:
         type: string
         default: "rapidsai/ci-conda:latest"
       run_script:
-        required: true
+        required: false
         type: string
+        description: "DEPRECATED - use 'script' instead"
       script:
         required: false
         type: string

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -25,6 +25,10 @@ on:
       run_script:
         required: true
         type: string
+      script:
+        required: false
+        type: string
+        description: "Shell code to be executed in a step. Ideally this should just invoke a script managed in the repo the workflow runs from, like 'ci/test_java.sh'."
       file_to_upload:
         type: string
         default: "gh-status.json"
@@ -99,7 +103,7 @@ jobs:
             echo "RAPIDS_NIGHTLY_DATE=${RAPIDS_NIGHTLY_DATE}"
           } >> "${GITHUB_ENV}"
       - name: Run script
-        run: ${{ inputs.run_script }}
+        run: ${{ inputs.script || inputs.run_script }}
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Upload file to GitHub Artifact

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -19,6 +19,7 @@ on:
       script:
         required: true
         type: string
+        description: "Shell code to be executed in a step. Ideally this should just invoke a script managed in the repo the workflow runs from, like 'ci/build_wheel.sh'."
       package-name:
         required: true
         type: string

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -24,6 +24,7 @@ on:
       script:
         type: string
         default: "ci/test_wheel.sh"
+        description: "Shell code to be executed in a step. Ideally this should just invoke a script managed in the repo the workflow runs from, like 'ci/test_wheel.sh'."
       matrix_filter:
         type: string
         default: "."


### PR DESCRIPTION
Contributes to #337 and #356

`custom-job.yaml` accepts an input called `run_script`

https://github.com/rapidsai/shared-workflows/blob/2f858a6bafd375bd495042f73c1669cc17aa4d48/.github/workflows/custom-job.yaml#L25-L27

All other workflows which accept a script like that use the name `script` for such input:

https://github.com/rapidsai/shared-workflows/blob/2f858a6bafd375bd495042f73c1669cc17aa4d48/.github/workflows/conda-cpp-build.yaml#L19-L21

This starts the process of resolving that inconsistency. It adds support for input `script` to the `custom-job` workflow.

Once all repos have been migrated, a follow-up PR will remove `run_script` here and make `script:` required.

## Notes for Reviewers

### How I tested this

Tested on an `rmm` PR, both with `script:` supplied and `run_script:` supplied. Both forms worked, so I think this is safe to merge.

Details: https://github.com/rapidsai/rmm/pull/1926#issuecomment-2895813992