### PR TITLE
feat: add override env-var for setting custom artifact name

### DIFF
--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -169,9 +169,16 @@ jobs:
           # NEEDS alternative-gh-token-secret-name - API limits need to be for whatever token is used for upload/download. Repo token may be a different pool for rate limits.
           GH_TOKEN: ${{ inputs.alternative-gh-token-secret-name && secrets[inputs.alternative-gh-token-secret-name] || github.token }} # zizmor: ignore[overprovisioned-secrets]
       - name: C++ build
+        id: cpp-build
         run: |
           ulimit -n "$(ulimit -Hn)"
-          $INPUTS_SCRIPT
+          # shellcheck disable=SC1090
+          source "${INPUTS_SCRIPT}"
+
+          # Capture RAPIDS_PACKAGE_NAME if set by the build script
+          if [[ -n "${RAPIDS_PACKAGE_NAME:-}" ]]; then
+            echo "rapids-package-name=${RAPIDS_PACKAGE_NAME}" >> "${GITHUB_OUTPUT}"
+          fi
         env:
           INPUTS_SCRIPT: "${{ inputs.script }}"
           STEP_NAME: "C++ build"
@@ -179,8 +186,16 @@ jobs:
           GH_TOKEN: ${{ inputs.alternative-gh-token-secret-name && secrets[inputs.alternative-gh-token-secret-name] || github.token }} # zizmor: ignore[overprovisioned-secrets]
       - name: Get Package Name and Location
         if: ${{ inputs.upload-artifacts }}
+        env:
+          # Pass RAPIDS_PACKAGE_NAME from cpp-build step if available
+          RAPIDS_PACKAGE_NAME: ${{ steps.cpp-build.outputs.rapids-package-name }}
         run: |
-          echo "RAPIDS_PACKAGE_NAME=$(RAPIDS_NO_PKG_EXTENSION=true rapids-package-name conda_cpp)" >> "${GITHUB_OUTPUT}"
+          # Use RAPIDS_PACKAGE_NAME from build step if available, otherwise generate default
+          if [[ -n "${RAPIDS_PACKAGE_NAME:-}" ]]; then
+            echo "RAPIDS_PACKAGE_NAME=${RAPIDS_PACKAGE_NAME}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "RAPIDS_PACKAGE_NAME=$(RAPISD_NO_PKG_EXTENSION=true rapids-package-name conda_cpp)" >> "${GITHUB_OUTPUT}"
+          fi
           echo "CONDA_OUTPUT_DIR=${RAPIDS_CONDA_BLD_OUTPUT_DIR}" >> "${GITHUB_OUTPUT}"
         id: package-name
       - name: Show files to be uploaded


### PR DESCRIPTION
This is part of rapidsai/build-planning#270.

I'm rolling out a new `rapids-artifact-name` tool to make our artifact names more consistent - part of the first phase of this is overriding the "default" names that get created by `shared-workflows`.  I previously added the capability to override the artifact name from within the ci scripts for the stable ABI work, but that only covered the `python-build` workflows, this extends that capability to the `cpp-build` workflows.

Tested this in https://github.com/rapidsai/rmm/pull/2370 along with the vendored version of the script from https://github.com/rapidsai/gha-tools/pull/253