### PR TITLE
enable renovate (accidentally not enabled)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   ],
   "packageRules": [
     {
-      "enabled": false,
+      "enabled": true,
       "groupName": "github-actions",
       "matchManagers": [
         "gh-actions"


### PR DESCRIPTION
#533 added configuration to group together updates, but it did so in a `renovate.json` rule group that has `enabled: false`.

I think that's why we didn't get any new updates, even when I checked the box on #128 asking Renovate to re-run. This fixes that.

Other reasons? Yet another GitHub outage with pull requests 🙃 

https://www.githubstatus.com/incidents/f5pb5d5mr9yh

## Notes for Reviewers

I've specifically chosen this branch name + checked the box to run renovate on #128. According to the Renovate docs, that should trigger a check on the config: https://docs.renovatebot.com/config-validation/#validation-of-renovate-config-change-prs