### PR TITLE
create workflow to sync main branch to branch-25.08

### DIFF
--- a/.github/workflows/branch-migration-sync.yaml
+++ b/.github/workflows/branch-migration-sync.yaml
@@ -1,0 +1,22 @@
+name: Sync main to branch-25.08 (migration)
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync-branches:
+    runs-on: ubuntu-latest
+    name: Syncing branches
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: "branch-25.08"
+      - shell: bash
+        run: |
+          git config --global user.email "noreply@nvidia.com"
+          git config --global user.name "NVIDIA RAPIDS Bot"
+          git config --global push.default current
+          git pull --ff-only origin main
+          git push origin branch-25.08


### PR DESCRIPTION
This is one possible solution to https://github.com/rapidsai/ops/issues/3935#issuecomment-2851460675

This strategy makes branch-25.08 a one-way mirror of main. I used the --ff-only merge strategy so that things just fail if there's any kind of ambiguity in the merge.

There are other ways to do this that create PRs instead of direct pushes, such as https://github.com/marketplace/actions/sync-branches. I'm not sure if we need them.