### PR TITLE
remove git clones and telemetry for package-publishing jobs, use full semver tags for third-party actions

### DIFF
--- a/.github/workflows/build-devcontainer.yaml
+++ b/.github/workflows/build-devcontainer.yaml
@@ -70,7 +70,7 @@ jobs:
       tag: ${{ steps.build.outputs.tag }}
       version: ${{ steps.setup.outputs.version }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/build-in-devcontainer.yaml
+++ b/.github/workflows/build-in-devcontainer.yaml
@@ -99,7 +99,7 @@ jobs:
     runs-on: "linux-${{ matrix.ARCH }}-${{ inputs.node_type }}"
     name: "${{ matrix.ARCH }}, ${{ matrix.CUDA_VER }}, ${{ matrix.PACKAGER }}"
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}

--- a/.github/workflows/changed-files.yaml
+++ b/.github/workflows/changed-files.yaml
@@ -64,7 +64,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Checkout code repo
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: true
       - name: Calculate changed files

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -55,7 +55,7 @@ jobs:
         RAPIDS_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: true
       - name: Telemetry setup
@@ -97,7 +97,7 @@ jobs:
           VERSION_FILES_CHANGED: ${{ (inputs.enable_check_version_files_changed && fromJSON(steps.changed-files.outputs.changed_file_groups).version_files) || 'false' }}
       - name: Fetch tags
         if: ${{ inputs.enable_check_version_against_tag }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           fetch-depth: 0 # https://github.com/actions/checkout/issues/1471
@@ -126,7 +126,7 @@ jobs:
       image: rapidsai/ci-conda:26.08-cuda13.3.0-ubuntu24.04-py3.12 # zizmor: ignore[unpinned-images]
     steps:
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           persist-credentials: true

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -107,7 +107,7 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
           role-duration-seconds: 43200 # 12h
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}

--- a/.github/workflows/conda-cpp-post-build-checks.yaml
+++ b/.github/workflows/conda-cpp-post-build-checks.yaml
@@ -63,7 +63,7 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
           role-duration-seconds: 43200 # 12h
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}
@@ -113,7 +113,7 @@ jobs:
           EXTRACTED_DIR=$(rapids-extract-conda-files "${CPP_DIR}")
           echo "RAPIDS_EXTRACTED_DIR=${EXTRACTED_DIR}" >> "${GITHUB_ENV}"
       - name: Get weak detection tool
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: rapidsai/detect-weak-linking
           ref: refs/heads/main

--- a/.github/workflows/conda-cpp-tests.yaml
+++ b/.github/workflows/conda-cpp-tests.yaml
@@ -149,7 +149,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           role-duration-seconds: 43200 # 12h
 
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -117,7 +117,7 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
           role-duration-seconds: 43200 # 12h
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}

--- a/.github/workflows/conda-python-tests.yaml
+++ b/.github/workflows/conda-python-tests.yaml
@@ -153,7 +153,7 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           role-duration-seconds: 43200 # 12h
 
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -77,7 +77,7 @@ jobs:
         if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -79,7 +79,9 @@ jobs:
           branch: ${{ inputs.branch }}
           build_workflow_name: ${{ inputs.build_workflow_name }}
           date: ${{ inputs.date }}
-          sha: ${{ inputs.sha }}
+          # On 'push' or 'tag', 'inputs.sha' is null.
+          # Fall back to 'github.sha' to avoid needing a repo checkout.
+          sha: ${{ inputs.sha || github.sha }}
 
       # Per the docs at https://docs.github.com/en/rest/rate-limit/rate-limit?apiVersion=2022-11-28#get-rate-limit-status-for-the-authenticated-user,
       # checking '/rate_limit | jq .' should not itself count against any rate limits.

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -71,18 +71,6 @@ jobs:
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:
-      - name: Telemetry setup
-        uses: rapidsai/shared-actions/telemetry-dispatch-setup@main
-        continue-on-error: true
-        if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
-        env:
-          GH_TOKEN: ${{ github.token }}
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: ${{ inputs.repo }}
-          ref: ${{ inputs.sha }}
-          fetch-depth: 0
-          persist-credentials: true
 
       - name: Standardize repository information
         uses: rapidsai/shared-actions/rapids-github-info@main
@@ -116,10 +104,4 @@ jobs:
         env:
           SKIP_UPLOAD_PKGS: ${{ inputs.skip_upload_pkgs }}
           RAPIDS_CONDA_UPLOAD_LABEL: ${{ inputs.upload_to_label }}
-          GH_TOKEN: ${{ github.token }}
-      - name: Telemetry upload attributes
-        uses: rapidsai/shared-actions/telemetry-dispatch-stash-job-artifacts@main
-        continue-on-error: true
-        if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
-        env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -137,7 +137,7 @@ jobs:
           role-to-assume: ${{ vars.AWS_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION }}
           role-duration-seconds: 43200 # 12h
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}
@@ -192,7 +192,7 @@ jobs:
           GH_TOKEN: ${{ inputs.alternative-gh-token-secret-name && secrets[inputs.alternative-gh-token-secret-name] || github.token }} # zizmor: ignore[overprovisioned-secrets]
       - name: Get RAPIDS License Builder
         if: ${{ inputs.requires_license_builder }}
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: "rapidsai/spdx-license-builder"
           ref: "refs/heads/main"

--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -19,7 +19,7 @@ jobs:
           NEEDS: ${{ inputs.needs }}
         run: jq -en 'env.NEEDS | fromjson | all(.result as $result | ["success", "skipped"] | any($result == .))'
       - name: Checkout code
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 1
           persist-credentials: false

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -150,11 +150,11 @@ jobs:
           role-duration-seconds: 43200 # 12h
 
       - name: checkout code repo
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: ${{ inputs.repo }}
           ref: ${{ inputs.sha }}
