### PR TITLE
breaking-change-alert: fix webhook URL passing

### DIFF
--- a/.github/workflows/breaking-change-alert.yaml
+++ b/.github/workflows/breaking-change-alert.yaml
@@ -45,9 +45,9 @@ on:
         required: true
         type: boolean
     secrets:
-      NV_SLACK_BREAKING_CHANGE_ALERT:
-        required: false
-        description: "Token for posting breaking change alerts to Slack"
+      slack-webhook-url:
+        required: true
+        description: "Webhook URL to post breaking changes to a Slack channel."
 
 defaults:
   run:
@@ -170,5 +170,5 @@ jobs:
               ]
             }
           payload-templated: true
-          webhook: ${{ secrets.NV_SLACK_BREAKING_CHANGE_NOTIFIER_APP }}
+          webhook: ${{ secrets.slack-webhook-url }}
           webhook-type: incoming-webhook


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/shared-workflows/issues/560

`breaking-change-alert` requires a webhook URL directing it to post to an internal Slack channel. This value is secret, and changes to secrets-handling as part of https://github.com/rapidsai/build-planning/issues/275 introduced misconfigurations that led to this workflow failing.

This makes the interface clearer with a more clearly-named input variable and a corrected docstring (the one on `main` incorrectly refers to this secret as holding a "token" but it holds a URL).

## Notes for Reviewers

### Won't merging this break CI?

Yes but it's fine.

1. most callers of this workflow are ALREADY broken
2. this workflow does not block PRs or any other CI. It's just an informational thing to archive links to PRs with the `breaking` label into Slack (the same type of information that also shows up in release notes)

### How I tested this

In an internal repo.

* changes similar to what I'll roll out across RAPIDS: https://github.com/rapidsai/literate-octo-potato/commit/e02107f62c6612d547d14c2e988b028a7e77766d
* observed things working: https://github.com/rapidsai/literate-octo-potato/pull/928#issuecomment-4593987408