### PR TITLE
feat(wheels,conda): support passing `RAPIDS_PACKAGE_NAME` from build step to artifact upload

### DIFF
--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -222,7 +222,7 @@ jobs:
           if [[ -n "${RAPIDS_PACKAGE_NAME:-}" ]]; then
             echo "RAPIDS_PACKAGE_NAME=${RAPIDS_PACKAGE_NAME}" >> "${GITHUB_OUTPUT}"
           else
-            echo "RAPIDS_PACKAGE_NAME=$(RAPIDS_NO_PKG_EXTENSION=true rapids-package-name conda_python)" >> "${GITHUB_OUTPUT}"
+            echo "RAPIDS_PACKAGE_NAME=$(rapids-package-name conda_python)" >> "${GITHUB_OUTPUT}"
           fi
           echo "CONDA_OUTPUT_DIR=${RAPIDS_CONDA_BLD_OUTPUT_DIR}" >> "${GITHUB_OUTPUT}"
         id: package-name

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -305,7 +305,7 @@ jobs:
           if [[ -n "${RAPIDS_PACKAGE_NAME:-}" ]]; then
             echo "RAPIDS_PACKAGE_NAME=${RAPIDS_PACKAGE_NAME}" >> "${GITHUB_OUTPUT}"
           else
-            echo "RAPIDS_PACKAGE_NAME=$(RAPIDS_NO_PKG_EXTENSION=true rapids-package-name "wheel_${PACKAGE_TYPE}")" >> "${GITHUB_OUTPUT}"
+            echo "RAPIDS_PACKAGE_NAME=$(rapids-package-name "wheel_${PACKAGE_TYPE}")" >> "${GITHUB_OUTPUT}"
           fi
           echo "WHEEL_OUTPUT_DIR=${RAPIDS_WHEEL_BLD_OUTPUT_DIR}" >> "${GITHUB_OUTPUT}"
         id: package-name


### PR DESCRIPTION
This is in support of (part of) rapidsai/build-planning#204

There are other changes that are in `gha-tools` for how to configure the artifact names for uploading and downloading interim wheels and conda packages (rapidsai/gha-tools#218 rapidsai/gha-tools#219).

The change here is to allow setting the value of `RAPIDS_PACKAGE_NAME` in a downstream build script and then having that value passed to the `Get package name` step so that we have the option to configure artifact names on a per-job basis.
