### PR TITLE
Version CI images.

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -40,7 +40,7 @@ jobs:
   other-checks:
     runs-on: ubuntu-latest
     container:
-      image: rapidsai/ci-conda:latest
+      image: rapidsai/ci-conda:25.08-latest
       env:
         RAPIDS_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -76,7 +76,7 @@ jobs:
     if: ${{ inputs.enable_check_style }}
     runs-on: ubuntu-latest
     container:
-      image: rapidsai/ci-conda:latest
+      image: rapidsai/ci-conda:25.08-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -103,7 +103,7 @@ jobs:
     env:
       RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
     container:
-      image: rapidsai/ci-conda:cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
+      image: rapidsai/ci-conda:25.08-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:

--- a/.github/workflows/conda-cpp-post-build-checks.yaml
+++ b/.github/workflows/conda-cpp-post-build-checks.yaml
@@ -50,7 +50,7 @@ jobs:
     if: ${{ inputs.enable_check_symbols }}
     runs-on: linux-amd64-cpu4
     container:
-      image: rapidsai/ci-wheel:latest
+      image: rapidsai/ci-wheel:25.08-latest
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -149,7 +149,7 @@ jobs:
       RAPIDS_DEPENDENCIES: ${{ matrix.DEPENDENCIES }}
       RAPIDS_TESTS_DIR: ${{ github.workspace }}/test-results
     container:
-      image: rapidsai/ci-conda:cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
+      image: rapidsai/ci-conda:25.08-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
       options: ${{ inputs.container-options }}
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -108,7 +108,7 @@ jobs:
     env:
       RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
     container:
-      image: rapidsai/ci-conda:cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
+      image: rapidsai/ci-conda:25.08-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -153,7 +153,7 @@ jobs:
       RAPIDS_DEPENDENCIES: ${{ matrix.DEPENDENCIES }}
       RAPIDS_TESTS_DIR: ${{ github.workspace }}/test-results
     container:
-      image: rapidsai/ci-conda:cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
+      image: rapidsai/ci-conda:25.08-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
       options: ${{ inputs.container-options }}
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -49,7 +49,7 @@ jobs:
   upload:
     runs-on: linux-amd64-cpu4
     container:
-      image: rapidsai/ci-conda:latest
+      image: rapidsai/ci-conda:25.08-latest
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -27,7 +27,7 @@ on:
         default: "cpu8"
       container_image:
         type: string
-        default: "rapidsai/ci-conda:latest"
+        default: "rapidsai/ci-conda:25.08-latest"
       script:
         required: false
         type: string

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -147,7 +147,7 @@ jobs:
     env:
       RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
     container:
-      image: "rapidsai/ci-wheel:cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
+      image: "rapidsai/ci-wheel:25.08-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
 

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -60,7 +60,7 @@ jobs:
     container:
       # CUDA toolkit version of the container is irrelevant in the publish step.
       # This just uploads already-built wheels to remote storage.
-      image: "rapidsai/ci-wheel:latest"
+      image: "rapidsai/ci-wheel:25.08-latest"
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -159,7 +159,7 @@ jobs:
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
     runs-on: "linux-${{ matrix.ARCH }}-gpu-${{ matrix.GPU }}-${{ matrix.DRIVER }}-1"
     container:
-      image: "rapidsai/citestwheel:cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
+      image: "rapidsai/citestwheel:25.08-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
       options: ${{ inputs.container-options }}
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }} # GPU jobs must set this container env variable

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -26,5 +26,5 @@ for FILE in .github/workflows/*.yaml; do
   sed_runner "/rapidsai\/shared-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"
 
   # Update CI image tags
-  sed_runner "/rapidsai\/ci-/ s/:[0-9\.]*-/:${NEXT_SHORT_TAG}-/g" "${FILE}"
+  sed_runner "/rapidsai\/ci.*:[0-9\.]*-/ s/:[0-9\.]*-/:${NEXT_SHORT_TAG}-/g" "${FILE}"
 done

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -24,4 +24,7 @@ function sed_runner() {
 
 for FILE in .github/workflows/*.yaml; do
   sed_runner "/rapidsai\/shared-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"
+
+  # Update CI image tags
+  sed_runner "/rapidsai\/ci-/ s/:[0-9\.]*-/:${NEXT_SHORT_TAG}-/g" "${FILE}"
 done


### PR DESCRIPTION
This adds major.minor version prefixes to CI image tags.

Image names like `rapidsai/ci-conda:cuda12.9.0-ubuntu24.04-py3.13` will now be `rapidsai/ci-conda:25.08-cuda12.9.0-ubuntu24.04-py3.13`.

This allows us to pin CI images before a release, and continue work on CI images targeting new versions.

Depends on https://github.com/rapidsai/ci-imgs/pull/287.

More information: https://github.com/rapidsai/build-planning/issues/187