### PR TITLE
use full semver tags for third-party actions

### DIFF
--- a/.github/workflows/build-devcontainer.yaml
+++ b/.github/workflows/build-devcontainer.yaml
@@ -70,7 +70,7 @@ jobs:
       tag: ${{ steps.build.outputs.tag }}
       version: ${{ steps.setup.outputs.version }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -85,7 +85,7 @@ jobs:
 
       - name: Login to ghcr.io
         if: inputs.push
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: "ghcr.io"
           username: "${{ github.actor }}"
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Login to ghcr.io
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: "ghcr.io"
           username: "${{ github.actor }}"

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -99,7 +99,7 @@ jobs:
     runs-on: "linux-${{ matrix.ARCH }}-${{ inputs.node_type }}"
     name: "${{ matrix.ARCH }}, ${{ matrix.CUDA_VER }}, ${{ matrix.PACKAGER }}"
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}
@@ -146,7 +146,7 @@ jobs:
           role-duration-seconds: 43200 # 12h
 
       - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24'
 
@@ -212,7 +212,7 @@ jobs:
 
       - if: ${{ !cancelled() }}
         name: Upload sccache logs
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sccache-client-logs-${{ env.BUILD_SLUG }}-${{ env.ARTIFACT_SLUG }}
           path: repo/sccache*.log

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -64,7 +64,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Checkout code repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true
       - name: Calculate changed files

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -55,7 +55,7 @@ jobs:
         RAPIDS_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: true
       - name: Telemetry setup
@@ -97,7 +97,7 @@ jobs:
           VERSION_FILES_CHANGED: ${{ (inputs.enable_check_version_files_changed && fromJSON(steps.changed-files.outputs.changed_file_groups).version_files) || 'false' }}
       - name: Fetch tags
         if: ${{ inputs.enable_check_version_against_tag }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
           fetch-depth: 0 # https://github.com/actions/checkout/issues/1471
@@ -126,7 +126,7 @@ jobs:
       image: rapidsai/ci-conda:26.08-cuda13.2.0-ubuntu24.04-py3.12 # zizmor: ignore[unpinned-images]
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: true
@@ -139,7 +139,7 @@ jobs:
       - name: Get PR Info
         id: get-pr-info
         uses: nv-gha-runners/get-pr-info@main
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-0|${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -107,7 +107,7 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
           role-duration-seconds: 43200 # 12h
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}
@@ -205,7 +205,7 @@ jobs:
         run: |
           echo "Contents of directory to be uploaded:"
           ls -R "${CONDA_OUTPUT_DIR}"
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ inputs.upload-artifacts }}
         with:
           if-no-files-found: 'error'

--- a/.github/workflows/conda-cpp-post-build-checks.yaml
+++ b/.github/workflows/conda-cpp-post-build-checks.yaml
@@ -63,7 +63,7 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
           role-duration-seconds: 43200 # 12h
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}
@@ -113,7 +113,7 @@ jobs:
           EXTRACTED_DIR=$(rapids-extract-conda-files "${CPP_DIR}")
           echo "RAPIDS_EXTRACTED_DIR=${EXTRACTED_DIR}" >> "${GITHUB_ENV}"
       - name: Get weak detection tool
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: rapidsai/detect-weak-linking
           ref: refs/heads/main

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -149,7 +149,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           role-duration-seconds: 43200 # 12h
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -117,7 +117,7 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
           role-duration-seconds: 43200 # 12h
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}
@@ -210,7 +210,7 @@ jobs:
         run: |
           echo "Contents of directory to be uploaded:"
           ls -R "${CONDA_OUTPUT_DIR}"
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ inputs.upload-artifacts }}
         with:
           if-no-files-found: 'error'

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -153,7 +153,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           role-duration-seconds: 43200 # 12h
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -77,7 +77,7 @@ jobs:
         if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -137,7 +137,7 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
           role-duration-seconds: 43200 # 12h
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}
@@ -192,7 +192,7 @@ jobs:
           GH_TOKEN: ${{ inputs.alternative-gh-token-secret-name && secrets[inputs.alternative-gh-token-secret-name] || github.token }} # zizmor: ignore[overprovisioned-secrets]
       - name: Get RAPIDS License Builder
         if: ${{ inputs.requires_license_builder }}
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: "rapidsai/spdx-license-builder"
           ref: "refs/heads/main"
@@ -208,7 +208,7 @@ jobs:
           GH_TOKEN: ${{ inputs.alternative-gh-token-secret-name && secrets[inputs.alternative-gh-token-secret-name] || github.token }} # zizmor: ignore[overprovisioned-secrets]
           INPUTS_SCRIPT: ${{ inputs.script }}
       - name: Upload file to GitHub Artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.artifact-name }}
           path: ${{ inputs.file_to_upload }}

--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -19,7 +19,7 @@ jobs:
           NEEDS: ${{ inputs.needs }}
         run: jq -en 'env.NEEDS | fromjson | all(.result as $result | ["success", "skipped"] | any($result == .))'
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -150,7 +150,7 @@ jobs:
           role-duration-seconds: 43200 # 12h
 
       - name: checkout code repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}
@@ -175,7 +175,7 @@ jobs:
           echo "EXTRA_REPO_PATH=${EXTRA_REPO_PATH}" >> "${GITHUB_OUTPUT}"
 
       - name: checkout extra repos
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: ${{ inputs.extra-repo != '' }}
         with:
           repository: ${{ inputs.extra-repo }}
@@ -283,7 +283,7 @@ jobs:
           echo "Contents of directory to be uploaded:"
           ls -R "$WHEEL_OUTPUT_DIR"
 
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: ${{ inputs.upload-artifacts }}
         with:
           if-no-files-found: 'error'

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -84,7 +84,7 @@ jobs:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:
     - name: checkout code repo
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ inputs.repo }}
         ref: ${{ inputs.sha }}

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -180,7 +180,7 @@ jobs:
       run: nvidia-smi
 
     - name: checkout code repo
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: ${{ inputs.repo }}
         ref: ${{ inputs.sha }}


### PR DESCRIPTION
Proposes using full semver for tag reference comments in `uses:` blocks, to improve the usefulness of `renovate`'s output.

See #547

<img width="855" height="540" alt="image" src="https://github.com/user-attachments/assets/531b7cc8-ed92-48c5-b27e-d19b2f12051f" />

Because we weren't using the full semver tag that `docker/login-action` uses (just as an example), `renovate`'s auto-bump PR:

* shows a change in commit SHAs instead of versions
* does not auto-generate a link to release notes

## Notes for Reviewers

We're using the full version tags like this in most of the rest of RAPIDS as of #275