### PR TITLE
refactor(pure builds): allow overriding default pure `MATRIX_FILTER` from downstream

### DIFF
--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -128,8 +128,8 @@ jobs:
           "
 
 
-          # When pure-conda is true, ignore matrix_filter and build one conda package with amd64, latest CUDA_VER, and the latest PY_VER
-          if [ "${PURE_CONDA}" = "true" ]; then
+          # When pure-conda is true and matrix_filter is default, override to build one conda package with amd64, latest CUDA_VER, and the latest PY_VER
+          if [ "${PURE_CONDA}" = "true" ] && [ "${MATRIX_FILTER}" = "." ]; then
             MATRIX_FILTER="map(select(.ARCH == \"amd64\")) | sort_by(.CUDA_VER, .PY_VER) | [last]"
           else
             MATRIX_FILTER="${MATRIX_FILTER}"

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -159,8 +159,8 @@ jobs:
           - { ARCH: 'arm64', PY_VER: '3.13', CUDA_VER: '13.0.2', LINUX_VER: 'rockylinux8' }
           "
 
-          # When pure-wheel is true, ignore matrix_filter and build one wheel per CUDA version with amd64 and the latest PY_VER
-          if [ "${PURE_WHEEL}" = "true" ]; then
+          # When pure-wheel is true and matrix_filter is default, override to build one wheel per CUDA version with amd64 and the latest PY_VER
+          if [ "${PURE_WHEEL}" = "true" ] && [ "${MATRIX_FILTER}" = "." ]; then
             MATRIX_FILTER="map(select(.ARCH == \"amd64\")) | group_by(.CUDA_VER) | map(max_by(.PY_VER | split(\".\") | map(tonumber)))"
           else
             MATRIX_FILTER="${MATRIX_FILTER}"


### PR DESCRIPTION
xref rapidsai/build-planning#43

Noticed in https://github.com/rapidsai/dask-cuda/pull/1577

Most of our pure wheels need `cu12` and `cu13` suffixes to differentiate, but we also have "truly" pure wheels that need only a single build.  For those (and whatever other cases), we should be able to override the default matrix filter that results when setting `pure-wheel` or `pure-conda` to True.
