### PR TITLE
feat: config renovate to wait 7 days after dependency release before update PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,8 @@
       "enabled": false,
       "matchPackageNames": [
         "/^rapidsai//"
-      ]
+      ],
+      "minimumReleaseAge": "7 days"
     }
   ]
 }


### PR DESCRIPTION
`shared-workflows` touches all of the RAPIDS projects -- this adds a cooldown that waits 1 week after a given release before `renovate` opens a PR here to update the dependency.

This avoids us quickly updating into a supply-chain attack.
