### PR TITLE
Pin check-style image to Python 3.12

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -136,7 +136,8 @@ jobs:
     if: ${{ inputs.enable_check_style }}
     runs-on: ubuntu-latest
     container:
-      image: rapidsai/ci-conda:25.12-latest # zizmor: ignore[unpinned-images]
+      # Must pin to Python <3.13, cmake-format is broken, see https://github.com/python/cpython/issues/140797
+      image: rapidsai/ci-conda:25.12-cuda13.0.2-ubuntu24.04-py3.12 # zizmor: ignore[unpinned-images]
     steps:
       - name: Checkout code
         uses: actions/checkout@v5


### PR DESCRIPTION
Backport https://github.com/rapidsai/shared-workflows/pull/475 to the release/25.12 branch