### PR TITLE
make 'script' input required

### DIFF
--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -18,7 +18,7 @@ on:
         default: "cpu8"
       script:
         type: string
-        default: "ci/build_cpp.sh"
+        required: true
         description: "Shell code to be executed in a step. Ideally this should just invoke a script managed in the repo the workflow runs from, like 'ci/build_cpp.sh'."
       upload-artifacts:
         type: boolean

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -20,7 +20,7 @@ on:
         type: string
       script:
         type: string
-        default: "ci/test_cpp.sh"
+        required: true
         description: "Shell code to be executed in a step. Ideally this should just invoke a script managed in the repo the workflow runs from, like 'ci/test_cpp.sh'."
       matrix_filter:
         type: string

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -18,7 +18,7 @@ on:
         default: "cpu8"
       script:
         type: string
-        default: "ci/build_python.sh"
+        required: true
         description: "Shell code to be executed in a step. Ideally this should just invoke a script managed in the repo the workflow runs from, like 'ci/build_python.sh'."
       upload-artifacts:
         type: boolean

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -20,7 +20,7 @@ on:
         type: string
       script:
         type: string
-        default: "ci/test_python.sh"
+        required: true
         description: "Shell code to be executed in a step. Ideally this should just invoke a script managed in the repo the workflow runs from, like 'ci/test_python.sh'."
       run_codecov:
         type: boolean

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -23,7 +23,7 @@ on:
         default: "auto"
       script:
         type: string
-        default: "ci/test_wheel.sh"
+        required: true
         description: "Shell code to be executed in a step. Ideally this should just invoke a script managed in the repo the workflow runs from, like 'ci/test_wheel.sh'."
       matrix_filter:
         type: string


### PR DESCRIPTION
Closes #356

Proposes removing default values for `script:` from all workflows, and making that input required.

This makes configuration of these workflows a bit more explicit and reduces configuration complexity.

## Notes for Reviewers

### How I tested this

Found uses of these workflows (across `nv-legate`, `nv-morpheus`, `NVIDIA`, and `rapidsai` orgs) via GitHub search, and I believe I've migrated all of them. See the list in #356.

So this should hopefully not break any projects' CI.

But if it does break something, the error will be loud and obvious, and the fix will be quick.