### PR TITLE
wheels-publish: make upload directory explicit

### DIFF
--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -120,7 +120,14 @@ jobs:
         GH_TOKEN: ${{ github.token }}
 
     - name: Download wheels from artifact storage and publish to anaconda repository
-      run: rapids-wheels-anaconda-github "${INPUTS_PACKAGE_NAME}" "${INPUTS_PACKAGE_TYPE}"
+      id: download_wheels
+      run: |
+        UPLOAD_DIR="$(mktemp -d)"
+        rapids-wheels-anaconda-github \
+          "${INPUTS_PACKAGE_NAME}" \
+          "${INPUTS_PACKAGE_TYPE}" \
+          "${UPLOAD_DIR}"
+        echo "package_upload_dir=${UPLOAD_DIR}" >> "${GITHUB_OUTPUT}"
       env:
         GH_TOKEN: ${{ github.token }}
         RAPIDS_CONDA_TOKEN: ${{ secrets.CONDA_RAPIDSAI_WHEELS_NIGHTLY_TOKEN }}
@@ -146,8 +153,9 @@ jobs:
       if: ${{ inputs.publish_to_pypi && steps.check_if_release.outputs.is_release_build == 'true' }}
       run: |
         python3 -m pip install twine
-        python3 -m twine upload -u __token__ dist/*
+        python3 -m twine upload -u __token__ "${UPLOAD_DIR}"/*
       env:
+        UPLOAD_DIR: ${{ steps.download_wheels.outputs.package_upload_dir }}
         TWINE_PASSWORD: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
     - name: Telemetry upload attributes
       uses: rapidsai/shared-actions/telemetry-dispatch-stash-job-artifacts@main


### PR DESCRIPTION
Until recently, `rapids-wheels-anaconda-github` downloaded package artifacts to `./dist` (hard-coded) and the code to upload to `pypi.org` still expects to find them in `dist/*` (also hard-coded).

https://github.com/rapidsai/shared-workflows/blob/3f5f9d01f3873916bf830fdc3e0fd684ccc0befb/.github/workflows/wheels-publish.yaml#L145-L149

In https://github.com/rapidsai/gha-tools/pull/263 I changed that hard-coded to `./dist` in `gha-tools` which now breaks publishing to PyPI.

```text
ERROR    InvalidDistribution: Cannot find file (or expand pattern): 'dist/*'    
Error: Process completed with exit code 1.
```

([jupyterlab-nvdashboard build link](https://github.com/rapidsai/jupyterlab-nvdashboard/actions/runs/28184382922/job/83483178079))

Wasn't caught there because this is a code path that only runs on uploads to `pypi.org`, and I only tested uploads to the RAPIDS nightly index.

This proposes changes for `wheels-publish` to fix that:

* explicitly publish the location that packages were downloaded to as an output of the step that runs `rapids-wheels-anaconda-github`
* re-use that in the upload-to-PyPI block

## Notes for Reviewers

Deployment order:

1. merge https://github.com/rapidsai/gha-tools/pull/264
2. wait for new images to be built: https://github.com/rapidsai/ci-imgs/actions/workflows/push.yaml
3. merge this PR