### PR TITLE
fix(conda): restore `pure-conda` input for matrix filtering

### DIFF
--- a/.github/workflows/compute-matrix.yaml
+++ b/.github/workflows/compute-matrix.yaml
@@ -25,6 +25,16 @@ on:
         required: false
         type: boolean
         default: false
+      pure-conda:
+        required: false
+        type: string
+        default: "false"
+        description: |
+          One of [true, false, cuda_major]. 'true' if the conda package is not
+          dependent on operating system, Python minor version, CPU architecture,
+          or CUDA version. 'cuda_major' if the package is not dependent on
+          operating system, Python minor version, or CPU architecture, but is
+          dependent on CUDA major version.
     outputs:
       matrix:
         value: ${{ jobs.compute-matrix.outputs.matrix }}
@@ -204,6 +214,7 @@ jobs:
           MATRIX: ${{ steps.prepare-matrix.outputs.matrix }}
           MATRIX_FILTER: ${{ inputs.matrix_filter }}
           PURE_WHEEL: ${{ inputs.pure_wheel }}
+          PURE_CONDA: ${{ inputs.pure-conda }}
         run: |
           set -eo pipefail
 
@@ -221,6 +232,13 @@ jobs:
           # When pure-wheel is true and matrix_filter is default, override to build one wheel per CUDA version with amd64 and the latest PY_VER
           if [ "${PURE_WHEEL}" = "true" ] && [ "${MATRIX_FILTER}" = "." ]; then
             MATRIX_FILTER="map(select(.ARCH == \"amd64\")) | group_by(.CUDA_VER) | map(max_by(.PY_VER | split(\".\") | map(tonumber)))"
+          fi
+
+          # When pure-conda is true and matrix_filter is default, override to build one conda package with amd64, latest CUDA_VER, and the latest PY_VER
+          if [ "${PURE_CONDA}" = "true" ] && [ "${MATRIX_FILTER}" = "." ]; then
+            MATRIX_FILTER="map(select(.ARCH == \"amd64\")) | sort_by(.CUDA_VER, .PY_VER) | [last]"
+          elif [ "${PURE_CONDA}" = "cuda_major" ] && [ "${MATRIX_FILTER}" = "." ]; then
+            MATRIX_FILTER="map(select(.ARCH == \"amd64\")) | group_by(.CUDA_VER|split(\".\")|map(tonumber)|.[0]) | map(max_by([(.PY_VER|split(\".\")|map(tonumber)), (.CUDA_VER|split(\".\")|map(tonumber))]))"
           fi
 
           MATRIX="$(


### PR DESCRIPTION
In #524 we introduced `compute-matrix` as a standalone job. The
`pure_wheel` input made it into the new matrix job, but not
`pure-conda`.

This restores the conda filtering logic.

This should have broken more jobs sooner, but for some reason, our upload artifact jobs sometimes don't care about key collisions, and sometimes they do.

So sometimes, we get (from https://github.com/rapidsai/cudf/actions/runs/25685645333/job/75414007215?pr=22319):

```
Run actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
/usr/bin/docker exec  5e876c7f2b338b6b36a42462685b4afe700a9c384f406e603d1426f0a1152d6f sh -c "cat /etc/*release | grep ^ID"
With the provided path, there will be 5 files uploaded
Artifact name is valid!
Root directory input is valid!
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```

And others, we just end up with 16 identically named artifacts
