### PR TITLE
allow customizing build workflow name in conda-upload-packages and wheels-publish

### DIFF
--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -29,6 +29,12 @@ on:
         description: The label that should be applied to packages uploaded to Anaconda.org
         type: string
         default: main
+      build_workflow_name:
+        description: |
+          Name of a workflow file that produced artifacts to be downloaded in this run.
+          If not set (the default), artifact-handling scripts use RAPIDS-conventional defaults (like "build.yaml" when "build_type == nightly").
+        required: false
+        type: string
 
 defaults:
   run:
@@ -71,17 +77,13 @@ jobs:
           persist-credentials: true
 
       - name: Standardize repository information
-        env:
-          RAPIDS_REPOSITORY: ${{ inputs.repo || github.repository }}
-          RAPIDS_REF_NAME: ${{ inputs.branch || github.ref_name }}
-          RAPIDS_NIGHTLY_DATE: ${{ inputs.date }}
-        run: |
-          {
-            echo "RAPIDS_REPOSITORY=${RAPIDS_REPOSITORY}"
-            echo "RAPIDS_SHA=$(git rev-parse HEAD)"
-            echo "RAPIDS_REF_NAME=${RAPIDS_REF_NAME}"
-            echo "RAPIDS_NIGHTLY_DATE=${RAPIDS_NIGHTLY_DATE}"
-          } >> "${GITHUB_ENV}"
+        uses: rapidsai/shared-actions/rapids-github-info@main
+        with:
+          repo: ${{ inputs.repo }}
+          branch: ${{ inputs.branch }}
+          build_workflow_name: ${{ inputs.build_workflow_name }}
+          date: ${{ inputs.date }}
+          sha: ${{ inputs.sha }}
 
       # Per the docs at https://docs.github.com/en/rest/rate-limit/rate-limit?apiVersion=2022-11-28#get-rate-limit-status-for-the-authenticated-user,
       # checking '/rate_limit | jq .' should not itself count against any rate limits.

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -37,6 +37,12 @@ on:
         description: "If true, the wheel will be published to pypi.org"
         type: boolean
         default: false
+      build_workflow_name:
+        description: |
+          Name of a workflow file that produced artifacts to be downloaded in this run.
+          If not set (the default), artifact-handling scripts use RAPIDS-conventional defaults (like "build.yaml" when "build_type == nightly").
+        required: false
+        type: string
 
 permissions:
   actions: read
@@ -86,6 +92,7 @@ jobs:
       with:
         repo: ${{ inputs.repo }}
         branch: ${{ inputs.branch }}
+        build_workflow_name: ${{ inputs.build_workflow_name }}
         date: ${{ inputs.date }}
         sha: ${{ inputs.sha }}
 


### PR DESCRIPTION
RAPIDS tooling to find artifacts in GitHub Actions workflows relies on some RAPIDS convention for workflow file naming:

https://github.com/rapidsai/gha-tools/blob/3996b1773127b5b5b3969accf8a7660067571ab7/tools/rapids-github-run-id#L27-L46

When that was introduced, a mechanism for overriding that by saying "look for artifacts from this specific workflow" was added:

* https://github.com/rapidsai/shared-actions/pull/52
* #331

This expands support for that override to the `conda-upload-packages` and `wheels-publish` workflows, so those can be used for releases (`build_type = "branch"`) where the packages to upload were built by a workflow not called `build.yaml`.

## Notes for Reviewers

This is needed for `rapids-build-backend`.

Its releases are failing like this:

> HTTP 404: workflow build.yaml not found on the default branch (https://api.github.com/repos/rapidsai/rapids-build-backend/actions/workflows/build.yaml)

([build link](https://github.com/rapidsai/rapids-build-backend/actions/runs/16676292209))

### How I tested this

`rapids-build-backend` (https://github.com/rapidsai/rapids-build-backend/pull/71)

* ✅  PR CI (https://github.com/rapidsai/rapids-build-backend/actions/runs/16677534472/job/47207886991?pr=71)
* ⌛ `build_type=branch` run that actually publishes stuff *(we'll have to test this live by merging that PR)*

`rmm` (https://github.com/rapidsai/rmm/pull/2001):

* ✅ PR CI ([build link](https://github.com/rapidsai/rmm/actions/runs/16679488378/job/47214402025?pr=2001))
* ✅ `build_type=branch` run that actually publishes stuff: https://github.com/rapidsai/rmm/pull/2001#issuecomment-3145084641