### PR TITLE
Fix when there is no changed-files workflow

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -94,7 +94,7 @@ jobs:
             exit 1
           fi
         env:
-          VERSION_FILES_CHANGED: ${{ (steps.changed-files.outputs.changed_file_groups && fromJSON(steps.changed-files.outputs.changed_file_groups).version_files) || 'false' }}
+          VERSION_FILES_CHANGED: ${{ (inputs.enable_check_version_files_changed && fromJSON(steps.changed-files.outputs.changed_file_groups).version_files) || 'false' }}
       - name: Fetch tags
         if: ${{ inputs.enable_check_version_against_tag }}
         uses: actions/checkout@v6

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -94,7 +94,7 @@ jobs:
             exit 1
           fi
         env:
-          VERSION_FILES_CHANGED: ${{ fromJSON(steps.changed-files.outputs.changed_file_groups).version_files }}
+          VERSION_FILES_CHANGED: ${{ (steps.changed-files.outputs.changed_file_groups && fromJSON(steps.changed-files.outputs.changed_file_groups).version_files) || 'false' }}
       - name: Fetch tags
         if: ${{ inputs.enable_check_version_against_tag }}
         uses: actions/checkout@v6


### PR DESCRIPTION
I have a repo with no VERSION file. I set `enable_check_version_files_changed: false` in `checks.yaml` but still got an error:

```
Error: The template is not valid. rapidsai/shared-workflows/.github/workflows/checks.yaml@main (Line: 97, Col: 34): Error reading JToken from JsonReader. Path '', line 0, position 0.
```

CI logs: https://github.com/rapidsai/velox-testing/actions/runs/21686871425/job/62536173276

The issue is that this is expecting output from a `changed-files` job that doesn't exist. We can work around this by including a check for that case and fallback value.