### PR TITLE
Define RAPIDS_ARTIFACTS_DIR in custom jobs

### DIFF
--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -122,8 +122,9 @@ jobs:
       image: ${{ inputs.container_image }} # zizmor: ignore[unpinned-images]
       options: ${{ inputs.container-options }}
       env:
-        RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
+        RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
+        RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:
       - uses: aws-actions/configure-aws-credentials@00943011d9042930efac3dcd3a170e4273319bc8 # v5.1.0
         with:


### PR DESCRIPTION
https://github.com/rapidsai/shared-workflows/pull/445 uses `RAPIDS_ARTIFACTS_DIR` but it is not defined in `custom-job.yaml`.

https://github.com/rapidsai/gha-tools/pull/223 makes our workflows less fragile, but the proper solution is for us to define that variable if it is meant to be used.
