### PR TITLE
Add `continue-on-error` input to `wheels-test`

### DIFF
--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -85,6 +85,14 @@ on:
           When this is non-empty, that secret's value is used in place of the default repo-level token
           anywhere that environment variable GH_TOKEN is set. This is especially useful for downloading
           artifacts from other private repos, which repo tokens do not have access to.
+      continue-on-error:
+        description: |
+          If false (the default), treat job failures as workflow failures.
+          If true, job failures do not result in workflow failures (useful for implementing optional CI workflows).
+          See https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idcontinue-on-error
+        type: boolean
+        required: false
+        default: false
 
 defaults:
   run:
@@ -186,6 +194,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.compute-matrix.outputs.MATRIX) }}
     runs-on: "linux-${{ matrix.ARCH }}-gpu-${{ matrix.GPU }}-${{ matrix.DRIVER }}-1"
+    continue-on-error: ${{ inputs.continue-on-error }}
     container:
       image: "rapidsai/citestwheel:25.12-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
       options: ${{ inputs.container-options }}


### PR DESCRIPTION
This lets users of the `wheels-test` workflow selectively ignore errors for workflows that shouldn't block CI, similar to what's offered by `custom-job`.

The default should be backwards compatible: it's not required, and it defaults to `false` (i.e. don't continue on errors).

xref https://github.com/rapidsai/cudf/pull/20555