### PR TITLE
wheels-build: use newest CTK (13.3.0) for wheel builds

### DIFF
--- a/.github/workflows/compute-matrix.yaml
+++ b/.github/workflows/compute-matrix.yaml
@@ -150,19 +150,19 @@ jobs:
               - { ARCH: 'amd64', PY_VER: '3.12', CUDA_VER: '12.9.2', LINUX_VER: 'rockylinux8' }
               - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '12.9.2', LINUX_VER: 'rockylinux8' }
               - { ARCH: 'amd64', PY_VER: '3.14', CUDA_VER: '12.9.2', LINUX_VER: 'rockylinux8' }
-              - { ARCH: 'amd64', PY_VER: '3.11', CUDA_VER: '13.0.3', LINUX_VER: 'rockylinux8' }
-              - { ARCH: 'amd64', PY_VER: '3.12', CUDA_VER: '13.0.3', LINUX_VER: 'rockylinux8' }
-              - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '13.0.3', LINUX_VER: 'rockylinux8' }
-              - { ARCH: 'amd64', PY_VER: '3.14', CUDA_VER: '13.0.3', LINUX_VER: 'rockylinux8' }
+              - { ARCH: 'amd64', PY_VER: '3.11', CUDA_VER: '13.3.0', LINUX_VER: 'rockylinux8' }
+              - { ARCH: 'amd64', PY_VER: '3.12', CUDA_VER: '13.3.0', LINUX_VER: 'rockylinux8' }
+              - { ARCH: 'amd64', PY_VER: '3.13', CUDA_VER: '13.3.0', LINUX_VER: 'rockylinux8' }
+              - { ARCH: 'amd64', PY_VER: '3.14', CUDA_VER: '13.3.0', LINUX_VER: 'rockylinux8' }
               # arm64
               - { ARCH: 'arm64', PY_VER: '3.11', CUDA_VER: '12.9.2', LINUX_VER: 'rockylinux8' }
               - { ARCH: 'arm64', PY_VER: '3.12', CUDA_VER: '12.9.2', LINUX_VER: 'rockylinux8' }
               - { ARCH: 'arm64', PY_VER: '3.13', CUDA_VER: '12.9.2', LINUX_VER: 'rockylinux8' }
               - { ARCH: 'arm64', PY_VER: '3.14', CUDA_VER: '12.9.2', LINUX_VER: 'rockylinux8' }
-              - { ARCH: 'arm64', PY_VER: '3.11', CUDA_VER: '13.0.3', LINUX_VER: 'rockylinux8' }
-              - { ARCH: 'arm64', PY_VER: '3.12', CUDA_VER: '13.0.3', LINUX_VER: 'rockylinux8' }
-              - { ARCH: 'arm64', PY_VER: '3.13', CUDA_VER: '13.0.3', LINUX_VER: 'rockylinux8' }
-              - { ARCH: 'arm64', PY_VER: '3.14', CUDA_VER: '13.0.3', LINUX_VER: 'rockylinux8' }
+              - { ARCH: 'arm64', PY_VER: '3.11', CUDA_VER: '13.3.0', LINUX_VER: 'rockylinux8' }
+              - { ARCH: 'arm64', PY_VER: '3.12', CUDA_VER: '13.3.0', LINUX_VER: 'rockylinux8' }
+              - { ARCH: 'arm64', PY_VER: '3.13', CUDA_VER: '13.3.0', LINUX_VER: 'rockylinux8' }
+              - { ARCH: 'arm64', PY_VER: '3.14', CUDA_VER: '13.3.0', LINUX_VER: 'rockylinux8' }
             nightly: *wheels_build
 
           wheels-test:


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/268

Switches RAPIDS wheel builds from CTK 13.0 to 13.3 (the latest RAPIDS supports as of this writing).