### PR TITLE
fix: declare secrets for breaking change alert

### DIFF
--- a/.github/workflows/breaking-change-alert.yaml
+++ b/.github/workflows/breaking-change-alert.yaml
@@ -44,6 +44,10 @@ on:
         description: 'Pull request merged status'
         required: true
         type: boolean
+    secrets:
+      NV_SLACK_BREAKING_CHANGE_ALERT:
+        required: false
+        description: "Token for posting breaking change alerts to Slack"
 
 defaults:
   run:


### PR DESCRIPTION
As part of rapidsai/build-planning#275 I've been declaring used secrets explicitly -- they also need to be declared explicitly in the `on.workflow_call.secrets` section (this broke a bunch of nightly builds)

Workflows that are still using `secrets: inherit` will continue to work, but this will fix any callers that are passing explicit secrets by name.

Same idea as #535 but I missed the breaking change alert
