### PR TITLE
pre-commit.ci: reduce update frequency to 'monthly'

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,7 @@
 # Copyright (c) 2025, NVIDIA CORPORATION.
 
 ci:
+  autoupdate_schedule: 'monthly'
   skip: [actionlint-docker]
 
 repos:


### PR DESCRIPTION
Proposing limiting `pre-commit.ci` to only checking for updates once a month (the default is "weekly"), to reduce the volume of PRs like #576 .

If it weren't for `zizmor` pulling in security fixes, I'd propose something even slower like "quarterly".

docs: https://pre-commit.ci/#configuration-autoupdate_schedule