### PR TITLE
DO NOT MERGE: use `citestwheel` image built on `cuda-base` instead of `cuda-devel`

### DIFF
--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -234,7 +234,7 @@ jobs:
     runs-on: "linux-${{ matrix.ARCH }}-gpu-${{ matrix.GPU }}-${{ matrix.DRIVER }}-1"
     continue-on-error: ${{ inputs.continue-on-error }}
     container:
-      image: "rapidsai/citestwheel:26.06-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
+      image: "rapidsai/staging:citestwheel-400-26.06-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
       options: ${{ inputs.container-options }}
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }} # GPU jobs must set this container env variable


### PR DESCRIPTION
xref rapidsai/build-planning#143
xref rapidsai/ci-imgs#400

Swapping over to a `citestwheel` image built on top of `cuda-base` instead of `cuda-devel` - pushing up this branch for testing before we merge in the `ci-imgs` PR