### PR TITLE
Don't install dunamai in `VERSION` tag check

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -82,7 +82,6 @@ jobs:
       - name: Check VERSION file against latest tag
         if: ${{ inputs.enable_check_version_against_tag }}
         run: |
-          python -m pip install dunamai
           expected_version="$(python -m dunamai from git --format '{base}')"
           if [ "$expected_version" != "$(cat VERSION)" ]; then
             echo "ERROR: Expected VERSION file to be \"$expected_version\", got:"


### PR DESCRIPTION
This check runs on `rapidsai/ci-conda`, which already has dunamai installed.

Follow-up to https://github.com/rapidsai/shared-workflows/pull/454