### PR TITLE
[DO NOT MERGE] remove 'run_script' input from custom-job

### DIFF
--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -22,10 +22,6 @@ on:
       container_image:
         type: string
         default: "rapidsai/ci-conda:latest"
-      run_script:
-        required: false
-        type: string
-        description: "DEPRECATED - use 'script' instead"
       script:
         required: false
         type: string
@@ -104,7 +100,7 @@ jobs:
             echo "RAPIDS_NIGHTLY_DATE=${RAPIDS_NIGHTLY_DATE}"
           } >> "${GITHUB_ENV}"
       - name: Run script
-        run: ${{ inputs.script || inputs.run_script }}
+        run: ${{ inputs.script }}
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Upload file to GitHub Artifact


### PR DESCRIPTION
Closes #337 

Proposes removing `run_script` input to the `custom-job` workflow.

See the list in #337 ... all actively-developed repos using `branch-25.06` or newer of `shared-workflows` have been updated to use `script:` instead (see the list in #337).

GitHub search: https://github.com/search?q=org%3Arapidsai+%22+run_script%3A+%22+language%3AYAML+path%3A.github%2Fworkflows%2F*+AND+NOT+is%3Aarchived&type=code

## Notes for Reviewers

### Do not merge this yet

Need these PRs to be merged first:

* [ ] https://github.com/rapidsai/rapids-logger/pull/39