### PR TITLE
revert snok/container-retention-policy version bump, skip them in the future

### DIFF
--- a/.github/workflows/build-devcontainers.yaml
+++ b/.github/workflows/build-devcontainers.yaml
@@ -83,7 +83,7 @@ jobs:
           EOF
 
       - name: Clean up untagged images
-        uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53 # v3.1.0
+        uses: snok/container-retention-policy@snok/container-retention-policy@3b0972b2276b171b212f8c4efbca59ebba26eceb # v3.0.1
         with:
           cut-off: 6hr
           tag-selection: untagged

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,12 @@
       "minimumReleaseAge": "7 days"
     },
     {
+      "enabled": false,
+      "matchPackageNames": [
+        "snok/container-retention-policy"
+      ]
+    },
+    {
       "matchManagers": [
         "github-actions"
       ],


### PR DESCRIPTION
#562 broken RAPIDS nightly builds, because it updated `snok/container-retention-policy` to a version that's not in the org-wide allowlist.

> _[Error](https://github.com/rapidsai/cudf/actions/runs/27120509594/workflow)
The action snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53 is not allowed in rapidsai/cudf because all actions must be from a repository owned by your enterprise, created by GitHub, verified in the GitHub Marketplace, or match one of the patterns:_

https://github.com/rapidsai/cudf/actions/runs/27120509594

I've requested that that new version be added, but for now this proposes the following:

* revert that update, to get CI working again
* avoid `renovate` suggesting updates to this dependency in the future
  - _it's allowlisted one SHA at a time, so will be a bit annoying to keep updating. Proposing we just stick to a pinned version and manually update as needed_