### PR TITLE
remove ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,12 +16,6 @@ repos:
     rev: v1.7.7
     hooks:
       - id: actionlint-docker
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.0
-    hooks:
-      - id: ruff
-        args: ["--fix"]
-      - id: ruff-format
   - repo: https://github.com/rapidsai/pre-commit-hooks
     rev: v0.7.0
     hooks:


### PR DESCRIPTION
Follow-up to #349

This repo doesn't contain any Python code, and there aren't plans to add any.

So there's nothing for `ruff` to do here. This removes it from the `pre-commit` config, to simplify configuration and reduce the frequency of auto-update PRs like #383.