### PR TITLE
WIP: print GitHub API rate limit information to logs

### DIFF
--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -131,6 +131,17 @@ jobs:
         with:
             extra_attributes: "rapids.PACKAGER=conda,rapids.CUDA_VER=${{ matrix.CUDA_VER }},rapids.PY_VER=${{ matrix.PY_VER }},rapids.ARCH=${{ matrix.ARCH }},rapids.LINUX_VER=${{ matrix.LINUX_VER }}"
 
+      # Per the docs at https://docs.github.com/en/rest/rate-limit/rate-limit?apiVersion=2022-11-28#get-rate-limit-status-for-the-authenticated-user,
+      # checking '/rate_limit' should not itself count against any rate limits.
+      - name: Check GitHub API rate limits
+        run: |
+          if ! type gh >/dev/null; then
+              echo "'gh' CLI is not installed... skipping rate-limits check"
+          else
+              gh api /rate_limit
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: C++ build
         run: ${{ inputs.script }}
         env:

--- a/.github/workflows/conda-cpp-post-build-checks.yaml
+++ b/.github/workflows/conda-cpp-post-build-checks.yaml
@@ -75,6 +75,17 @@ jobs:
             echo "RAPIDS_REF_NAME=${RAPIDS_REF_NAME}"
             echo "RAPIDS_NIGHTLY_DATE=${RAPIDS_NIGHTLY_DATE}"
           } >> "${GITHUB_ENV}"
+      # Per the docs at https://docs.github.com/en/rest/rate-limit/rate-limit?apiVersion=2022-11-28#get-rate-limit-status-for-the-authenticated-user,
+      # checking '/rate_limit' should not itself count against any rate limits.
+      - name: Check GitHub API rate limits
+        run: |
+          if ! type gh >/dev/null; then
+              echo "'gh' CLI is not installed... skipping rate-limits check"
+          else
+              gh api /rate_limit
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Download conda C++ build artifacts
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -173,6 +173,17 @@ jobs:
         uses: nv-gha-runners/setup-proxy-cache@main
         continue-on-error: true
 
+      # Per the docs at https://docs.github.com/en/rest/rate-limit/rate-limit?apiVersion=2022-11-28#get-rate-limit-status-for-the-authenticated-user,
+      # checking '/rate_limit' should not itself count against any rate limits.
+      - name: Check GitHub API rate limits
+        run: |
+          if ! type gh >/dev/null; then
+              echo "'gh' CLI is not installed... skipping rate-limits check"
+          else
+              gh api /rate_limit
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: C++ tests
         run: ${{ inputs.script }}
         env:

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -136,6 +136,17 @@ jobs:
           extra_attributes: "rapids.PACKAGER=conda,rapids.CUDA_VER=${{ matrix.CUDA_VER }},rapids.PY_VER=${{ matrix.PY_VER }},rapids.ARCH=${{ matrix.ARCH }},rapids.LINUX_VER=${{ matrix.LINUX_VER }}"
       - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
+      # Per the docs at https://docs.github.com/en/rest/rate-limit/rate-limit?apiVersion=2022-11-28#get-rate-limit-status-for-the-authenticated-user,
+      # checking '/rate_limit' should not itself count against any rate limits.
+      - name: Check GitHub API rate limits
+        run: |
+          if ! type gh >/dev/null; then
+              echo "'gh' CLI is not installed... skipping rate-limits check"
+          else
+              gh api /rate_limit
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Python build
         run: ${{ inputs.script }}
         env:

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -178,6 +178,17 @@ jobs:
         uses: nv-gha-runners/setup-proxy-cache@main
         continue-on-error: true
 
+      # Per the docs at https://docs.github.com/en/rest/rate-limit/rate-limit?apiVersion=2022-11-28#get-rate-limit-status-for-the-authenticated-user,
+      # checking '/rate_limit' should not itself count against any rate limits.
+      - name: Check GitHub API rate limits
+        run: |
+          if ! type gh >/dev/null; then
+              echo "'gh' CLI is not installed... skipping rate-limits check"
+          else
+              gh api /rate_limit
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Python tests
         run: ${{ inputs.script }}
         env:

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -75,6 +75,17 @@ jobs:
             echo "RAPIDS_NIGHTLY_DATE=${RAPIDS_NIGHTLY_DATE}"
           } >> "${GITHUB_ENV}"
 
