### PR TITLE
Pass GitHub token to style checks

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -146,6 +146,7 @@ jobs:
       - name: Run ci/check_style.sh
         run: ci/check_style.sh
         env:
+          GH_TOKEN: ${{ github.token }}
           RAPIDS_BASE_BRANCH: ${{ fromJSON(steps.get-pr-info.outputs.pr-info).base.ref }}
       - name: Telemetry upload attributes
         uses: rapidsai/shared-actions/telemetry-dispatch-stash-job-artifacts@main


### PR DESCRIPTION
This exposes the GitHub Actions token to `ci/check_style.sh` as `GH_TOKEN`. The style-check job already receives a repository-scoped token with `contents: read`, but the failing step did not have it in its environment, so `rapids-metadata` made an unauthenticated request and hit HTTP 429. Passing the token follows GitHub's supported authentication pattern and enables the companion rapidsai/rapids-metadata#79 change to make authenticated requests with retries. rapidsai/rapids-metadata#79 depends on this PR.
