### PR TITLE
Add `build-devcontainers.yaml` and  `build-devcontainer.yaml` workflows

### DIFF
--- a/.github/workflows/build-devcontainer.yaml
+++ b/.github/workflows/build-devcontainer.yaml
@@ -1,0 +1,132 @@
+on:
+  workflow_call:
+    inputs:
+      push:
+        type: string
+        default: true
+        description: "Whether to push the image."
+      repo:
+        type: string
+        required: true
+        description: "Devcontainer image repository."
+      tag:
+        type: string
+        required: true
+        description: "Devcontainer image tag."
+      workspace-dir:
+        type: string
+        default: '.'
+        description: "Devcontainer workspace directory."
+      devcontainer-json:
+        type: string
+        required: true
+        description: "Path to the devcontainer.json file."
+      timeout-minutes:
+        type: number
+        default: 360
+        description: "Maximum time (in minutes) allowed for a run of this workflow."
+      retries:
+        type: string
+        default: '3'
+        description: "Number of times to retry the image build"
+      runs-on:
+        type: string
+        default: "ubuntu-latest"
+        description: "GHA runner label."
+    outputs:
+      version:
+        value: ${{ jobs.build.outputs.version }}
+
+
+permissions:
+  actions: none
+  checks: none
+  contents: none
+  deployments: none
+  discussions: none
+  issues: none
+  packages: write
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
+jobs:
+  build:
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64]
+    runs-on: ${{ fromJSON(github.actor != 'rapidsai' && '"ubuntu-latest"' || format('"${{ inputs.runs-on }}"', matrix.arch)) }}
+    name: "${{ inputs.tag }} (${{ matrix.arch }})"
+    outputs:
+      hash_amd64: ${{ steps.build.outputs.hash_amd64 }}
+      hash_arm64: ${{ steps.build.outputs.hash_arm64 }}
+      name: ${{ steps.build.outputs.name }}
+      repo: ${{ steps.build.outputs.repo }}
+      tag: ${{ steps.build.outputs.tag }}
+      version: ${{ steps.setup.outputs.version }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - id: setup
+        name: Setup versions
+        run: |
+          cat <<EOF | tee -a "$GITHUB_OUTPUT"
+          version=$(git describe --abbrev=0 --tags | sed 's/[a-zA-Z]//g' | cut -d '.' -f -2)
+          EOF
+
+      - name: Login to ghcr.io
+        if: inputs.push == 'true'
+        uses: docker/login-action@v4
+        with:
+          registry: "ghcr.io"
+          username: "${{ github.actor }}"
+          password: "${{ github.token }}"
+
+      - id: build
+        name: Build devcontainer (${{ matrix.arch }})
+        uses: rapidsai/shared-actions/build-devcontainer@fea/build-devcontainer
+        with:
+          arch: "${{ matrix.arch }}"
+          repo: "ghcr.io/${{ inputs.repo }}"
+          push: "${{ inputs.push }}"
+          retries: "${{ inputs.retries }}"
+          tag: "${{ inputs.tag }}"
+          version: "${{ steps.setup.outputs.version }}"
+          workspace-dir: "${{ inputs.workspace-dir }}"
+          devcontainer-json: "${{ inputs.devcontainer-json }}"
+
+  push:
+    if: inputs.push == 'true'
+    name: Push to ghcr.io
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to ghcr.io
+        uses: docker/login-action@v4
+        with:
+          registry: "ghcr.io"
+          username: "${{ github.actor }}"
+          password: "${{ github.token }}"
+
+      - id: push
+        name: Push manifest to ghcr.io
+        shell: bash --noprofile --norc -x -eo pipefail {0}
+        env:
+          hash_amd64: "${{ needs.build.outputs.hash_amd64 }}"
+          hash_arm64: "${{ needs.build.outputs.hash_arm64 }}"
+          name: "${{ needs.build.outputs.name }}"
+          name_latest: "${{ needs.build.outputs.name_latest }}"
+          ref_name: "${{ github.ref_name }}"
+        run: |
+          # Create the multiarch manifest
+          docker buildx imagetools create --tag "${name}" "${hash_amd64}" "${hash_arm64}";
+          if [[ "${ref_name}" == main ]]; then
+            docker buildx imagetools create --tag "${name_latest}" "${hash_amd64}" "${hash_arm64}";
+          fi

--- a/.github/workflows/build-devcontainer.yaml
+++ b/.github/workflows/build-devcontainer.yaml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Login to ghcr.io
         if: inputs.push == 'true'
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: "ghcr.io"
           username: "${{ github.actor }}"
@@ -109,7 +109,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Login to ghcr.io
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: "ghcr.io"
           username: "${{ github.actor }}"

--- a/.github/workflows/build-devcontainer.yaml
+++ b/.github/workflows/build-devcontainer.yaml
@@ -2,7 +2,7 @@ on:
   workflow_call:
     inputs:
       push:
-        type: string
+        type: boolean
         default: true
         description: "Whether to push the image."
       repo:
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         arch: [amd64, arm64]
-    runs-on: ${{ fromJSON(github.actor != 'rapidsai' && '"ubuntu-latest"' || format('"${{ inputs.runs-on }}"', matrix.arch)) }}
+    runs-on: ${{ fromJSON(github.repository_owner != 'rapidsai' && '"ubuntu-latest"' || format('"${{ inputs.runs-on }}"', matrix.arch)) }}
     name: "${{ inputs.tag }} (${{ matrix.arch }})"
     outputs:
       hash_amd64: ${{ steps.build.outputs.hash_amd64 }}
@@ -76,13 +76,14 @@ jobs:
 
       - id: setup
         name: Setup versions
+        shell: bash --noprofile --norc -x -eo pipefail {0}
         run: |
           cat <<EOF | tee -a "$GITHUB_OUTPUT"
           version=$(git describe --abbrev=0 --tags | sed 's/[a-zA-Z]//g' | cut -d '.' -f -2)
           EOF
 
       - name: Login to ghcr.io
-        if: inputs.push == 'true'
+        if: inputs.push
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: "ghcr.io"
@@ -103,7 +104,7 @@ jobs:
           devcontainer-json: "${{ inputs.devcontainer-json }}"
 
   push:
-    if: inputs.push == 'true'
+    if: inputs.push
     name: Push to ghcr.io
     needs: [build]
     runs-on: ubuntu-latest
@@ -115,8 +116,7 @@ jobs:
           username: "${{ github.actor }}"
           password: "${{ github.token }}"
 
-      - id: push
-        name: Push manifest to ghcr.io
+      - name: Push manifest to ghcr.io
         shell: bash --noprofile --norc -x -eo pipefail {0}
         env:
           hash_amd64: "${{ needs.build.outputs.hash_amd64 }}"

--- a/.github/workflows/build-devcontainer.yaml
+++ b/.github/workflows/build-devcontainer.yaml
@@ -91,7 +91,7 @@ jobs:
 
       - id: build
         name: Build devcontainer (${{ matrix.arch }})
-        uses: rapidsai/shared-actions/build-devcontainer@f727ef8676873a0fac406e5f8a50d46b3fa36136
+        uses: rapidsai/shared-actions/build-devcontainer@main
         with:
           arch: "${{ matrix.arch }}"
           repo: "ghcr.io/${{ inputs.repo }}"

--- a/.github/workflows/build-devcontainer.yaml
+++ b/.github/workflows/build-devcontainer.yaml
@@ -91,7 +91,7 @@ jobs:
 
       - id: build
         name: Build devcontainer (${{ matrix.arch }})
-        uses: rapidsai/shared-actions/build-devcontainer@fea/build-devcontainer
+        uses: rapidsai/shared-actions/build-devcontainer@f727ef8676873a0fac406e5f8a50d46b3fa36136
         with:
           arch: "${{ matrix.arch }}"
           repo: "ghcr.io/${{ inputs.repo }}"

--- a/.github/workflows/build-devcontainers.yaml
+++ b/.github/workflows/build-devcontainers.yaml
@@ -1,0 +1,96 @@
+name: Build devcontainers
+
+on:
+  workflow_call:
+    inputs:
+      cuda:
+        description: |
+          Stringified JSON array of CUDA versions to run this workflow for.
+          This is used to select .devcontainer/ directories local to wherever this workflow is invoked from.
+          For example, if a repository has directories '.devcontainer/cuda12.9-pip/' and '.devcontainer/cuda13.1-pip/',
+          '["12.9", "13.1"]' could be passed here to build both of those devcontainers in CI.
+        type: string
+        default: '["12.9", "13.1"]'
+      python_package_manager:
+        description: |
+          Stringified JSON array of Python package managers to run devcontainer builds for.
+          One of: '["conda"]', '["pip"]', '["conda", "pip"]'.
+        type: string
+        default: '["conda", "pip"]'
+      retries:
+        type: string
+        default: '3'
+        description: "Number of times to retry the image build"
+      push:
+        type: string
+        default: true
+
+jobs:
+  build:
+    secrets: inherit
+    uses: ./.github/workflows/build-devcontainer.yaml
+    permissions:
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        cuda: ${{ fromJSON(inputs.cuda) }}
+        python_package_manager: ${{ fromJSON(inputs.python_package_manager) }}
+    with:
+      runs-on: 'linux-{0}-cpu4'
+      push: "${{ inputs.push }}"
+      retries: "${{ inputs.retries }}"
+      repo: "${{ github.repository }}/devcontainer"
+      tag: "cuda${{ matrix.cuda }}-${{ matrix.python_package_manager }}"
+      devcontainer-json: ".devcontainer/cuda${{ matrix.cuda }}-${{ matrix.python_package_manager }}/devcontainer.json"
+
+  cleanup:
+    if: inputs.push == 'true'
+    needs: [build]
+    name: Clean up untagged images
+    runs-on: ubuntu-latest
+    outputs:
+      digests: ${{ steps.values.outputs.digests }}
+      name: ${{ steps.values.outputs.name }}
+      tags: ${{ steps.values.outputs.tags }}
+    steps:
+      - id: vars
+        name: Get image name, tags, and digests
+        env:
+          NAME: "ghcr.io/${{ github.repository }}/devcontainer"
+          VERSIONS: '["latest", "${{ needs.build.outputs.version }}"]'
+        run: |
+          set -xeuo pipefail
+
+          declare -a TAGS="($(jq -cnr \
+            --argjson vers "${VERSIONS}" \
+            --argjson cuda '${{ inputs.cuda }}' \
+            --argjson pkgr '${{ inputs.python_package_manager }}' \
+            '[[$vers, $cuda, $pkgr] | combinations | [.[0], "cuda" + .[1], .[2]] | join("-")] | join(" ")'))"
+
+          declare -a DIGESTS=()
+          for TAG in "${TAGS[@]}"; do
+            mapfile -O "${#DIGESTS[@]}" -t DIGESTS < <(
+              docker buildx imagetools inspect --raw "${NAME}:${TAG}" | jq -r '.manifests.[] | .digest'
+            )
+          done
+
+          NAME="${NAME#ghcr.io/${{ github.actor }}/}"
+
+          # Set values to control ghcr.io cleanup below
+          cat <<EOF >> "$GITHUB_OUTPUT"
+          digests=${DIGESTS[*]}
+          name=${NAME}
+          tags=${TAGS[*]}
+          EOF
+
+      - name: Clean up untagged images
+        uses: snok/container-retention-policy@3b0972b2276b171b212f8c4efbca59ebba26eceb
+        with:
+          cut-off: 1hr
+          tag-selection: untagged
+          token: "${{ github.token }}"
+          image-tags: "${{ steps.vars.outputs.tags }}"
+          image-names: "${{ steps.vars.outputs.name }}"
+          skip-shas: "${{ steps.vars.outputs.digests }}"
+          account: "${{ github.actor == github.triggering_actor && 'user' || github.actor }}"

--- a/.github/workflows/build-devcontainers.yaml
+++ b/.github/workflows/build-devcontainers.yaml
@@ -48,10 +48,6 @@ jobs:
     needs: [build]
     name: Clean up untagged images
     runs-on: ubuntu-latest
-    outputs:
-      digests: ${{ steps.values.outputs.digests }}
-      name: ${{ steps.values.outputs.name }}
-      tags: ${{ steps.values.outputs.tags }}
     steps:
       - id: vars
         name: Get image name, tags, and digests

--- a/.github/workflows/build-devcontainers.yaml
+++ b/.github/workflows/build-devcontainers.yaml
@@ -8,9 +8,9 @@ on:
           Stringified JSON array of CUDA versions to run this workflow for.
           This is used to select .devcontainer/ directories local to wherever this workflow is invoked from.
           For example, if a repository has directories '.devcontainer/cuda12.9-pip/' and '.devcontainer/cuda13.1-pip/',
-          '["12.9", "13.1"]' could be passed here to build both of those devcontainers in CI.
+          '["12.9", "13.2"]' could be passed here to build both of those devcontainers in CI.
         type: string
-        default: '["12.9", "13.1"]'
+        required: true
       python_package_manager:
         description: |
           Stringified JSON array of Python package managers to run devcontainer builds for.
@@ -22,7 +22,7 @@ on:
         default: '3'
         description: "Number of times to retry the image build"
       push:
-        type: string
+        type: boolean
         default: true
 
 jobs:
@@ -44,22 +44,21 @@ jobs:
       devcontainer-json: ".devcontainer/cuda${{ matrix.cuda }}-${{ matrix.python_package_manager }}/devcontainer.json"
 
   cleanup:
-    if: inputs.push == 'true'
+    if: inputs.push
     needs: [build]
     name: Clean up untagged images
     runs-on: ubuntu-latest
     steps:
       - id: vars
         name: Get image name, tags, and digests
+        shell: bash --noprofile --norc -eo pipefail {0}
         env:
           CUDA: "${{ inputs.cuda }}"
-          NAME_PREFIX: "ghcr.io/${{ github.actor }}"
+          NAME_PREFIX: "ghcr.io/${{ github.repository_owner }}"
           NAME: "ghcr.io/${{ github.repository }}/devcontainer"
           PYTHON_PACKAGE_MANAGER: "${{ inputs.python_package_manager }}"
           VERSIONS: '["latest", "${{ needs.build.outputs.version }}"]'
         run: |
-          set -xeuo pipefail
-
           declare -a TAGS="($(jq -cnr \
             --argjson vers "${VERSIONS}" \
             --argjson cuda "${CUDA}" \
@@ -83,12 +82,12 @@ jobs:
           EOF
 
       - name: Clean up untagged images
-        uses: snok/container-retention-policy@3b0972b2276b171b212f8c4efbca59ebba26eceb
+        uses: snok/container-retention-policy@3b0972b2276b171b212f8c4efbca59ebba26eceb # v3.0.1
         with:
-          cut-off: 1hr
+          cut-off: 6hr
           tag-selection: untagged
           token: "${{ github.token }}"
           image-tags: "${{ steps.vars.outputs.tags }}"
           image-names: "${{ steps.vars.outputs.name }}"
           skip-shas: "${{ steps.vars.outputs.digests }}"
-          account: "${{ github.actor == github.triggering_actor && 'user' || github.actor }}"
+          account: "${{ github.repository_owner == 'rapidsai' && 'rapidsai' || 'user' }}"

--- a/.github/workflows/build-devcontainers.yaml
+++ b/.github/workflows/build-devcontainers.yaml
@@ -27,7 +27,6 @@ on:
 
 jobs:
   build:
-    secrets: inherit
     uses: ./.github/workflows/build-devcontainer.yaml
     permissions:
       packages: write
@@ -57,15 +56,18 @@ jobs:
       - id: vars
         name: Get image name, tags, and digests
         env:
+          CUDA: "${{ inputs.cuda }}"
+          NAME_PREFIX: "ghcr.io/${{ github.actor }}"
           NAME: "ghcr.io/${{ github.repository }}/devcontainer"
+          PYTHON_PACKAGE_MANAGER: "${{ inputs.python_package_manager }}"
           VERSIONS: '["latest", "${{ needs.build.outputs.version }}"]'
         run: |
           set -xeuo pipefail
 
           declare -a TAGS="($(jq -cnr \
             --argjson vers "${VERSIONS}" \
-            --argjson cuda '${{ inputs.cuda }}' \
-            --argjson pkgr '${{ inputs.python_package_manager }}' \
+            --argjson cuda "${CUDA}" \
+            --argjson pkgr "${PYTHON_PACKAGE_MANAGER}" \
             '[[$vers, $cuda, $pkgr] | combinations | [.[0], "cuda" + .[1], .[2]] | join("-")] | join(" ")'))"
 
           declare -a DIGESTS=()
@@ -75,7 +77,7 @@ jobs:
             )
           done
 
-          NAME="${NAME#ghcr.io/${{ github.actor }}/}"
+          NAME="${NAME#${NAME_PREFIX}/}"
 
           # Set values to control ghcr.io cleanup below
           cat <<EOF >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Add workflows to build and publish devcontainers to `ghcr.io` so we can use `cacheFrom` to speed up devcontainer launch times.

Depends on https://github.com/rapidsai/shared-actions/pull/104