### PR TITLE
Add container options to custom jobs

### DIFF
--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -35,6 +35,14 @@ on:
         description: "Container image URI"
         type: string
         default: "rapidsai/ci-conda:25.10-latest"
+      container-options:
+        description: |
+          Command-line arguments passed to 'docker run' when starting the container this workflow runs in.
+          This should be provided as a single string to be inlined into 'docker run', not an array.
+          For example, '--quiet --ulimit nofile=2048'.
+        required: false
+        type: string
+        default: "-e _NOOP"
       script:
         required: false
         type: string
@@ -102,6 +110,7 @@ jobs:
     continue-on-error: ${{ inputs.continue-on-error }}
     container:
       image: ${{ inputs.container_image }} # zizmor: ignore[unpinned-images]
+      options: ${{ inputs.container-options }}
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}


### PR DESCRIPTION
Custom jobs should also support specifying container options. The lack of this feature has caused [RapidsMPF nightly test jobs](https://github.com/rapidsai/rapidsmpf/actions/runs/17789510126/workflow) to silently fail as we don't get automated notifications in Slack because the job never actually runs.