### PR TITLE
Add descriptions on all inputs

### DIFF
--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -10,34 +10,60 @@ on:
         type: string
         default: '["amd64"]'
       cuda:
+        description: |
+          Stringified JSON array of CUDA versions to run this workflow for.
+          This is used to select .devcontainer/ directories local to wherever this workflow is invoked from.
+          For example, if a repository has directories '.devcontainer/cuda12.0-pip/' and '.devcontainer/cuda12.8-pip/',
+          '["12.0", "12.8"]' could be passed here to build both of those devcontainers in CI.
         type: string
         default: '["12.0"]'
       python_package_manager:
+        description: |
+          Stringified JSON array of Python package managers to run devcontainer builds for.
+          One of: '["conda"]', '["pip"]', '["conda", "pip"]'.
         type: string
         default: '["conda", "pip"]'
       repo:
+        description: "Git repo to check out, in '{org}/{repo}' form, e.g. 'rapidsai/cudf'"
         type: string
       timeout-minutes:
+        description: "Maximum time (in minutes) allowed for a run of this workflow."
         type: number
         default: 360
       node_type:
+        description: |
+          Suffix, without leading '-', indicating the type of machine to run jobs on (e.g., 'cpu4' or 'gpu-l4-latest-1').
+          Runner labels are of the form '{operating_system}-{arch}-{node_type}'.
+          See https://github.com/nv-gha-runners/enterprise-runner-configuration/blob/main/docs/runner-groups.md for a list
+          of valid values.
         type: string
         default: "cpu8"
       build_command:
+        description: |
+          Shell commands to run inside the devcontainer after it's built and started.
+          This is almost always some form of 'build-all --verbose;'.
+          See https://github.com/rapidsai/devcontainers for details.
         type: string
         required: true
-      # Note that this is the _name_ of a secret containing the key, not the key itself.
       extra-repo-deploy-key:
+        description: |
+          The NAME (not value) of a GitHub secret in the calling repo, containing a repo deploy key.
+          This is here to allow the use of private repos in runs of this workflow.
         required: false
         type: string
         default: ''
-      # Note that this is the _name_ of a secret containing the key, not the key itself.
       extra-repo-deploy-key-2:
+        description: |
+          The NAME (not value) of a GitHub secret in the calling repo, containing a repo deploy key.
+          This is here to allow the use of private repos in runs of this workflow.
         required: false
         type: string
         default: ''
-      # Note that this is the _name_ of a secret containing the key, not the key itself.
       rapids-aux-secret-1:
+        description: |
+          The NAME (not value) of a GitHub secret in the calling repo.
+          This allows callers of the workflow to make a single secret available in the devcontainer's
+          environment, via environment variable `RAPIDS_AUX_SECRET_1`.
         required: false
         type: string
         default: ''

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -2,11 +2,15 @@ on:
   workflow_call:
     inputs:
       env:
+        description: |
+          Additional environment variables to be set inside the devcontainer.
+          Should be a space-delimited string in the form "KEY=value".
         type: string
       sha:
         description: "Full git commit SHA to check out"
         type: string
       arch:
+        description: "One of [amd64, arm64]. CPU architecture to run on."
         type: string
         default: '["amd64"]'
       cuda:
@@ -48,14 +52,14 @@ on:
       extra-repo-deploy-key:
         description: |
           The NAME (not value) of a GitHub secret in the calling repo, containing a repo deploy key.
-          This is here to allow the use of private repos in runs of this workflow.
+          This is here to allow the use of additional private repos in runs of this workflow.
         required: false
         type: string
         default: ''
       extra-repo-deploy-key-2:
         description: |
           The NAME (not value) of a GitHub secret in the calling repo, containing a repo deploy key.
-          This is here to allow the use of private repos in runs of this workflow.
+          This is here to allow the use of additional private repos in runs of this workflow.
         required: false
         type: string
         default: ''

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -14,7 +14,7 @@ on:
       transform_expr:
         description: |
           jq expression for post-processing results to create this workflow's outputs.
-          Provided for backwards compatibility, should not need to be updated with normal use.
+          Provided for backwards compatibility; should not need to be updated with normal use.
         type: string
         required: false
         default: |

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -2,9 +2,19 @@ on:
   workflow_call:
     inputs:
       files_yaml:
+        description: |
+          YAML string containing mappings of the form `{key}: [{glob1}, {glob2}, etc.]`.
+          Where `{key}` is an arbitrary identifier for grouping a set of changed files
+          (e.g. "test_cpp" for "if these files change, C++ tests should be re-run") and
+          each `{glob}` is a glob expression matching file paths in the calling repo.
+          For example, "re-run all C++ tests on any changes EXCEPT docs" might look like this:
+          'test_cpp: ["**", "!docs/**"]'.
         type: string
         required: true
       transform_expr:
+        description: |
+          jq expression for post-processing results to create this workflow's outputs.
+          Provided for backwards compatibility, should not need to be updated with normal use.
         type: string
         required: false
         default: |

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -20,6 +20,11 @@ on:
         description: "Git repo to check out, in '{org}/{repo}' form, e.g. 'rapidsai/cudf'"
         type: string
       node_type:
