### PR TITLE
feat(publish): pass through override for wheel_search_key

### DIFF
--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -43,6 +43,10 @@ on:
           If not set (the default), artifact-handling scripts use RAPIDS-conventional defaults (like "build.yaml" when "build_type == nightly").
         required: false
         type: string
+      publish-wheel-search-key:
+        description: "Search key to use to override constructed search path in `rapids-wheels-anaconda-github`"
+        type: string
+        required: false
 
 permissions:
   actions: read
@@ -117,6 +121,8 @@ jobs:
         PACKAGETYPE: ${{ inputs.package-type }}
         INPUTS_PACKAGE_NAME: ${{ inputs.package-name }}
         INPUTS_PACKAGE_TYPE: ${{ inputs.package-type }}
+        # Used to override search key construction as needed
+        WHEEL_SEARCH_KEY: ${{ inputs.publish-wheel-search-key }}
 
     - name: Check if build is release
       id: check_if_release


### PR DESCRIPTION
Supporting `gha-tools` update in https://github.com/rapidsai/gha-tools/pull/225

Part of rapidsai/build-planning#43 -- now that we have more complex artifact names, this is a temporary override so we can specify those names in the publish workflow as needed.  This is temporary, but will get us unblocked leading up to release.
