### PR TITLE
run package uploads in python slim containers

### DIFF
--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -87,7 +87,7 @@ jobs:
             git
 
           # install gha-tools
-          git clone --depth 1 --branch test-uploads https://github.com/rapidsai/gha-tools /tmp/gha-tools
+        git clone --depth 1 https://github.com/rapidsai/gha-tools /tmp/gha-tools
           echo "/tmp/gha-tools/tools" >> "${GITHUB_PATH}"
           export PATH="/tmp/gha-tools/tools:${PATH}"
 

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -67,10 +67,56 @@ jobs:
   upload:
     runs-on: linux-amd64-cpu4
     container:
-      image: rapidsai/ci-conda:26.08-latest # zizmor: ignore[unpinned-images]
+      image: "python:3.14-slim"
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:
+
+      - name: Setup proxy cache
+        uses: nv-gha-runners/setup-proxy-cache@main
+        continue-on-error: true
+        with:
+          enable-apt: true
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: rapidsai/gha-tools
+          ref: test-uploads
+          fetch-depth: 1
+          fetch-tags: false
+          lfs: false
+          submodules: false
+          path: ${{ runner.temp }}/gha-tools
+          persist-credentials: false
+          sparse-checkout: |
+            tools
+
+      - name: Add gha-tools to PATH
+        run: echo "${RUNNER_TEMP}/gha-tools/tools" >> "${GITHUB_PATH}"
+
+      - name: Install tools
+        run: |
+          # install tools needed to bootstrap others
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            curl
+
+          # set up source for latest 'gh' releases
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+          chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list
+
+          # install tools with system package manager
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            git \
+            gh \
+            jq
+
+          # anaconda client (for 'rapids-wheels-anaconda-github')
+          python -m pip install \
+            --prefer-binary \
+            'anaconda-client>=1.13.1'
 
       - name: Standardize repository information
         uses: rapidsai/shared-actions/rapids-github-info@main
@@ -87,11 +133,7 @@ jobs:
       # checking '/rate_limit | jq .' should not itself count against any rate limits.
       - name: Check GitHub API rate limits
         run: |
-          if ! type gh >/dev/null; then
-              echo "'gh' CLI is not installed... skipping rate-limits check"
-          else
-              gh api /rate_limit | jq .
-          fi
+            gh api /rate_limit | jq .
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Set Proper Conda Upload Token

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -78,28 +78,18 @@ jobs:
         with:
           enable-apt: true
 
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          repository: rapidsai/gha-tools
-          ref: test-uploads
-          fetch-depth: 1
-          fetch-tags: false
-          lfs: false
-          submodules: false
-          path: ${{ runner.temp }}/gha-tools
-          persist-credentials: false
-          sparse-checkout: |
-            tools
-
-      - name: Add gha-tools to PATH
-        run: echo "${RUNNER_TEMP}/gha-tools/tools" >> "${GITHUB_PATH}"
-
       - name: Install tools
         run: |
           # install tools needed to bootstrap others
           apt-get update
           apt-get install -y --no-install-recommends \
-            curl
+            curl \
+            git
+
+          # install gha-tools
+          git clone --depth 1 --branch test-uploads https://github.com/rapidsai/gha-tools /tmp/gha-tools
+          echo "/tmp/gha-tools/tools" >> "${GITHUB_PATH}"
+          export PATH="/tmp/gha-tools/tools:${PATH}"
 
           # set up source for latest 'gh' releases
           curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
@@ -109,12 +99,11 @@ jobs:
           # install tools with system package manager
           apt-get update
           apt-get install -y --no-install-recommends \
-            git \
             gh \
             jq
 
-          # anaconda client (for 'rapids-wheels-anaconda-github')
-          python -m pip install \
+          # anaconda client (for 'rapids-upload-to-anaconda-github')
+          rapids-pip-retry install \
             --prefer-binary \
             'anaconda-client>=1.13.1'
 

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -87,7 +87,7 @@ jobs:
             git
 
           # install gha-tools
