### PR TITLE
conda-upload-packages: fix nightly uploads

### DIFF
--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -140,7 +140,7 @@ jobs:
             echo "is_release=false" >> "${GITHUB_OUTPUT}"
           fi
       - name: Upload packages to release location
-        if: ${{ steps.conda-upload-destination.outputs.is_release == true }}
+        if: ${{ steps.conda-upload-destination.outputs.is_release == 'true' }}
         run: rapids-upload-to-anaconda-github
         env:
           SKIP_UPLOAD_PKGS: ${{ inputs.skip_upload_pkgs }}
@@ -148,7 +148,7 @@ jobs:
           RAPIDS_CONDA_TOKEN: ${{ secrets.CONDA_RAPIDSAI_TOKEN }}
           GH_TOKEN: ${{ github.token }}
       - name: Upload packages to nightly location
-        if: ${{ steps.conda-upload-destination.outputs.is_release == false || inputs.dual_publish }}
+        if: ${{ steps.conda-upload-destination.outputs.is_release == 'false' || inputs.dual_publish }}
         run: rapids-upload-to-anaconda-github
         env:
           SKIP_UPLOAD_PKGS: ${{ inputs.skip_upload_pkgs }}


### PR DESCRIPTION
Uploads of nightly conda packages stopped working after https://github.com/rapidsai/shared-workflows/pull/602 was merged (only affects `main`).

Thankfully we have integration tests to catch exactly this type of thing, and they caught it: https://github.com/rapidsai/integration/issues/861

This fixes that.