+        description: |
+          Suffix, without leading '-', indicating the type of machine to run jobs on (e.g., 'cpu4' or 'gpu-l4-latest-1').
+          Runner labels are of the form '{operating_system}-{arch}-{node_type}'.
+          See https://github.com/nv-gha-runners/enterprise-runner-configuration/blob/main/docs/runner-groups.md for a list
+          of valid values.
         type: string
         default: "cpu8"
       script:
@@ -32,6 +37,9 @@ on:
         required: false
         description: "One of [true, false], true if artifacts should be uploaded to GitHub's artifact store"
       matrix_filter:
+        description: |
+          jq expression which modifies the matrix.
+          For example, 'map(select(.ARCH == "amd64"))' to achieve "only run amd64 jobs".
         type: string
         default: "."
       alternative-gh-token-secret-name:

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -35,6 +35,10 @@ on:
         type: string
         default: "."
       container-options:
+        description: |
+          Command-line arguments passed to 'docker run' when starting the container this workflow runs in.
+          This should be provided as a single string to be inlined into 'docker run', not an array.
+          For example, '--quiet --ulimit nofile=2048'.
         required: false
         type: string
         default: "-e _NOOP"

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -29,6 +29,9 @@ on:
         required: true
         description: "Shell code to be executed in a step. Ideally this should just invoke a script managed in the repo the workflow runs from, like 'ci/test_cpp.sh'."
       matrix_filter:
+        description: |
+          jq expression which modifies the matrix.
+          For example, 'map(select(.ARCH == "amd64"))' to achieve "only run amd64 jobs".
         type: string
         default: "."
       container-options:

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -20,6 +20,11 @@ on:
         description: "Git repo to check out, in '{org}/{repo}' form, e.g. 'rapidsai/cudf'"
         type: string
       node_type:
+        description: |
+          Suffix, without leading '-', indicating the type of machine to run jobs on (e.g., 'cpu4' or 'gpu-l4-latest-1').
+          Runner labels are of the form '{operating_system}-{arch}-{node_type}'.
+          See https://github.com/nv-gha-runners/enterprise-runner-configuration/blob/main/docs/runner-groups.md for a list
+          of valid values.
         type: string
         default: "cpu8"
       script:
@@ -32,6 +37,9 @@ on:
         required: false
         description: "One of [true, false], true if artifacts should be uploaded to GitHub's artifact store"
       matrix_filter:
+        description: |
+          jq expression which modifies the matrix.
+          For example, 'map(select(.ARCH == "amd64"))' to achieve "only run amd64 jobs".
         type: string
         default: "."
       alternative-gh-token-secret-name:

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -32,6 +32,9 @@ on:
         type: boolean
         default: true
       matrix_filter:
+        description: |
+          jq expression which modifies the matrix.
+          For example, 'map(select(.ARCH == "amd64"))' to achieve "only run amd64 jobs".
         type: string
         default: "."
       container-options:

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -38,6 +38,10 @@ on:
         type: string
         default: "."
       container-options:
+        description: |
+          Command-line arguments passed to 'docker run' when starting the container this workflow runs in.
+          This should be provided as a single string to be inlined into 'docker run', not an array.
+          For example, '--quiet --ulimit nofile=2048'.
         required: false
         type: string
         default: "-e _NOOP"

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -20,6 +20,10 @@ on:
         description: "Git repo to check out, in '{org}/{repo}' form, e.g. 'rapidsai/cudf'"
         type: string
       skip_upload_pkgs:
+        description: |
+          Space-delimited string of package names to skip uploading to anaconda.org.
+          When this is empty (the default), all conda packages found in CI artifacts for a given
+          run will be uploaded to anaconda.org
         type: string
       upload_to_label:
         description: The label that should be applied to packages uploaded to Anaconda.org

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -20,9 +20,16 @@ on:
         description: "Git repo to check out, in '{org}/{repo}' form, e.g. 'rapidsai/cudf'"
         type: string
       arch:
+        description:
+    
         type: string
         default: "amd64"
       node_type:
+        description: |
+          Suffix, without leading '-', indicating the type of machine to run jobs on (e.g., 'cpu4' or 'gpu-l4-latest-1').
+          Runner labels are of the form '{operating_system}-{arch}-{node_type}'.
+          See https://github.com/nv-gha-runners/enterprise-runner-configuration/blob/main/docs/runner-groups.md for a list
+          of valid values.
         type: string
         default: "cpu8"
       container_image:

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -20,8 +20,7 @@ on:
         description: "Git repo to check out, in '{org}/{repo}' form, e.g. 'rapidsai/cudf'"
         type: string
       arch:
-        description:
-    
+        description: "One of [amd64, arm64]. CPU architecture to run on."
         type: string
         default: "amd64"
       node_type:
@@ -33,6 +32,7 @@ on:
         type: string
         default: "cpu8"
       container_image:
