### PR TITLE
WIP: [NOT READY FOR REVIEW] Allow use of a different GitHub token from repo secrets

### DIFF
--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -28,6 +28,13 @@ on:
       matrix_filter:
         type: string
         default: "."
+      alternative-gh-token-secret-name:
+        type: string
+        required: false
+        description: |
+          If provided, should contain the name of a secret in the repo which holds a GitHub API token.
+          When this is non-empty, that secret's value is used in place of the default repo-level token
+          anywhere that environment variable GH_TOKEN is set.
 
 defaults:
   run:
@@ -141,12 +148,12 @@ jobs:
               gh api /rate_limit | jq .
           fi
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ inputs.alternative-gh-token-secret-name && secrets[inputs.alternative-gh-token-secret-name] || github.token }}
       - name: C++ build
         run: ${{ inputs.script }}
         env:
           STEP_NAME: "C++ build"
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ inputs.alternative-gh-token-secret-name && secrets[inputs.alternative-gh-token-secret-name] || github.token }}
       - name: Get Package Name and Location
         if: ${{ inputs.upload-artifacts }}
         run: |

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -35,6 +35,13 @@ on:
           If not set (the default), artifact-handling scripts use RAPIDS-conventional defaults (like "build.yaml" when "build_type == nightly").
         required: false
         type: string
+      alternative-gh-token-secret-name:
+        type: string
+        required: false
+        description: |
+          If provided, should contain the name of a secret in the repo which holds a GitHub API token.
+          When this is non-empty, that secret's value is used in place of the default repo-level token
+          anywhere that environment variable GH_TOKEN is set.
 
 defaults:
   run:
@@ -185,11 +192,11 @@ jobs:
               gh api /rate_limit | jq .
           fi
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ inputs.alternative-gh-token-secret-name && secrets[inputs.alternative-gh-token-secret-name] || github.token }}
       - name: C++ tests
         run: ${{ inputs.script }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ inputs.alternative-gh-token-secret-name && secrets[inputs.alternative-gh-token-secret-name] || github.token }}
       - name: Generate test report
         uses: test-summary/action@v2.4
         with:

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -28,6 +28,13 @@ on:
       matrix_filter:
         type: string
         default: "."
+      alternative-gh-token-secret-name:
+        type: string
+        required: false
+        description: |
+          If provided, should contain the name of a secret in the repo which holds a GitHub API token.
+          When this is non-empty, that secret's value is used in place of the default repo-level token
+          anywhere that environment variable GH_TOKEN is set.
 
 defaults:
   run:
@@ -146,11 +153,11 @@ jobs:
               gh api /rate_limit | jq .
           fi
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ inputs.alternative-gh-token-secret-name && secrets[inputs.alternative-gh-token-secret-name] || github.token }}
       - name: Python build
         run: ${{ inputs.script }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ inputs.alternative-gh-token-secret-name && secrets[inputs.alternative-gh-token-secret-name] || github.token }}
       - name: Get Package Name and Location
         if: ${{ inputs.upload-artifacts }}
         run: |

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -38,6 +38,13 @@ on:
           If not set (the default), artifact-handling scripts use RAPIDS-conventional defaults (like "build.yaml" when "build_type == nightly").
         required: false
         type: string
+      alternative-gh-token-secret-name:
+        type: string
+        required: false
+        description: |
+          If provided, should contain the name of a secret in the repo which holds a GitHub API token.
+          When this is non-empty, that secret's value is used in place of the default repo-level token
+          anywhere that environment variable GH_TOKEN is set.
 
 defaults:
   run:
@@ -190,11 +197,11 @@ jobs:
               gh api /rate_limit | jq .
           fi
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ inputs.alternative-gh-token-secret-name && secrets[inputs.alternative-gh-token-secret-name] || github.token }}
       - name: Python tests
         run: ${{ inputs.script }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ inputs.alternative-gh-token-secret-name && secrets[inputs.alternative-gh-token-secret-name] || github.token }}
       - name: Generate test report
         uses: test-summary/action@v2.4
         with:

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -39,6 +39,13 @@ on:
           If not set (the default), artifact-handling scripts use RAPIDS-conventional defaults (like "build.yaml" when "build_type == nightly").
         required: false
         type: string