-          fetch-depth: 0 # unshallow fetch for setuptools-scm
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Standardize repository information
@@ -175,7 +175,7 @@ jobs:
           echo "EXTRA_REPO_PATH=${EXTRA_REPO_PATH}" >> "${GITHUB_OUTPUT}"
 
       - name: checkout extra repos
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         if: ${{ inputs.extra-repo != '' }}
         with:
           repository: ${{ inputs.extra-repo }}

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -84,11 +84,14 @@ jobs:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:
     - name: checkout code repo
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         repository: ${{ inputs.repo }}
         ref: ${{ inputs.sha }}
-        fetch-depth: 0 # unshallow fetch for setuptools-scm
+        fetch-depth: 1
+        # fetch all tags even though we're only fetching 1 commit
+        # (for use in logic that checks recent tags to determine versions)
+        fetch-tags: true
         persist-credentials: false
 
     - name: Telemetry setup

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -91,7 +91,9 @@ jobs:
         branch: ${{ inputs.branch }}
         build_workflow_name: ${{ inputs.build_workflow_name }}
         date: ${{ inputs.date }}
-        sha: ${{ inputs.sha }}
+        # On 'push' or 'tag', 'inputs.sha' is null.
+        # Fall back to 'github.sha' to avoid needing a repo checkout.
+        sha: ${{ inputs.sha || github.sha }}
 
     # Per the docs at https://docs.github.com/en/rest/rate-limit/rate-limit?apiVersion=2022-11-28#get-rate-limit-status-for-the-authenticated-user,
     # checking '/rate_limit | jq .' should not itself count against any rate limits.

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -83,23 +83,6 @@ jobs:
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:
-    - name: checkout code repo
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      with:
-        repository: ${{ inputs.repo }}
-        ref: ${{ inputs.sha }}
-        fetch-depth: 1
-        # fetch all tags even though we're only fetching 1 commit
-        # (for use in logic that checks recent tags to determine versions)
-        fetch-tags: true
-        persist-credentials: false
-
-    - name: Telemetry setup
-      uses: rapidsai/shared-actions/telemetry-dispatch-setup@main
-      continue-on-error: true
-      if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
-      env:
-        GH_TOKEN: ${{ github.token }}
 
     - name: Standardize repository information
       uses: rapidsai/shared-actions/rapids-github-info@main
@@ -160,9 +143,3 @@ jobs:
       env:
         UPLOAD_DIR: ${{ steps.download_wheels.outputs.package_upload_dir }}
         TWINE_PASSWORD: ${{ secrets.RAPIDSAI_PYPI_TOKEN }}
-    - name: Telemetry upload attributes
-      uses: rapidsai/shared-actions/telemetry-dispatch-stash-job-artifacts@main
-      continue-on-error: true
-      if: ${{ vars.TELEMETRY_ENABLED == 'true' }}
-      env:
-        GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/wheels-test.yaml
+++ b/.github/workflows/wheels-test.yaml
@@ -180,11 +180,11 @@ jobs:
       run: nvidia-smi
 
     - name: checkout code repo
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         repository: ${{ inputs.repo }}
         ref: ${{ inputs.sha }}
-        fetch-depth: 0 # unshallow fetch for setuptools-scm
+        fetch-depth: 0
         persist-credentials: false
 
     - name: Telemetry setup

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       - id: codespell
         additional_dependencies: [tomli]
   - repo: https://github.com/rapidsai/pre-commit-hooks
-    rev: v1.5.1
+    rev: v1.6.0
     hooks:
       - id: verify-copyright
   - repo: https://github.com/zizmorcore/zizmor-pre-commit


### PR DESCRIPTION
Contributes to #505 

* removes telemetry and source checkouts for package-publishing jobs (`conda-upload-packages` and `wheels-publish`)

And other tiny things I noticed while doing this:

* removes outdated comments about `setuptools-scm` (RAPIDS does not use this any more)
* switches from `#v7` to `#v7.0.0` in comments on `actions/checkout` (improves clarity of auto-generated PRs to update that)
* updates all pre-commit hooks w/ `pre-commit` hooks

## Notes for Reviewers

### Is this safe?

I think so.

`conda-upload-packages` and `wheels-publish` don't depend on anything in the calling repo's source or git history.

The `rapids-release-build` check here sort of depends on git tags:

https://github.com/rapidsai/shared-workflows/blob/ad100ac25a47afe772ed86ee69e6eabd6966a419/.github/workflows/conda-upload-packages.yaml#L110-L112

But doesn't get it from a local checkout... it reads the GitHub-specific environment variable `GITHUB_REF`: https://github.com/rapidsai/gha-tools/blob/d85a30d7a8930b079ef681a086e8f3646120c27a/tools/rapids-is-release-build#L11

### Impact

Reduces runtime of these jobs a tiny bit, and more importantly removes some network requests (a common source of CI instability).

The impact on runtime will be larger for repos where `git clone` is more expensive. For example, on a recent `cudf` build on `main`, checking out the code took 14 seconds and telemetry-related things added around 4 seconds.

<img width="1837" height="899" alt="image" src="https://github.com/user-attachments/assets/82c7119d-41b1-43e6-b2df-7d66f8567cb4" />

https://github.com/rapidsai/cudf/actions/runs/28378826926/job/84082197842

### How I tested this

Proposing testing this here: https://github.com/rapidsai/rmm/pull/2458