+      # Per the docs at https://docs.github.com/en/rest/rate-limit/rate-limit?apiVersion=2022-11-28#get-rate-limit-status-for-the-authenticated-user,
+      # checking '/rate_limit' should not itself count against any rate limits.
+      - name: Check GitHub API rate limits
+        run: |
+          if ! type gh >/dev/null; then
+              echo "'gh' CLI is not installed... skipping rate-limits check"
+          else
+              gh api /rate_limit
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Set Proper Conda Upload Token
         run: |
           RAPIDS_CONDA_TOKEN=${{ secrets.CONDA_RAPIDSAI_NIGHTLY_TOKEN }}

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -103,6 +103,17 @@ jobs:
             echo "RAPIDS_REF_NAME=${RAPIDS_REF_NAME}"
             echo "RAPIDS_NIGHTLY_DATE=${RAPIDS_NIGHTLY_DATE}"
           } >> "${GITHUB_ENV}"
+      # Per the docs at https://docs.github.com/en/rest/rate-limit/rate-limit?apiVersion=2022-11-28#get-rate-limit-status-for-the-authenticated-user,
+      # checking '/rate_limit' should not itself count against any rate limits.
+      - name: Check GitHub API rate limits
+        run: |
+          if ! type gh >/dev/null; then
+              echo "'gh' CLI is not installed... skipping rate-limits check"
+          else
+              gh api /rate_limit
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Run script
         run: ${{ inputs.script || inputs.run_script }}
         env:

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -197,6 +197,17 @@ jobs:
         with:
           extra_attributes: "rapids.PACKAGER=wheel,rapids.CUDA_VER=${{ matrix.CUDA_VER }},rapids.PY_VER=${{ matrix.PY_VER }},rapids.ARCH=${{ matrix.ARCH }},rapids.LINUX_VER=${{ matrix.LINUX_VER }}"
 
+      # Per the docs at https://docs.github.com/en/rest/rate-limit/rate-limit?apiVersion=2022-11-28#get-rate-limit-status-for-the-authenticated-user,
+      # checking '/rate_limit' should not itself count against any rate limits.
+      - name: Check GitHub API rate limits
+        run: |
+          if ! type gh >/dev/null; then
+              echo "'gh' CLI is not installed... skipping rate-limits check"
+          else
+              gh api /rate_limit
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Build and repair the wheel
         run: |
           ${{ inputs.script }}

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -86,6 +86,18 @@ jobs:
         date: ${{ inputs.date }}
         sha: ${{ inputs.sha }}
 
+    # Per the docs at https://docs.github.com/en/rest/rate-limit/rate-limit?apiVersion=2022-11-28#get-rate-limit-status-for-the-authenticated-user,
+    # checking '/rate_limit' should not itself count against any rate limits.
+    - name: Check GitHub API rate limits
+      run: |
+        if ! type gh >/dev/null; then
+            echo "'gh' CLI is not installed... skipping rate-limits check"
+        else
+            gh api /rate_limit
+        fi
+      env:
+        GH_TOKEN: ${{ github.token }}
+
     - name: Download wheels from artifact storage and publish to anaconda repository
       run: rapids-wheels-anaconda "${{ inputs.package-name }}" "${{ inputs.package-type }}"
       env:

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -181,6 +181,18 @@ jobs:
       uses: nv-gha-runners/setup-proxy-cache@main
       continue-on-error: true
 
+    # Per the docs at https://docs.github.com/en/rest/rate-limit/rate-limit?apiVersion=2022-11-28#get-rate-limit-status-for-the-authenticated-user,
+    # checking '/rate_limit' should not itself count against any rate limits.
+    - name: Check GitHub API rate limits
+      run: |
+        if ! type gh >/dev/null; then
+            echo "'gh' CLI is not installed... skipping rate-limits check"
+        else
+            gh api /rate_limit
+        fi
+      env:
+        GH_TOKEN: ${{ github.token }}
+
     - name: Run tests
       run: ${{ inputs.script }}
       env:


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-infra/issues/241

Proposes printing information about GitHub API rate limits to logs.

## Notes for Reviewers

### Intentionally targeting 25.06

We have a bit of a way to go on the 25.06 release, and I think we'll want this rate-limiting information available if more issues come up while trying to get the release out.

### How I tested this

TBD