### PR TITLE
renovate: group GitHub Actions updates into fewer PRs (actually)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,14 +5,17 @@
   ],
   "packageRules": [
     {
-      "enabled": true,
-      "groupName": "github-actions",
-      "matchManagers": [
-        "gh-actions"
-      ],
+      "enabled": false,
       "matchPackageNames": [
         "/^rapidsai//"
       ],
+      "minimumReleaseAge": "7 days"
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "groupName": "github-actions",
       "minimumReleaseAge": "7 days"
     }
   ]


### PR DESCRIPTION
I'd tried in #533 to group GitHub Actions version bumps from `renovate` into a single PR, but didn't do that correctly: https://github.com/rapidsai/shared-workflows/pull/533#issuecomment-4421985876

This fixes it for real.

1. `"matchManagers"` don't map to display names... those entries have special meaning and have to match known values (e.g. from https://docs.renovatebot.com/modules/manager/github-actions/)
2. I'd misinterpreted `"enabled": false` in #534 ... it doesn't mean "turn off this rule", it means "ignore updates to dependencies matching this rule"... sheesh 😫 

## Notes for Reviewers

I've specifically chosen this branch name + checked the box to run renovate on #128. According to the Renovate docs, that should trigger a check on the config: https://docs.renovatebot.com/config-validation/#validation-of-renovate-config-change-prs

Based on https://github.com/rapidsai/shared-workflows/pull/541#issuecomment-4422919042, I think this will do what we want!