### PR TITLE
Add docs on project automation

### DIFF
--- a/docs/get-project-field-info.py
+++ b/docs/get-project-field-info.py
@@ -17,23 +17,23 @@ from pprint import pprint
 def get_project_info(org: str, project_number: int, token: str) -> Tuple[str, Dict[str, Any]]:
     """
     Retrieve project information and custom fields from GitHub Projects.
-    
+
     Args:
         org: GitHub organization name
         project_number: GitHub project number (integer)
         token: GitHub personal access token with appropriate permissions
-        
+
     Returns:
         Tuple containing:
             - project_id: The GitHub project ID (string)
             - fields: Dictionary mapping field names to field configurations
-            
+
     Raises:
         requests.RequestException: If the HTTP request fails
         KeyError: If the expected data structure is not found in the response
     """
     headers = {"Authorization": f"Bearer {token}"}
-    
+
     query = '''
         query($org: String!, $number: Int!) {
             organization(login: $org){
@@ -110,17 +110,17 @@ def get_project_info(org: str, project_number: int, token: str) -> Tuple[str, Di
 
     # Standard GitHub project fields that should be excluded as they are not controlled by the projectv2 API
     not_project_fields = ['Title', 'Assignees', 'Labels', 'Linked pull requests', 'Reviewers', 'Repository', 'Milestone', 'Tracks']
-    
+
     # Filter out standard project fields and create field mappings
     field_names = [
-        {'name': field['name'], 'id': field['id']} 
-        for field in fields_response_json['data']['node']['fields']['nodes'] 
+        {'name': field['name'], 'id': field['id']}
+        for field in fields_response_json['data']['node']['fields']['nodes']
         if field['name'] not in not_project_fields
     ]
-    
+
     fields = {
-        field['name']: field 
-        for field in fields_response_json['data']['node']['fields']['nodes'] 
+        field['name']: field
+        for field in fields_response_json['data']['node']['fields']['nodes']
         if field['name'] not in not_project_fields
     }
 
@@ -135,7 +135,7 @@ def get_project_info(org: str, project_number: int, token: str) -> Tuple[str, Di
 def main() -> None:
     """
     Main function to parse command line arguments and execute the script.
-    
+
     Parses command line arguments for GitHub organization, project number,
     and personal access token, then retrieves and displays project field information.
     """
@@ -144,16 +144,16 @@ def main() -> None:
     parser.add_argument('--token', '-t', required=True, help='GitHub personal access token')
     parser.add_argument('--org', '-o', required=True, help='GitHub organization name')
     parser.add_argument('--project', '-p', required=True, type=int, help='GitHub project number')
-    
+
     args = parser.parse_args()
-    
+
     try:
         # Use the provided arguments
         project_id, fields = get_project_info(org=args.org, project_number=args.project, token=args.token)
-        
+
         pprint(project_id)
         pprint(fields)
-        
+
     except requests.RequestException as e:
         print(f"HTTP request failed: {e}")
     except (KeyError, ValueError) as e:

--- a/docs/project-automation-readme.md
+++ b/docs/project-automation-readme.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This collection of GitHub Actions workflows supports automation of the management of GitHub Projects, helping track development progress across RAPIDS repositories. 
+This collection of GitHub Actions workflows supports automation of the management of GitHub Projects, helping track development progress across RAPIDS repositories.
 
 The automations can also synchronize fields from PR to Issue such as the statuses, release information, and development stages into project fields, making project management effortless and consistent.
 
@@ -43,21 +43,21 @@ flowchart LR
 
 ### Core Workflows
 
-1. **project-get-item-id.yaml**  
+1. **project-get-item-id.yaml**
    Gets the project-specific ID for an item (PR or issue) within a project - a critical first step for all operations.
 
-2. **project-set-text-date-numeric-field.yaml**  
+2. **project-set-text-date-numeric-field.yaml**
    Updates text, date, or numeric fields in the project.
 
-3. **project-get-set-single-select-field.yaml**  
+3. **project-get-set-single-select-field.yaml**
    Handles single-select (dropdown) fields like Status, Stage, etc.
 
-4. **project-get-set-iteration-field.yaml**  
+4. **project-get-set-iteration-field.yaml**
    Manages iteration fields for sprint/week tracking.
 
 ### Support Workflow
 
-5. **project-update-linked-issues.yaml**  
+5. **project-update-linked-issues.yaml**
    Synchronizes linked issues with the PR's field values.<br>
    Unfortunately, we cannot go from Issue -> PR; the linkage exists only within the PR's API.
 


### PR DESCRIPTION
This pull request adds documentation and a helper script to streamline and clarify the automation of GitHub Project management for RAPIDS repositories. The most significant changes include a new Python script for fetching project and field IDs via the GitHub GraphQL API, and a detailed README explaining the architecture, workflows, and configuration steps for project automation.

**New helper script for project field discovery:**

* Added `get-project-field-info.py`, a Python script that queries the GitHub GraphQL API to retrieve project and field IDs, including options for single-select and iteration fields, while filtering out standard fields not controlled by the API. This script simplifies setup for workflow configuration.

**Documentation and workflow guidance:**

* Introduced `project-automation-readme.md`, a guide covering the challenges of GitHub Project automation, architectural overview of reusable workflows, step-by-step instructions for obtaining required IDs using the new script, and sample use cases for tracking PR progress.