-        git clone --depth 1 https://github.com/rapidsai/gha-tools /tmp/gha-tools
+          git clone --depth 1 https://github.com/rapidsai/gha-tools /tmp/gha-tools
           echo "/tmp/gha-tools/tools" >> "${GITHUB_PATH}"
           export PATH="/tmp/gha-tools/tools:${PATH}"
 

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -122,7 +122,7 @@ jobs:
       # checking '/rate_limit | jq .' should not itself count against any rate limits.
       - name: Check GitHub API rate limits
         run: |
-            gh api /rate_limit | jq .
+          gh api /rate_limit | jq .
         env:
           GH_TOKEN: ${{ github.token }}
       - name: Set Proper Conda Upload Token

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -90,28 +90,18 @@ jobs:
       with:
         enable-apt: true
 
-    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      with:
-        repository: rapidsai/gha-tools
-        ref: test-uploads
-        fetch-depth: 1
-        fetch-tags: false
-        lfs: false
-        submodules: false
-        path: ${{ runner.temp }}/gha-tools
-        persist-credentials: false
-        sparse-checkout: |
-          tools
-
-    - name: Add gha-tools to PATH
-      run: echo "${RUNNER_TEMP}/gha-tools/tools" >> "${GITHUB_PATH}"
-
     - name: Install tools
       run: |
         # install tools needed to bootstrap others
         apt-get update
         apt-get install -y --no-install-recommends \
-          curl
+          curl \
+          git
+
+        # install gha-tools
+        git clone --depth 1 --branch test-uploads https://github.com/rapidsai/gha-tools /tmp/gha-tools
+        echo "/tmp/gha-tools/tools" >> "${GITHUB_PATH}"
+        export PATH="/tmp/gha-tools/tools:${PATH}"
 
         # set up source for latest 'gh' releases
         curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
@@ -121,12 +111,11 @@ jobs:
         # install tools with system package manager
         apt-get update
         apt-get install -y --no-install-recommends \
-          git \
           gh \
           jq
 
-        # anaconda client (for 'rapids-wheels-anaconda-github')
-        python -m pip install \
+        # anaconda client (for 'rapids-upload-to-anaconda-github')
+        rapids-pip-retry install \
           --prefer-binary \
           'anaconda-client>=1.13.1'
 

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -79,10 +79,56 @@ jobs:
     container:
       # CUDA toolkit version of the container is irrelevant in the publish step.
       # This just uploads already-built wheels to remote storage.
-      image: "rapidsai/ci-wheel:26.08-latest" # zizmor: ignore[unpinned-images]
+      image: "python:3.14-slim"
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
     steps:
+
+    - name: Setup proxy cache
+      uses: nv-gha-runners/setup-proxy-cache@main
+      continue-on-error: true
+      with:
+        enable-apt: true
+
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      with:
+        repository: rapidsai/gha-tools
+        ref: test-uploads
+        fetch-depth: 1
+        fetch-tags: false
+        lfs: false
+        submodules: false
+        path: ${{ runner.temp }}/gha-tools
+        persist-credentials: false
+        sparse-checkout: |
+          tools
+
+    - name: Add gha-tools to PATH
+      run: echo "${RUNNER_TEMP}/gha-tools/tools" >> "${GITHUB_PATH}"
+
+    - name: Install tools
+      run: |
+        # install tools needed to bootstrap others
+        apt-get update
+        apt-get install -y --no-install-recommends \
+          curl
+
+        # set up source for latest 'gh' releases
+        curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+        chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list
+
+        # install tools with system package manager
+        apt-get update
+        apt-get install -y --no-install-recommends \
+          git \
+          gh \
+          jq
+
+        # anaconda client (for 'rapids-wheels-anaconda-github')
+        python -m pip install \
+          --prefer-binary \
+          'anaconda-client>=1.13.1'
 
     - name: Standardize repository information
       uses: rapidsai/shared-actions/rapids-github-info@main
