### PR TITLE
Add workflow inputs for enabling `sccache-dist`

### DIFF
--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -169,7 +169,7 @@ jobs:
 
       # Install latest rapidsai/sccache client and configure sccache-dist
       - name: Setup sccache-dist
-        uses: rapidsai/shared-actions/setup-sccache-dist@fea/setup-sccache-dist
+        uses: rapidsai/shared-actions/setup-sccache-dist@main
         if: ${{ inputs.sccache-dist-token-secret-name != '' }}
         env:
           AWS_REGION: "${{env.AWS_REGION}}"

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -214,7 +214,7 @@ jobs:
 
       # Install latest rapidsai/sccache client and configure sccache-dist
       - name: Setup sccache-dist
-        uses: rapidsai/shared-actions/setup-sccache-dist@fea/setup-sccache-dist
+        uses: rapidsai/shared-actions/setup-sccache-dist@main
         if: ${{ inputs.sccache-dist-token-secret-name != '' }}
         env:
           AWS_REGION: "${{env.AWS_REGION}}"

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -174,7 +174,7 @@ jobs:
         uses: nv-gha-runners/setup-proxy-cache@main
       # Install latest rapidsai/sccache client and configure sccache-dist
       - name: Setup sccache-dist
-        uses: rapidsai/shared-actions/setup-sccache-dist@fea/setup-sccache-dist
+        uses: rapidsai/shared-actions/setup-sccache-dist@main
         if: ${{ inputs.sccache-dist-token-secret-name != '' }}
         env:
           AWS_REGION: "${{env.AWS_REGION}}"

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -219,7 +219,7 @@ jobs:
 
       # Install latest rapidsai/sccache client and configure sccache-dist
       - name: Setup sccache-dist
-        uses: rapidsai/shared-actions/setup-sccache-dist@fea/setup-sccache-dist
+        uses: rapidsai/shared-actions/setup-sccache-dist@main
         if: ${{ inputs.sccache-dist-token-secret-name != '' }}
         env:
           AWS_REGION: "${{env.AWS_REGION}}"

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -235,7 +235,7 @@ jobs:
 
       # Install latest rapidsai/sccache client and configure sccache-dist
       - name: Setup sccache-dist
-        uses: rapidsai/shared-actions/setup-sccache-dist@fea/setup-sccache-dist
+        uses: rapidsai/shared-actions/setup-sccache-dist@main
         if: ${{ inputs.sccache-dist-token-secret-name != '' }}
         env:
           AWS_REGION: "${{env.AWS_REGION}}"

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -235,7 +235,7 @@ jobs:
 
     # Install latest rapidsai/sccache client and configure sccache-dist
     - name: Setup sccache-dist
-      uses: rapidsai/shared-actions/setup-sccache-dist@fea/setup-sccache-dist
+      uses: rapidsai/shared-actions/setup-sccache-dist@main
       if: ${{ inputs.sccache-dist-token-secret-name != '' }}
       env:
         AWS_REGION: "${{env.AWS_REGION}}"


### PR DESCRIPTION
This PR adds an `sccache-dist-token-secret-name` input to our conda and wheel workflows. When the name of a secret is provided, the workflow will invoke the [`rapidsai/shared-workflows/setup-sccache-dist`](https://github.com/rapidsai/shared-actions/pull/81) to install the latest sccache client from [`rapidsai/sccache`](https://github.com/rapidsai/sccache) and configure it for distributed compilation.

This PR also adds the sccache client logfile as an additional build artifact so the logs can be inspected if anything goes wrong.

Tested in https://github.com/rapidsai/rmm/pull/2101 (example workflow run [here](https://github.com/rapidsai/rmm/actions/runs/18859867864/job/53815921352?pr=2101)).