### PR TITLE
ci: prevent renovate from incorrectly bumping rapidsai docker images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"]
+  "extends": ["config:base"],
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["^rapidsai/"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
Closes #394 
Closes #395 

Renovate is seeing our updated docker images for the 25.10 branch and thinking it should update the images here.  It should not do this, and the bump is handled by our own `update-version.sh` script, so I'm disabling renovate updates for the `rapidsai/` dockerhub org.