### PR TITLE
builds: add support for computing a date-based version component at build time

### DIFF
--- a/.github/workflows/compute-build-details.yaml
+++ b/.github/workflows/compute-build-details.yaml
@@ -16,4 +16,4 @@ jobs:
       - name: build
         id: build-details
         run: |
-          echo "version-suffix=.post$(date +%s)" | tee -a "${GITHUB_OUTPUT}"
+          echo "version-suffix=.post$(date -u +'%y%m%d%H%M%S')" | tee -a "${GITHUB_OUTPUT}"

--- a/.github/workflows/compute-build-details.yaml
+++ b/.github/workflows/compute-build-details.yaml
@@ -1,0 +1,19 @@
+on:
+  workflow_call:
+    outputs:
+      package-version-suffix:
+        description: "Suffix to be appended to conda/sdist/wheel version numbers."
+        value: ${{ jobs.build.outputs.version-suffix }}
+
+permissions: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-slim
+    outputs:
+      version-suffix: ${{ steps.build-details.outputs.version-suffix }}
+    steps:
+      - name: build
+        id: build-details
+        run: |
+          echo "version-suffix=.post$(date +%s)" | tee -a "${GITHUB_OUTPUT}"

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -16,6 +16,14 @@ on:
       sha:
         description: "Full git commit SHA to check out"
         type: string
+      version-suffix:
+        description: |
+          Optional value to be appended to package versions.
+          Will be appended exactly, so e.g. to add a '.' separator,
+          provide '.post1' not 'post1'.
+        default: null
+        required: false
+        type: string
       repo:
         description: "Git repo to check out, in '{org}/{repo}' form, e.g. 'rapidsai/cudf'"
         type: string
@@ -101,6 +109,7 @@ jobs:
       image: rapidsai/ci-conda:26.10-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
+        RAPIDS_VERSION_SUFFIX: ${{ inputs.version-suffix }}
     steps:
       - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -16,6 +16,14 @@ on:
       sha:
         description: "Full git commit SHA to check out"
         type: string
+      version-suffix:
+        description: |
+          Optional value to be appended to package versions.
+          Will be appended exactly, so e.g. to add a '.' separator,
+          provide '.post1' not 'post1'.
+        default: null
+        required: false
+        type: string
       repo:
         description: "Git repo to check out, in '{org}/{repo}' form, e.g. 'rapidsai/cudf'"
         type: string
@@ -111,6 +119,7 @@ jobs:
       image: rapidsai/ci-conda:26.10-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
+        RAPIDS_VERSION_SUFFIX: ${{ inputs.version-suffix }}
     steps:
       - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -16,6 +16,14 @@ on:
       sha:
         description: "Full git commit SHA to check out"
         type: string
+      version-suffix:
+        description: |
+          Optional value to be appended to package versions.
+          Will be appended exactly, so e.g. to add a '.' separator,
+          provide '.post1' not 'post1'.
+        default: null
+        required: false
+        type: string
       repo:
         description: "Git repo to check out, in '{org}/{repo}' form, e.g. 'rapidsai/cudf'"
         type: string
@@ -131,6 +139,7 @@ jobs:
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
+        RAPIDS_VERSION_SUFFIX: ${{ inputs.version-suffix }}
     steps:
       - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -14,6 +14,14 @@ on:
       sha:
         description: "Full git commit SHA to check out"
         type: string
+      version-suffix:
+        description: |
+          Optional value to be appended to package versions.
+          Will be appended exactly, so e.g. to add a '.' separator,
+          provide '.post1' not 'post1'.
+        default: null
+        type: string
+        required: false
       repo:
         description: "Git repo to check out, in '{org}/{repo}' form, e.g. 'rapidsai/cudf'"
         type: string
@@ -141,6 +149,7 @@ jobs:
       image: "rapidsai/ci-wheel:26.10-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
+        RAPIDS_VERSION_SUFFIX: ${{ inputs.version-suffix }}
 
     steps:
       - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/218

Proposes adding a new workflow, `compute-build-details`, which computes information to be passed into builds.

Right now this only calculates a version suffix like `.post{current-time-in-epoch-seconds}` to help with distinguishing nightlies, but proposing giving it a generic workflow name in case we want to stick other data in here in the future.

## Notes for Reviewers

### How does this solve the problem with nightlies?

With this time-based version component, every new non-release run of `build.yaml` in a RAPIDS repo should produce packages with a never-before-seen version, so uploads to anaconda.org should succeed.

e.g. we might see this version sequence for nightlies:

```text
26.08.00a35.post1785176675  # 35 commits past '26.08.00a' tag, CI run started at epoch time 1785176675
26.08.00a35.post1785180275  # 35 commits past '26.08.00a' tag, CI run started 1 hour later
26.08.00a36.post1785180475  # 36 commits past '26.08.00a' tag, CI run started a little later
```

These versions will only be used in pre-releases built on `main`, not releases or packages built in PR CI (https://github.com/rapidsai/gha-tools/pull/268).

### What about timing problems?

This workflow will run once at the very beginning of the branch/nightly workflow run, then its output is passed as input to all other build jobs.

That makes the value static across an entire workflow run, so packages will have the same version even for:

* builds starting at different times due to scheduling delays
* builds starting at different times from clicking "re-run failed jobs" (e.g. for network failures)

### How I tested this

Confirmed that versions like this are recognized as valid PEP 440 versions and sort the way we expect in `packaging.Version`.

```python
from packaging.version import Version

Version("2026.08.00") > Version("2026.08.00a35.post1785176675")
# True

Version("2026.08.00rc0") > Version("2026.08.00a35.post1785176675")
# True

# same commit, newer build wins
Version("2026.08.00a35.post1885176675") > Version("2026.08.00a35.post1785176675")
# True

# later commit wins
Version("2026.08.00a36.post1885176675") > Version("2026.08.00a35.post1785176675")
# True
```

Also tested live with on `cugraph-gnn`, see "How I tested this" on https://github.com/rapidsai/cugraph-gnn/pull/508