### PR TITLE
allow untagged image cleanup job to fail

### DIFF
--- a/.github/workflows/build-devcontainers.yaml
+++ b/.github/workflows/build-devcontainers.yaml
@@ -48,6 +48,7 @@ jobs:
     needs: [build]
     name: Clean up untagged images
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - id: vars
         name: Get image name, tags, and digests


### PR DESCRIPTION
Sometimes the `snok/container-retention-policy` job fails because the github token is invalid (expired?).

This shouldn't fail the workflow, eventually another job will run and cleanup will happen then instead.