### PR TITLE
conda: opt out of sharded repodata

### DIFF
--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -184,6 +184,11 @@ jobs:
           STEP_NAME: "C++ build"
           # NEEDS alternative-gh-token-secret-name - may require a token with more permissions
           GH_TOKEN: ${{ inputs.alternative-gh-token-secret-name && secrets[inputs.alternative-gh-token-secret-name] || github.token }} # zizmor: ignore[overprovisioned-secrets]
+          # opt out of conda sharded repodata
+          #
+          # TODO: remove these when this is resolved: https://github.com/conda/infrastructure/issues/1286#issuecomment-4628580232
+          CONDA_PLUGINS_USE_SHARDED_REPODATA: false
+          RATTLER_SHARDED: false
       - name: Get Package Name and Location
         if: ${{ inputs.upload-artifacts }}
         env:

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -232,6 +232,11 @@ jobs:
           INPUTS_SCRIPT: "${{ inputs.script }}"
           # NEEDS alternative-gh-token-secret-name - may require a token with more permissions
           GH_TOKEN: ${{ inputs.alternative-gh-token-secret-name && secrets[inputs.alternative-gh-token-secret-name] || github.token }} # zizmor: ignore[overprovisioned-secrets]
+          # opt out of conda sharded repodata
+          #
+          # TODO: remove these when this is resolved: https://github.com/conda/infrastructure/issues/1286#issuecomment-4628580232
+          CONDA_PLUGINS_USE_SHARDED_REPODATA: false
+          RATTLER_SHARDED: false
       - name: Generate test report
         uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2.4
         with:

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -189,6 +189,11 @@ jobs:
           # NEEDS alternative-gh-token-secret-name - may require a token with more permissions
           GH_TOKEN: ${{ inputs.alternative-gh-token-secret-name && secrets[inputs.alternative-gh-token-secret-name] || github.token }} # zizmor: ignore[overprovisioned-secrets]
           INPUTS_SCRIPT: ${{ inputs.script }}
+          # opt out of conda sharded repodata
+          #
+          # TODO: remove these when this is resolved: https://github.com/conda/infrastructure/issues/1286#issuecomment-4628580232
+          CONDA_PLUGINS_USE_SHARDED_REPODATA: false
+          RATTLER_SHARDED: false
       - name: Get Package Name and Location
         if: ${{ inputs.upload-artifacts }}
         env:

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -237,6 +237,11 @@ jobs:
           INPUTS_SCRIPT: "${{ inputs.script }}"
           # NEEDS alternative-gh-token-secret-name - may require a token with more permissions
           GH_TOKEN: ${{ inputs.alternative-gh-token-secret-name && secrets[inputs.alternative-gh-token-secret-name] || github.token }} # zizmor: ignore[overprovisioned-secrets]
+          # opt out of conda sharded repodata
+          #
+          # TODO: remove these when this is resolved: https://github.com/conda/infrastructure/issues/1286#issuecomment-4628580232
+          CONDA_PLUGINS_USE_SHARDED_REPODATA: false
+          RATTLER_SHARDED: false
       - name: Generate test report
         uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # v2.4
         with:

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -207,6 +207,11 @@ jobs:
           # NEEDS alternative-gh-token-secret-name - may require a token with more permissions
           GH_TOKEN: ${{ inputs.alternative-gh-token-secret-name && secrets[inputs.alternative-gh-token-secret-name] || github.token }} # zizmor: ignore[overprovisioned-secrets]
           INPUTS_SCRIPT: ${{ inputs.script }}
+          # opt out of conda sharded repodata
+          #
+          # TODO: remove these when this is resolved: https://github.com/conda/infrastructure/issues/1286#issuecomment-4628580232
+          CONDA_PLUGINS_USE_SHARDED_REPODATA: false
+          RATTLER_SHARDED: false
       - name: Upload file to GitHub Artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:


### PR DESCRIPTION
Sharded repodata was enabled on the `rapidsai` channel in mid-April: https://github.com/rapidsai/build-planning/issues/240#issuecomment-4247344676

During the 26.06 release, we found that sharded repodata updates were not propagating through anaconda.org's CDN, blocking CI with "package not found" types of issues: https://github.com/rapidsai/cugraph/pull/5542#discussion_r3360573913

This proposes opting out of sharded repodata for the 26.06 release. Hopefully it can be reverted on `main` when those issues are resolved. 

## Notes for Reviewers

### Why not do this in `ci-imgs`?

I'd started there (https://github.com/rapidsai/ci-imgs/pull/415) but think this is better.

Rebuilding CI images at this point is risky... unrelated updates could be pulled in that cause new problems for the release.

It's also more expensive (100+ image build + publish jobs) and time-consuming.

CI there is also currently broken by upstream issues and would need a backport of https://github.com/rapidsai/ci-imgs/pull/412

### How I tested this

On a `cugraph` PR:

* PR: https://github.com/rapidsai/cugraph/pull/5542
* build: https://github.com/rapidsai/cugraph/actions/runs/27019972403