+      alternative-gh-token-secret-name:
+        type: string
+        required: false
+        description: |
+          If provided, should contain the name of a secret in the repo which holds a GitHub API token.
+          When this is non-empty, that secret's value is used in place of the default repo-level token
+          anywhere that environment variable GH_TOKEN is set.
 
 defaults:
   run:
@@ -111,11 +118,11 @@ jobs:
               gh api /rate_limit | jq .
           fi
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ inputs.alternative-gh-token-secret-name && secrets[inputs.alternative-gh-token-secret-name] || github.token }}
       - name: Run script
         run: ${{ inputs.script }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ inputs.alternative-gh-token-secret-name && secrets[inputs.alternative-gh-token-secret-name] || github.token }}
       - name: Upload file to GitHub Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -54,21 +54,28 @@ on:
         default: true
         required: false
         description: "One of [true, false], true if artifacts should be uploaded to GitHub's artifact store"
-
-      # Extra repository that will be cloned into the project directory.
       extra-repo:
         required: false
         type: string
         default: ''
+        description: "Extra repository that will be cloned into the project directory."
       extra-repo-sha:
         required: false
         type: string
         default: ''
-      # Note that this is the _name_ of a secret containing the key, not the key itself.
+        description: "Commit SHA in 'extra-repo' to clone."
       extra-repo-deploy-key:
         required: false
         type: string
         default: ''
+        description: "The _name_ of a secret containing a deploy key for 'extra-repo' (not the key itself)."
+      alternative-gh-token-secret-name:
+        type: string
+        required: false
+        description: |
+          If provided, should contain the name of a secret in the repo which holds a GitHub API token.
+          When this is non-empty, that secret's value is used in place of the default repo-level token
+          anywhere that environment variable GH_TOKEN is set.
 
 defaults:
   run:
@@ -207,12 +214,12 @@ jobs:
               gh api /rate_limit | jq .
           fi
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ inputs.alternative-gh-token-secret-name && secrets[inputs.alternative-gh-token-secret-name] || github.token }}
       - name: Build and repair the wheel
         run: |
           ${{ inputs.script }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ inputs.alternative-gh-token-secret-name && secrets[inputs.alternative-gh-token-secret-name] || github.token }}
         # Use a shell that loads the rc file so that we get the compiler settings
         shell: bash -leo pipefail {0}
 

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -36,17 +36,24 @@ on:
         required: false
         type: string
         default: "fail"
-      # Note that this is the _name_ of a secret containing the key, not the key itself.
       rapids-aux-secret-1:
         required: false
         type: string
         default: ''
+        description: "The name of an extra secret in the repo (not the content of the secret itself)."
       build_workflow_name:
         description: |
           Name of a workflow file that produced artifacts to be downloaded in this run.
           If not set (the default), artifact-handling scripts use RAPIDS-conventional defaults (like "build.yaml" when "build_type == nightly").
         required: false
         type: string
+      alternative-gh-token-secret-name:
+        type: string
+        required: false
+        description: |
+          If provided, should contain the name of a secret in the repo which holds a GitHub API token.
+          When this is non-empty, that secret's value is used in place of the default repo-level token
+          anywhere that environment variable GH_TOKEN is set.
 
 defaults:
   run:
@@ -198,12 +205,12 @@ jobs:
             gh api /rate_limit | jq .
         fi
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ inputs.alternative-gh-token-secret-name && secrets[inputs.alternative-gh-token-secret-name] || github.token }}
 
     - name: Run tests
       run: ${{ inputs.script }}
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ inputs.alternative-gh-token-secret-name && secrets[inputs.alternative-gh-token-secret-name] || github.token }}
         RAPIDS_AUX_SECRET_1: ${{ inputs.rapids-aux-secret-1 != '' && secrets[inputs.rapids-aux-secret-1] || '' }}
 
     - name: Generate test report


### PR DESCRIPTION
Replaces #324

Occasionally, we want to run workflows which need more permissions for the GitHub API than the GitHub token automatically generated in each repo.

See https://github.com/rapidsai/build-infra/issues/242 (private issue, sorry)

This proposes adding an input to the workflows where RAPIDS has known use-cases for that type of thing, which allows specifying, at the call site for a workflow, the name of a secret in the repo which contains an alternative GitHub API token.

It also proposes adding logic to `pr-builder` to prevent checking in code that references that secret permanently. This mechanism is only intended for the type of testing described in https://docs.rapids.ai/resources/github-actions/#downloading-ci-artifacts.

## Notes for Reviewers

### How I tested this

TBD