### PR TITLE
Update preprocessor cache dir in `build-in-devcontainer.yaml`

### DIFF
--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -160,7 +160,7 @@ jobs:
         name: Setup sccache preprocessor cache
         uses: actions/cache@v4
         with:
-          path: .cache/sccache
+          path: .cache/sccache/preprocessor
           restore-keys: sccache-preprocessor-cache-${{ runner.os }}-${{ env.BUILD_SLUG }}
           key: sccache-preprocessor-cache-${{ runner.os }}-${{ env.BUILD_SLUG }}-${{ env.ARTIFACT_SLUG }}
 


### PR DESCRIPTION
After merging in the latest sccache changes, the preprocessor cache dir is now under `~/.cache/sccache/preprocessor`.