+        description: "Container image URI"
         type: string
         default: "rapidsai/ci-conda:25.08-latest"
       script:
@@ -40,9 +40,14 @@ on:
         type: string
         description: "Shell code to be executed in a step. Ideally this should just invoke a script managed in the repo the workflow runs from, like 'ci/test_java.sh'."
       file_to_upload:
+        description: "Path to a file to be uploaded as a CI artifact."
         type: string
         default: "gh-status.json"
       continue-on-error:
+        description: |
+          If false (the default), treat job failures as workflow failures.
+          If true, job failures do not result in workflow failures (useful for implementing optional CI workflows).
+          See https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error
         type: boolean
         required: false
         default: false

--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -2,6 +2,9 @@ on:
   workflow_call:
     inputs:
       needs:
+        description: |
+          JSON string with the content of the 'needs' context for a GitHub Actions workflow.
+          For details, see https://docs.github.com/en/actions/reference/accessing-contextual-information-about-workflow-runs#example-contents-of-the-needs-context
         required: false
         type: string
         default: '{}'

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -46,12 +46,20 @@ on:
 
       # allow a bigger runner instance
       node_type:
+        description: |
+          Suffix, without leading '-', indicating the type of machine to run jobs on (e.g., 'cpu4' or 'gpu-l4-latest-1').
+          Runner labels are of the form '{operating_system}-{arch}-{node_type}'.
+          See https://github.com/nv-gha-runners/enterprise-runner-configuration/blob/main/docs/runner-groups.md for a list
+          of valid values.
         required: false
         type: string
         default: "cpu16"
 
       # general settings
       matrix_filter:
+        description: |
+          jq expression which modifies the matrix.
+          For example, 'map(select(.ARCH == "amd64"))' to achieve "only run amd64 jobs".
         type: string
         default: "."
       upload-artifacts:

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -24,6 +24,8 @@ on:
 
       # general settings
       package-name:
+        description: |
+          Distribution name, without any other qualifiers (e.g. 'pylibcudf', not 'pylibcudf-cu12-cp311-manylinux_2_24_aarch64')
         required: true
         type: string
       package-type:
@@ -32,6 +34,7 @@ on:
         default: python
         type: string
       publish_to_pypi:
+        description: "One of [true, false], true if the wheel should be published to pypi.org"
         required: false
         type: boolean
         default: false

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -34,8 +34,7 @@ on:
         default: python
         type: string
       publish_to_pypi:
-        description: "One of [true, false], true if the wheel should be published to pypi.org"
-        required: false
+        description: "If true, the wheel will be published to pypi.org"
         type: boolean
         default: false
 

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -31,13 +31,25 @@ on:
         required: true
         description: "Shell code to be executed in a step. Ideally this should just invoke a script managed in the repo the workflow runs from, like 'ci/test_wheel.sh'."
       matrix_filter:
+        description: |
+          jq expression which modifies the matrix.
+          For example, 'map(select(.ARCH == "amd64"))' to achieve "only run amd64 jobs".
         type: string
         default: "."
       container-options:
+        description: |
+          Command-line arguments passed to 'docker run' when starting the container this workflow runs in.
+          This should be provided as a single string to be inlined into 'docker run', not an array.
+          For example, '--quiet --ulimit nofile=2048'.
         required: false
         type: string
         default: "-e _NOOP"
       test_summary_show:
+        description: |
+          Sets the 'show:' input to the test-summary/action third-party action.
+          The default, 'fail', means "only show failing tests in the summary in the GitHub UI".
+          See https://github.com/test-summary/action?tab=readme-ov-file#options for a list of
+          available options.
         required: false
         type: string
         default: "fail"

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -57,7 +57,10 @@ on:
         required: false
         type: string
         default: ''
-        description: "The name of an extra secret in the repo (not the content of the secret itself)."
+        description: |
+          The NAME (not value) of a GitHub secret in the calling repo.
+          This allows callers of the workflow to make a single secret available in the job's
+          environment, via environment variable `RAPIDS_AUX_SECRET_1`.
       build_workflow_name:
         description: |
           Name of a workflow file that produced artifacts to be downloaded in this run.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,11 @@ repos:
     rev: v1.7.7
     hooks:
       - id: actionlint-docker
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        additional_dependencies: [tomli]
   - repo: https://github.com/rapidsai/pre-commit-hooks
     rev: v0.7.0
     hooks:


### PR DESCRIPTION
Contributes to #376

This is a docs-only PR... it should not change any behavior for these workflows.

* adds descriptions for all remaining inputs that didn't have them
* adds `codespell` for typo-checking those descriptions

## Notes for Reviewers

### What else is left?

After this PR, I'll put up PRs across RAPIDS adding descriptions for all the inputs in workflows that can be triggered by `workflow_dispatch`, like here:

https://github.com/rapidsai/cudf/blob/7b536eefee428eb6d1a168e706c94422d13bd319/.github/workflows/build.yaml#L9-L22

So that people see those descriptions in the GitHub UI when manually triggering runs.

Someone asking "what should I put in this box?" was the original motivation for #376