### PR TITLE
Use shared-actions/changed-files action

### DIFF
--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -69,7 +69,7 @@ jobs:
           persist-credentials: false
       - name: Calculate changed files
         id: changed-files
-        uses: rapidsai/shared-actions/changed-files@changed-files
+        uses: rapidsai/shared-actions/changed-files@main
         with:
           files_yaml: ${{ inputs.files_yaml }}
           transform_expr: ${{ inputs.transform_expr }}

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -80,7 +80,7 @@ jobs:
       - name: Check changed files
         id: changed-files
         if: ${{ inputs.enable_check_version_files_changed }}
-        uses: rapidsai/shared-actions/changed-files@changed-files
+        uses: rapidsai/shared-actions/changed-files@main
         with:
           files_yaml: |
             version_files:


### PR DESCRIPTION
With the `changed-files` workflow being turned into an action (https://github.com/rapidsai/shared-actions/pull/85), we use it as such in the `changed-files` workflow and the `checks` workflow.