### PR TITLE
fix: update jq command to remove `exit 4` errors when there is no linked issue

### DIFF
--- a/.github/workflows/project-update-linked-issues.yaml
+++ b/.github/workflows/project-update-linked-issues.yaml
@@ -83,7 +83,7 @@ jobs:
               }' > linked_issues.json
 
             # Use jq with proper variable handling to get issue IDs
-            issue_ids=$(jq --exit-status --arg project_id "$ENV_PROJECT_ID" -r '
+            issue_ids=$(jq --arg project_id "$ENV_PROJECT_ID" -r '
               .data.node.closingIssuesReferences.nodes[].projectItems.nodes[] |
               select(.project.id == $project_id) |
               .id' linked_issues.json)


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/project-update-linked-issues.yaml` file.

Per [the jq docs ](https://jqlang.org/manual/):

>  `--exit-status / -e:`
> 
> Sets the exit status of jq to 0 if the last output value was neither false nor null, 1 if the last output value was either false or null, **or 4 if no valid result was ever produced**. Normally jq exits with 2 if there was any usage problem or system error, 3 if there was a jq program compile error, or 0 if the jq program ran.

So when we had no linked issues, the `--exit-status` part of the command caused actions to note an error, rather than the later logic in the script which exits 0 since there's no further action with no linked issues.

* Workflow improvement:
  * [`.github/workflows/project-update-linked-issues.yaml`](diffhunk://#diff-2267a44063f4c081b45b0264e2afe5163280e3d03f0793f0ea0e288040e233a7L86-R86): Removed the `--exit-status` flag from the `jq` command used to extract issue IDs.

