### PR TITLE
feat: add "bootstrap" option to `custom_job`

### DIFF
--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -97,6 +97,17 @@ on:
         default: false
         type: boolean
         required: false
+      bootstrap_script:
+        description: |
+          A script to run immediately after pulling the requested container
+          image to install any dependencies required for subsequent CI steps.
+
+          Scripts used here should not go beyond installing immediately
+          necessary dependencies, as any script passed in here will be executed
+          before telemetry and other steps are run.
+        required: false
+        type: string
+
 
 defaults:
   run:
@@ -143,6 +154,12 @@ jobs:
           ref: ${{ inputs.sha }}
           fetch-depth: 0
           persist-credentials: true
+      - name: Run bootstrap script
+        run: |
+          ulimit -n "$(ulimit -Hn)"
+          $BOOTSTRAP_SCRIPT
+        env:
+          BOOTSTRAP_SCRIPT: ${{ inputs.bootstrap_script }}
       - name: Telemetry setup
         uses: rapidsai/shared-actions/telemetry-dispatch-setup@main
         continue-on-error: true

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -148,6 +148,10 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
           role-duration-seconds: 43200 # 12h
+      - name: Ensure git is installed
+        run: |
+          # TODO: this (if it is even required) should be OS-agnostic
+          apt update && apt install -y git
       - uses: actions/checkout@v6
         with:
           repository: ${{ inputs.repo }}


### PR DESCRIPTION
While working on rapidsai/integration#837, I ran into an issue where we are specifically using lightweight `nvidia/cuda` images to test a clean install environment, but `shared-workflows` expects at least `git`, `jq`, and `curl` to be installed before the custom script is executed. (These dependencies are from the `rapids-github-info` and `setup-sccache` shared actions, respectively.

Adding an option here to run a smaller, bootstrap-only script to install any missing dependencies that would block the custom job from even making it to the custom script it is running.

Happy to discuss this further, but wanted to push this up to try it out.
