### PR TITLE
build-in-devcontainer: fail if expected devcontainer directories aren't found

### DIFF
--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -126,37 +126,28 @@ jobs:
           RUN_ID: ${{ github.run_id }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
         run: |
-          HAS_DEVCONTAINER=false
-          if test -f "repo/.devcontainer/cuda${CUDA_VER}-${PACKAGER}/devcontainer.json"; then
-            HAS_DEVCONTAINER=true
-          fi
           cat <<EOF | tee -a "${GITHUB_ENV}"
           ARTIFACT_SLUG=${RUN_ID}-${RUN_ATTEMPT}-$RANDOM
           BUILD_SLUG=cuda${CUDA_VER}-${PACKAGER}-${ARCH}
-          HAS_DEVCONTAINER=$HAS_DEVCONTAINER
           REPOSITORY=$(basename "$(pwd)")
           EOF
 
-      - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
-        uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
+      - uses: aws-actions/configure-aws-credentials@61815dcd50bd041e203e49132bacad1fd04d2708 # v5.1.1
         with:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
           role-duration-seconds: 43200 # 12h
 
-      - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
-        name: Setup Node.js
+      - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: '24'
 
-      - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
-        name: Setup proxy cache
+      - name: Setup proxy cache
         uses: nv-gha-runners/setup-proxy-cache@main
         continue-on-error: true
 
-      - if: ${{ env.HAS_DEVCONTAINER == 'true' }}
-        name: Run build in devcontainer
+      - name: Run build in devcontainer
         uses: devcontainers/ci@8bf61b26e9c3a98f69cb6ce2f88d24ff59b785c6 # v0.3.1900000417
         with:
           push: never
@@ -208,7 +199,7 @@ jobs:
             mkdir -p telemetry-artifacts;
             ${{ inputs.build_command }}
 
-      - if: ${{ !cancelled() && env.HAS_DEVCONTAINER == 'true' }}
+      - if: ${{ !cancelled() }}
         name: Upload sccache logs
         uses: actions/upload-artifact@v6
         with:


### PR DESCRIPTION
Follow-up from https://github.com/rapidsai/shared-workflows/pull/408#discussion_r2267393154

As of this PR, if the `build-in-devcontainer` workflow is called and the calling repo is missing the expected devcontainers directory, it'll fail loudly instead of passing silently.

## Notes for Reviewers

The extra flexibility here bit us during https://github.com/rapidsai/build-planning/issues/236. In the first round of PRs there, RAPIDS devcontainer directories were renamed from like `cuda13.0-pip` to `cuda13.1-pip` but the corresponding call of this workflow wasn't updated. The devcontainer CI jobs passed in CI and we didn't notice that builds were not actually running.

As of this PR, they'd fail loudly and alert us to that.