@@ -99,11 +145,7 @@ jobs:
     # checking '/rate_limit | jq .' should not itself count against any rate limits.
     - name: Check GitHub API rate limits
       run: |
-        if ! type gh >/dev/null; then
-            echo "'gh' CLI is not installed... skipping rate-limits check"
-        else
-            gh api /rate_limit | jq .
-        fi
+        gh api /rate_limit | jq .
       env:
         GH_TOKEN: ${{ github.token }}
 
@@ -140,7 +182,7 @@ jobs:
     - name: Publish the downloaded wheels to PyPI
       if: ${{ inputs.publish_to_pypi && steps.check_if_release.outputs.is_release_build == 'true' }}
       run: |
-        python3 -m pip install twine
+        python3 -m pip install 'twine>=6.2.0'
         python3 -m twine upload -u __token__ "${UPLOAD_DIR}"/*
       env:
         UPLOAD_DIR: ${{ steps.download_wheels.outputs.package_upload_dir }}

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -99,7 +99,7 @@ jobs:
           git
 
         # install gha-tools
-        git clone --depth 1 --branch test-uploads https://github.com/rapidsai/gha-tools /tmp/gha-tools
+        git clone --depth 1 https://github.com/rapidsai/gha-tools /tmp/gha-tools
         echo "/tmp/gha-tools/tools" >> "${GITHUB_PATH}"
         export PATH="/tmp/gha-tools/tools:${PATH}"
 


### PR DESCRIPTION
Contributes to #505

As described there, it's not uncommon for pulling the `rapidsai/ci-wheel` images to take 3-4 minutes.

This is extra painful for jobs like `wheels-publish`, which just need lightweight publishing tools and not CUDA libraries, compiler toolchain, etc.

This PR proposes working around that by doing the following:

* using a small `python:3.14-slim` image instead
* installing just the small set of necessary tools at runtime of the `wheels-publish`  job

## Notes for Reviewers

### Benefits

* faster `conda-uploads-packages` and `wheels-publish`, which means reduced end-to-end time for RAPIDS nightly pipeline (see "how I tested this")
* would allow us to stop installing `anaconda-client` and its dependencies in the `rapidsai/ci-conda` and `rapidsai/ci-wheel` images at https://github.com/rapidsai/ci-imgs
  - _that project has a lot of dependencies, so that might have a small but notable improvement in image size, build time, and pull time_
  - _that'd affect all wheel builds and conda building + testing jobs_

### Costs / Risks

* adds more network calls and package installs at runtime of `wheels-publish`, which might lead to more transient failures from network issues
* adds complexity to the workflow code

### Why not pre-build a `wheels-publish` image?

That WOULD make this even faster and avoid all those package installs at runtime.

But new images need to go through a compliance/legal approval process that's a bit heavier than this use case justifies, in my opinion. In my testing, installing tools took 15-20 seconds, so that's the most we'd save by having a pre-built image with everything installed.

### How I tested this

`rmm`'s `main` branch was already pointed at this branch for package-uploading jobs from #585.

Put up changes in a `gha-tools` branch (https://github.com/rapidsai/gha-tools/pull/265) to force-overwrite existing packages, so the upload time to anaconda.org is included in the timings.

Clicked "re-run all jobs" on `rmm`'s most recent run on `main`.

| workflow                         | previous `main` (as of #585)  |  this PR           |
|----------------------------------:|:-----------------------------------------:|:------------------:|
| upload-conda                 |    1m32s                                     |   **1m15s** |
| wheels-publish-cpp       |   2m51s                                      |  **0m37s**  |
| wheels-publish-python |   3m3s                                        |   **0m41s** |

*builds from `rmm`: ([previous main](https://github.com/rapidsai/rmm/actions/runs/28388699537/attempts/2) | [this PR](https://github.com/rapidsai/rmm/actions/runs/28388699537/job/84139196301))*