### PR TITLE
Pin check-style image to Python 3.12

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -122,7 +122,8 @@ jobs:
     if: ${{ inputs.enable_check_style }}
     runs-on: ubuntu-latest
     container:
-      image: rapidsai/ci-conda:26.02-latest # zizmor: ignore[unpinned-images]
+      # Must pin to Python <3.13, cmake-format is broken, see https://github.com/python/cpython/issues/140797
+      image: rapidsai/ci-conda:26.02-cuda13.0.2-ubuntu24.04-py3.12 # zizmor: ignore[unpinned-images]
     steps:
       - name: Checkout code
         uses: actions/checkout@v5


### PR DESCRIPTION
Python 3.13 and newer break cmake-format, see https://github.com/python/cpython/issues/140797. This is a workaround until a proper replacement for cmake-format is in place.