### PR TITLE
Pass `--quiet` flag in `build-in-devcontainer` workflow

### DIFF
--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -187,7 +187,7 @@ jobs:
             extra-index-url = https://pypi.anaconda.org/rapidsai-wheels-nightly/simple
             EOF
 
-            rapids-make-${PYTHON_PACKAGE_MANAGER}-env;
+            rapids-make-${PYTHON_PACKAGE_MANAGER}-env --quiet;
 
             cd ~/"${REPOSITORY}";
             mkdir -p telemetry-artifacts;


### PR DESCRIPTION
This passes the `--quiet` flag to the environment creation command, to avoid noisy output from progress bars like https://github.com/rapidsai/cudf/actions/runs/16429104215/job/46426604875?pr=19411#step:9:2240.