### PR TITLE
updated update-version.sh to handle release branch version changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Not all projects need that, so they sometimes invoke the workflow like this:
 ```yaml
 wheel-build-nx-cugraph:
   secrets: inherit
-  uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@branch-25.10
+  uses: rapidsai/shared-workflows/.github/workflows/wheels-build.yaml@main
   with:
     build_type: pull-request
     script: ci/build_wheel_nx-cugraph.sh

--- a/ci/release/update-version.sh
+++ b/ci/release/update-version.sh
@@ -5,17 +5,83 @@
 ###########################################
 
 ## Usage
-# bash update-version.sh <new_version>
+# Primary interface:   bash update-version.sh <new_version> [--run-context=main|release]
+# Fallback interface:  [RAPIDS_RUN_CONTEXT=main|release] bash update-version.sh <new_version>
+# CLI arguments take precedence over environment variables
+# Defaults to main when no run-context is specified
+
+set -euo pipefail
+
+# Verify we're running from the repository root
+if [[ ! -d ".git" ]]; then
+    echo "Error: This script must be run from the repository root directory."
+    echo "Expected to find: .git/"
+    echo "Current directory: $(pwd)"
+    exit 1
+fi
+
+# Parse command line arguments
+CLI_RUN_CONTEXT=""
+VERSION_ARG=""
+
+for arg in "$@"; do
+    case $arg in
+        --run-context=*)
+            CLI_RUN_CONTEXT="${arg#*=}"
+            shift
+            ;;
+        *)
+            if [[ -z "$VERSION_ARG" ]]; then
+                VERSION_ARG="$arg"
+            fi
+            ;;
+    esac
+done
 
 # Format is YY.MM.PP - no leading 'v' or trailing 'a'
-NEXT_FULL_TAG=$1
+NEXT_FULL_TAG="$VERSION_ARG"
+
+# Determine RUN_CONTEXT with CLI precedence over environment variable, defaulting to main
+if [[ -n "$CLI_RUN_CONTEXT" ]]; then
+    RUN_CONTEXT="$CLI_RUN_CONTEXT"
+    echo "Using run-context from CLI: $RUN_CONTEXT"
+elif [[ -n "${RAPIDS_RUN_CONTEXT}" ]]; then
+    RUN_CONTEXT="$RAPIDS_RUN_CONTEXT"
+    echo "Using run-context from environment: $RUN_CONTEXT"
+else
+    RUN_CONTEXT="main"
+    echo "No run-context provided, defaulting to: $RUN_CONTEXT"
+fi
+
+# Validate RUN_CONTEXT value
+if [[ "${RUN_CONTEXT}" != "main" && "${RUN_CONTEXT}" != "release" ]]; then
+    echo "Error: Invalid run-context value '${RUN_CONTEXT}'"
+    echo "Valid values: main, release"
+    exit 1
+fi
+
+# Validate version argument
+if [[ -z "$NEXT_FULL_TAG" ]]; then
+    echo "Error: Version argument is required"
+    echo "Usage: $0 <new_version> [--run-context=<context>]"
+    echo "   or: [RAPIDS_RUN_CONTEXT=<context>] $0 <new_version>"
+    echo "Note: Defaults to main when run-context is not specified"
+    exit 1
+fi
 
 #Get <major>.<minor> for next version
 NEXT_MAJOR=$(echo $NEXT_FULL_TAG | awk '{split($0, a, "."); print a[1]}')
 NEXT_MINOR=$(echo $NEXT_FULL_TAG | awk '{split($0, a, "."); print a[2]}')
 NEXT_SHORT_TAG=${NEXT_MAJOR}.${NEXT_MINOR}
 
-echo "Updating repository for $NEXT_FULL_TAG"
+# Set branch references based on RUN_CONTEXT
+if [[ "${RUN_CONTEXT}" == "main" ]]; then
+    WORKFLOW_BRANCH_REF="main"
+    echo "Preparing development branch update for $NEXT_FULL_TAG (targeting main branch)"
+elif [[ "${RUN_CONTEXT}" == "release" ]]; then
+    WORKFLOW_BRANCH_REF="release/${NEXT_SHORT_TAG}"
+    echo "Preparing release branch update for $NEXT_FULL_TAG (targeting release/${NEXT_SHORT_TAG} branch)"
+fi
 
 # Inplace sed replace; workaround for Linux and Mac
 function sed_runner() {
@@ -23,8 +89,14 @@ function sed_runner() {
 }
 
 for FILE in .github/workflows/*.yaml; do
-  sed_runner "/rapidsai\/shared-workflows/ s/@.*/@branch-${NEXT_SHORT_TAG}/g" "${FILE}"
+  # Update shared-workflows references
+  sed_runner "/rapidsai\/shared-workflows/ s|@release/[0-9]\+\.[0-9]\+|@${WORKFLOW_BRANCH_REF}|g" "${FILE}"
+  sed_runner "/rapidsai\/shared-workflows/ s|@\\<main\\>|@${WORKFLOW_BRANCH_REF}|g" "${FILE}"
 
   # Update CI image tags
   sed_runner "/rapidsai\/ci.*:[0-9\.]*-/ s/:[0-9\.]*-/:${NEXT_SHORT_TAG}-/g" "${FILE}"
 done
+
+# README example
+sed_runner "/shared-workflows.*\.yaml@/ s|@release/[0-9]\+\.[0-9]\+|@${WORKFLOW_BRANCH_REF}|g" README.md
+sed_runner "/shared-workflows.*\.yaml@/ s|@\\<main\\>|@${WORKFLOW_BRANCH_REF}|g" README.md


### PR DESCRIPTION
## Description
This PR supports handling the new main branch strategy outlined below:

* [RSN 47 - Changes to RAPIDS branching strategy in 25.12](https://docs.rapids.ai/notices/rsn0047/)

The `update-version.sh` script should now supports two modes controlled via  `CLI` params or `ENV` vars:

CLI arguments: `--run-context=main|release`
ENV var `RAPIDS_RUN_CONTEXT=main|release`

xref: https://github.com/rapidsai/build-planning/issues/224