### PR TITLE
conda-cpp-post-build-checks: switch to always running by default, add docs

### DIFF
--- a/.github/workflows/conda-cpp-post-build-checks.yaml
+++ b/.github/workflows/conda-cpp-post-build-checks.yaml
@@ -20,10 +20,15 @@ on:
         description: "Git repo to check out, in '{org}/{repo}' form, e.g. 'rapidsai/cudf'"
         type: string
       enable_check_symbols:
-        default: false
+        default: true
         type: boolean
         required: false
       symbol_exclusions:
+        description: |
+          Regular expression matching unmangled symbol names to be ignored by this check.
+          Should be wrapped in '()' to form a capture group.
+          For example, to ignore any function symbols coming from the 'thrust' or 'cub' namespaces,
+          you might provide '(void (thrust::|cub::))'.
         type: string
 
 defaults:


### PR DESCRIPTION
Contributes to #376

Contributes to #379

Some small changes to `conda-cpp-post-build-checks`:

* adds a description to the `symbol_exclusions` input
* switches the default for `enable_check_symbols` to `true`
  - *see #379 ... all repos calling this are already directly passing `true`. This is a step towards completely removing that input.*