### PR TITLE
Bump to `snok/container-retention-policy@v3.1.0` in `build-devcontainers.yaml`

### DIFF
--- a/.github/workflows/build-devcontainers.yaml
+++ b/.github/workflows/build-devcontainers.yaml
@@ -85,7 +85,7 @@ jobs:
           EOF
 
       - name: Clean up untagged images
-        uses: snok/container-retention-policy@3b0972b2276b171b212f8c4efbca59ebba26eceb # v3.0.1
+        uses: snok/container-retention-policy@d3bdcf5ce9b05f685154e4a16c39233b245e3d53 # v3.1.0
         with:
           cut-off: 6hr
           tag-selection: untagged


### PR DESCRIPTION
From [here](https://github.com/snok/container-retention-policy/releases/tag/v3.1.0):
> Fixed token parsing related to Github's token format migration ([source](https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens/)). Fixes https://github.com/snok/container-retention-policy/issues/132 and https://github.com/snok/container-retention-policy/issues/129.