### PR TITLE
Define `RAPIDS_ARTIFACTS_DIR` as a job envvar, not only a container envvar

### DIFF
--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -118,12 +118,13 @@ jobs:
       fail-fast: false
     runs-on: "linux-${{ inputs.arch }}-${{ inputs.node_type }}"
     continue-on-error: ${{ inputs.continue-on-error }}
+    env:
+      RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
     container:
       image: ${{ inputs.container_image }} # zizmor: ignore[unpinned-images]
       options: ${{ inputs.container-options }}
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
-        RAPIDS_ARTIFACTS_DIR: ${{ github.workspace }}/artifacts
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:
       - uses: aws-actions/configure-aws-credentials@00943011d9042930efac3dcd3a170e4273319bc8 # v5.1.0


### PR DESCRIPTION
This envvar needs to be defined at the job level, not the container level, like in [other workflows](https://github.com/rapidsai/shared-workflows/blob/release/25.12/.github/workflows/conda-cpp-build.yaml#L123-L128).