### PR TITLE
renovate: group GitHub Actions updates into fewer PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,13 @@
         "/^rapidsai//"
       ],
       "minimumReleaseAge": "7 days"
+    },
+    {
+      "matchManagers": [
+        "gh-actions"
+      ],
+      "groupName": "github-actions",
+      "minimumReleaseAge": "7 days"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -6,16 +6,13 @@
   "packageRules": [
     {
       "enabled": false,
-      "matchPackageNames": [
-        "/^rapidsai//"
-      ],
-      "minimumReleaseAge": "7 days"
-    },
-    {
+      "groupName": "github-actions",
       "matchManagers": [
         "gh-actions"
       ],
-      "groupName": "github-actions",
+      "matchPackageNames": [
+        "/^rapidsai//"
+      ],
       "minimumReleaseAge": "7 days"
     }
   ]


### PR DESCRIPTION
Proposes grouping all `renovate` updates to third-party GitHub Actions into a single PR, to reduce notifications and review effort.

We almost always accept all of these, so getting individual PRs like this is just extra work for no benefit:

* #519
* #531
* #532

## Notes for Reviewers

This has been working well in the `docker` repo:  https://github.com/rapidsai/docker/pull/823