### PR TITLE
feat(renovate): add 7-day cooldown before any updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,11 +5,17 @@
   ],
   "packageRules": [
     {
+      "description": "Wait for 7 days post-release before updating",
+      "matchPackageNames": [
+        "*"
+      ],
+      "minimumReleaseAge": "7 days"
+    },
+    {
       "enabled": false,
       "matchPackageNames": [
         "/^rapidsai//"
-      ],
-      "minimumReleaseAge": "7 days"
+      ]
     },
     {
       "enabled": false,
@@ -21,8 +27,7 @@
       "matchManagers": [
         "github-actions"
       ],
-      "groupName": "github-actions",
-      "minimumReleaseAge": "7 days"
+      "groupName": "github-actions"
     }
   ]
 }


### PR DESCRIPTION
Part of rapidsai/build-planning#273

Adds a 7-day cooldown period before renovate proposes any updates

Note: there were cooldowns here already, but this declares that ALL packages should have a 7-day cooldown