### PR TITLE
Add a shared workflow for publishing to Maven Central

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -8,6 +8,8 @@ self-hosted-runner:
 config-variables:
   - AWS_REGION
   - AWS_ROLE_ARN
+  - RAPIDS_ARTIFACTORY_REPO
+  - RAPIDS_ARTIFACTORY_URL
   - TELEMETRY_ENABLED
 
 paths:

--- a/.github/workflows/build-devcontainers.yaml
+++ b/.github/workflows/build-devcontainers.yaml
@@ -62,11 +62,12 @@ jobs:
           PYTHON_PACKAGE_MANAGER: "${{ inputs.python_package_manager }}"
           VERSIONS: '["latest", "${{ needs.build.outputs.version }}"]'
         run: |
-          declare -a TAGS="($(jq -cnr \
+          TAGS_JSON=$(jq -cnr \
             --argjson vers "${VERSIONS}" \
             --argjson cuda "${CUDA}" \
             --argjson pkgr "${PYTHON_PACKAGE_MANAGER}" \
-            '[[$vers, $cuda, $pkgr] | combinations | [.[0], "cuda" + .[1], .[2]] | join("-")] | join(" ")'))"
+            '[[$vers, $cuda, $pkgr] | combinations | [.[0], "cuda" + .[1], .[2]] | join("-")] | join(" ")')
+          declare -a TAGS="(${TAGS_JSON})"
 
           declare -a DIGESTS=()
           for TAG in "${TAGS[@]}"; do
@@ -75,7 +76,7 @@ jobs:
             )
           done
 
-          NAME="${NAME#${NAME_PREFIX}/}"
+          NAME="${NAME#"${NAME_PREFIX}"/}"
 
           # Set values to control ghcr.io cleanup below
           cat <<EOF >> "$GITHUB_OUTPUT"

--- a/.github/workflows/conda-cpp-post-build-checks.yaml
+++ b/.github/workflows/conda-cpp-post-build-checks.yaml
@@ -106,7 +106,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           if [ -n "$PACKAGE_NAME" ]; then
-            CPP_DIR=$(rapids-download-from-github "$(rapids-artifact-name conda_cpp $PACKAGE_NAME "${REPO##*/}" --cuda)")
+            CPP_DIR=$(rapids-download-from-github "$(rapids-artifact-name conda_cpp "$PACKAGE_NAME" "${REPO##*/}" --cuda)")
           else
             CPP_DIR=$(rapids-download-conda-from-github cpp)
           fi

--- a/.github/workflows/maven-publish.yaml
+++ b/.github/workflows/maven-publish.yaml
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Publishes a bundle of release-candidate Maven artifacts (jars, POMs,
+# sources, javadoc) to Maven Central via the Sonatype Central Publisher
+# Portal. Every file is GPG-signed and staged through Artifactory first.
+#
+# TODO: add nightly -> Sonatype snapshots
+name: Maven publish
+
+on:
+  workflow_call:
+    inputs:
+      publication-type:
+        description: |
+          Only "rc" (release candidate) is currently supported. Nightly is a
+          future addition. The input is kept single-valued so callers do not
+          have to change their `with:` block when nightly is introduced.
+        required: true
+        type: string
+      artifact-name:
+        description: |
+          Name of the GitHub Actions artifact (uploaded by the caller job via
+          actions/upload-artifact) to download and publish. Contents must be
+          a Maven repository directory.
+        required: true
+        type: string
+      stage-for-maven-central-publish:
+        description: |
+          When true, leave the bundle PENDING in the Sonatype Central
+          Publisher Portal for a human to release via the Portal UI
+          (https://central.sonatype.com). When false (default), validate then
+          drop the bundle.
+        required: false
+        type: boolean
+        default: false
+      source-git-sha:
+        description: |
+          Git SHA to attach as the Artifactory source.git-sha property on
+          every uploaded file.
+        required: false
+        type: string
+        default: ''
+    secrets:
+      GPG_PRIVATE_KEY:
+        description: Armored GPG private key used to sign every artifact at upload.
+        required: true
+      GPG_PASSPHRASE:
+        description: Passphrase for GPG_PRIVATE_KEY.
+        required: true
+      ARTIFACTORY_USERNAME:
+        description: Artifactory account with write access.
+        required: true
+      ARTIFACTORY_TOKEN:
+        description: Auth token for ARTIFACTORY_USERNAME.
+        required: true
+      MAVEN_DEPLOY_USERNAME:
+        description: Sonatype user token username for the Publisher Portal.
+        required: true
+      MAVEN_DEPLOY_TOKEN:
+        description: Auth token for MAVEN_DEPLOY_USERNAME.
+        required: true
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  maven-publish:
+    name: maven publish (${{ inputs.publication-type }})
+    runs-on: linux-amd64-cpu4
+    steps:
+      # Derive from github.workflow_ref. github.ref points at the
+      # caller's context, not this workflow's repo/ref.
+      - name: Resolve shared-workflows repo and ref
+        id: sw_ref
+        run: |
+          echo "repo=${GITHUB_WORKFLOW_REF%%/.github/*}" >> "${GITHUB_OUTPUT}"
+          echo "ref=${GITHUB_WORKFLOW_REF##*@}"         >> "${GITHUB_OUTPUT}"
+        env:
+          GITHUB_WORKFLOW_REF: ${{ github.workflow_ref }}
+
+      - name: Self-checkout shared-workflows
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ steps.sw_ref.outputs.repo }}
+          ref: ${{ steps.sw_ref.outputs.ref }}
+          path: shared-workflows
+          persist-credentials: false
+
+      - name: Download Maven repository artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: maven-repo
+
+      - name: Sign and upload to Artifactory
+        id: upload
+        run: |
+          shared-workflows/ci/maven-publish/artifactory_upload.sh \
+            --input maven-repo \
+            --publication-type "${PUBLICATION_TYPE}" \
+            --artifactory-url "${ARTIFACTORY_URL}" \
+            --artifactory-repository "${ARTIFACTORY_REPOSITORY}" \
+            ${SOURCE_GIT_SHA:+--source-git-sha "${SOURCE_GIT_SHA}"}
+        env:
+          PUBLICATION_TYPE: ${{ inputs.publication-type }}
+          ARTIFACTORY_URL: ${{ vars.RAPIDS_ARTIFACTORY_URL }}
+          ARTIFACTORY_REPOSITORY: ${{ vars.RAPIDS_ARTIFACTORY_REPO }}
+          SOURCE_GIT_SHA: ${{ inputs.source-git-sha }}
+          GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
+
+      - name: Promote to Maven Central
+        run: |
+          shared-workflows/ci/maven-publish/maven_central_publish.sh \
+            --group-id "${GROUP_ID}" \
+            --artifact-id "${ARTIFACT_ID}" \
+            --version "${VERSION}" \
+            --artifactory-url "${ARTIFACTORY_URL}" \
+            --artifactory-repository "${ARTIFACTORY_REPOSITORY}" \
+            --auto-drop "${AUTO_DROP}"
+        env:
+          GROUP_ID: ${{ steps.upload.outputs.GROUP_ID }}
+          ARTIFACT_ID: ${{ steps.upload.outputs.ARTIFACT_ID }}
+          VERSION: ${{ steps.upload.outputs.VERSION }}
+          ARTIFACTORY_URL: ${{ vars.RAPIDS_ARTIFACTORY_URL }}
+          ARTIFACTORY_REPOSITORY: ${{ vars.RAPIDS_ARTIFACTORY_REPO }}
+          # Invert: stage-for-...=true means don't auto-drop.
+          AUTO_DROP: ${{ !inputs.stage-for-maven-central-publish }}
+          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
+          MAVEN_DEPLOY_USERNAME: ${{ secrets.MAVEN_DEPLOY_USERNAME }}
+          MAVEN_DEPLOY_TOKEN: ${{ secrets.MAVEN_DEPLOY_TOKEN }}

--- a/ci/maven-publish/argparse.sh
+++ b/ci/maven-publish/argparse.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Shared argparse helpers for the ci/maven-publish/ host orchestrator scripts.
+# Meant to be sourced, not executed:
+#   . "${SCRIPT_DIR}/argparse.sh"
+
+# require_value <flag> <value>: exit 1 if <value> is empty.
+require_value() {
+  local flag=$1
+  local value=$2
+  if [[ -z ${value} ]]; then
+    echo "Error: ${flag} requires a value" >&2
+    exit 1
+  fi
+}
+
+# require_arg <flag> <value>: exit 1 if <value> empty, printing help if defined.
+require_arg() {
+  local flag=$1
+  local value=$2
+  if [[ -z ${value} ]]; then
+    echo "Error: ${flag} is required." >&2
+    if declare -F print_help > /dev/null; then
+      print_help
+    fi
+    exit 1
+  fi
+}

--- a/ci/maven-publish/artifactory_upload.sh
+++ b/ci/maven-publish/artifactory_upload.sh
@@ -1,0 +1,182 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Host wrapper that runs artifactory_upload_in_container.sh in the Maven
+# image; see --help for behavior and arguments.
+#
+# TODO: add --nightly-date + NIGHTLY_DATE env plumbing when nightly support
+# lands.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/argparse.sh"
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/maven_utils.sh"
+
+INPUT_DIR=""
+PUBLICATION_TYPE=""
+ARTIFACTORY_URL=""
+ARTIFACTORY_REPOSITORY=""
+SOURCE_GIT_SHA=""
+IMAGE="maven:3-eclipse-temurin-17"
+
+print_help() {
+  cat << EOF
+
+Usage: artifactory_upload.sh --input <path> --publication-type rc [OPTIONS]
+
+Signs every file under a Maven repository directory and uploads the result
+to an internal Artifactory repository. Any prior upload at the same
+coordinate is deleted first (logged as "OVERRIDE:").
+
+REQUIRED:
+    -i, --input                Maven repository directory to sign and upload
+                               (e.g. <input>/<groupPath>/<artifactId>/<version>/*).
+    -t, --publication-type     Only "rc" is currently supported. Nightly is
+                               a future addition. The flag is retained so
+                               callers do not have to change when it lands.
+    -u, --artifactory-url      Base URL of the Artifactory server (no
+                               trailing slash).
+    -r, --artifactory-repository
+                               Artifactory repository name to upload into.
+
+OPTIONS:
+    -s, --source-git-sha       Git SHA to attach as the source.git-sha
+                               Artifactory property (default: empty).
+    -h, --help                 Show this help message.
+
+ENVIRONMENT VARIABLES:
+    GPG_PRIVATE_KEY            Armored GPG private key (required).
+    GPG_PASSPHRASE             Passphrase for the GPG private key (required).
+    ARTIFACTORY_USERNAME       Artifactory account with write access (required).
+    ARTIFACTORY_TOKEN          Auth token for ARTIFACTORY_USERNAME (required).
+    GITHUB_OUTPUT              If set, the emitted key=value lines (see
+                               OUTPUTS below) are also appended here.
+
+OUTPUTS:
+    Writes key=value lines to stdout (also to \$GITHUB_OUTPUT, so GHA
+    steps can read them as \`steps.<id>.outputs.<key>\`):
+
+        GROUP_ID       Maven groupId, from the POM.
+        ARTIFACT_ID    Maven artifactId, from the POM.
+        VERSION        Maven version, from the POM.
+
+EOF
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+      -h|--help)
+        print_help
+        exit 0
+        ;;
+      -i|--input)
+        require_value "$1" "$2"
+        INPUT_DIR=$2
+        shift 2
+        ;;
+      -t|--publication-type)
+        require_value "$1" "$2"
+        PUBLICATION_TYPE=$2
+        shift 2
+        ;;
+      -u|--artifactory-url)
+        require_value "$1" "$2"
+        ARTIFACTORY_URL=$2
+        shift 2
+        ;;
+      -r|--artifactory-repository)
+        require_value "$1" "$2"
+        ARTIFACTORY_REPOSITORY=$2
+        shift 2
+        ;;
+      -s|--source-git-sha)
+        require_value "$1" "$2"
+        SOURCE_GIT_SHA=$2
+        shift 2
+        ;;
+      *)
+        echo "Error: Unknown argument $1"
+        print_help
+        exit 1
+        ;;
+    esac
+  done
+}
+
+parse_args "$@"
+
+require_arg --input                  "${INPUT_DIR}"
+require_arg --publication-type       "${PUBLICATION_TYPE}"
+require_arg --artifactory-url        "${ARTIFACTORY_URL}"
+require_arg --artifactory-repository "${ARTIFACTORY_REPOSITORY}"
+
+if [[ ${PUBLICATION_TYPE} != "rc" ]]; then
+  fatal "only --publication-type rc is supported for now; nightly is a future addition (got '${PUBLICATION_TYPE}')"
+fi
+if [[ ! -d ${INPUT_DIR} ]]; then
+  fatal "--input '${INPUT_DIR}' does not exist or is not a directory"
+fi
+
+# Fail fast before launching the container.
+: "${GPG_PRIVATE_KEY:?must be set}"
+: "${GPG_PASSPHRASE:?must be set}"
+: "${ARTIFACTORY_USERNAME:?must be set}"
+: "${ARTIFACTORY_TOKEN:?must be set}"
+
+INPUT_DIR="$(cd "${INPUT_DIR}" && pwd)"
+
+OUTPUT_SCRATCH="$(mktemp -d)"
+trap 'rm -rf "${OUTPUT_SCRATCH}"' EXIT
+
+echo "Artifactory upload"
+echo "  image:                ${IMAGE}"
+echo "  publication type:     ${PUBLICATION_TYPE}"
+echo "  input dir:            ${INPUT_DIR}"
+echo "  metadata scratch:     ${OUTPUT_SCRATCH}"
+
+DOCKER_ARGS=(
+  --rm
+  --volume "${INPUT_DIR}:/input"
+  --volume "${OUTPUT_SCRATCH}:/output"
+  --workdir /input
+  --env ARTIFACTORY_URL="${ARTIFACTORY_URL}"
+  --env ARTIFACTORY_REPOSITORY="${ARTIFACTORY_REPOSITORY}"
+  --env ARTIFACTORY_USERNAME="${ARTIFACTORY_USERNAME}"
+  --env ARTIFACTORY_TOKEN="${ARTIFACTORY_TOKEN}"
+  --env GPG_PRIVATE_KEY="${GPG_PRIVATE_KEY}"
+  --env GPG_PASSPHRASE="${GPG_PASSPHRASE}"
+  --env SOURCE_GIT_SHA="${SOURCE_GIT_SHA}"
+  --env HOST_UID="$(id -u)"
+  --env HOST_GID="$(id -g)"
+  --volume "${SCRIPT_DIR}:/scripts:ro"
+)
+
+docker run "${DOCKER_ARGS[@]}" "${IMAGE}" \
+  bash /scripts/artifactory_upload_in_container.sh
+
+METADATA_FILE="${OUTPUT_SCRATCH}/upload_metadata.env"
+if [[ ! -f ${METADATA_FILE} ]]; then
+  fatal "worker did not produce ${METADATA_FILE}"
+fi
+
+# shellcheck disable=SC1090
+. "${METADATA_FILE}"
+
+if [[ -z ${GROUP_ID} || -z ${ARTIFACT_ID} || -z ${VERSION} ]]; then
+  cat "${METADATA_FILE}" >&2 || true
+  fatal "worker metadata is missing GROUP_ID / ARTIFACT_ID / VERSION"
+fi
+
+{
+  echo "GROUP_ID=${GROUP_ID}"
+  echo "ARTIFACT_ID=${ARTIFACT_ID}"
+  echo "VERSION=${VERSION}"
+} | tee -a "${GITHUB_OUTPUT:-/dev/null}"
+
+echo "Artifactory upload completed for ${GROUP_ID}:${ARTIFACT_ID}:${VERSION}"

--- a/ci/maven-publish/artifactory_upload_in_container.sh
+++ b/ci/maven-publish/artifactory_upload_in_container.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# In-container worker for artifactory_upload.sh. Signs files under /input and
+# uploads them to Artifactory at <groupPath>/<artifactId>/<version>/, deleting
+# any prior content at that coordinate first (logged as "OVERRIDE:"); latest
+# wins. source.git-sha is set as a matrix property for audit. Writes
+# coordinates to /output/upload_metadata.env.
+#
+# TODO: add the nightly path (staging/nightly/<date>/...) when nightly
+# support lands.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/maven_utils.sh"
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/artifactory_upload_steps.sh"
+
+INPUT_DIR=/input
+OUTPUT_DIR=/output
+
+: "${ARTIFACTORY_URL:?must be set}"
+: "${ARTIFACTORY_REPOSITORY:?must be set}"
+: "${ARTIFACTORY_USERNAME:?must be set}"
+: "${ARTIFACTORY_TOKEN:?must be set}"
+: "${GPG_PRIVATE_KEY:?must be set}"
+: "${GPG_PASSPHRASE:?must be set}"
+: "${HOST_UID:?must be set}"
+: "${HOST_GID:?must be set}"
+
+mkdir -p "${OUTPUT_DIR}"
+trap 'chown -R "${HOST_UID}:${HOST_GID}" "${INPUT_DIR}" "${OUTPUT_DIR}" 2>/dev/null || true' EXIT
+
+install_container_deps
+
+# -----------------------------------------------------------------------------
+# Resolve the artifact we are publishing.
+# -----------------------------------------------------------------------------
+POM_FILE=""
+discover_single_pom "${INPUT_DIR}" POM_FILE
+ARTIFACT_DIR="$(dirname "${POM_FILE}")"
+
+GROUP_ID=""
+ARTIFACT_ID=""
+VERSION=""
+read_pom_coordinates "${POM_FILE}" GROUP_ID ARTIFACT_ID VERSION
+
+EXPECTED_ARTIFACT_DIR="${INPUT_DIR}/$(maven_group_path "${GROUP_ID}")/${ARTIFACT_ID}/${VERSION}"
+if [[ ${ARTIFACT_DIR} != "${EXPECTED_ARTIFACT_DIR}" ]]; then
+  fatal "POM location ${ARTIFACT_DIR} does not match expected Maven repository layout ${EXPECTED_ARTIFACT_DIR}"
+fi
+require_release_version "${VERSION}"
+
+# -----------------------------------------------------------------------------
+# Compute the Artifactory destination.
+# -----------------------------------------------------------------------------
+STAGING_PATH=$(maven_release_path "${GROUP_ID}" "${ARTIFACT_ID}" "${VERSION}")
+STAGING_URL="${ARTIFACTORY_URL}/${ARTIFACTORY_REPOSITORY}/${STAGING_PATH}"
+
+# Log the repo-relative path.
+echo "Destination: ${STAGING_PATH}"
+
+# -----------------------------------------------------------------------------
+# Sign every file under the POM's directory.
+# -----------------------------------------------------------------------------
+GPG_KEY_ID=""
+import_gpg_signing_key GPG_KEY_ID
+echo "GPG signing key: ${GPG_KEY_ID}"
+
+ARTIFACTS=()
+echo "Signing artifacts under ${ARTIFACT_DIR}"
+list_artifacts_to_sign "${ARTIFACT_DIR}" ARTIFACTS
+sign_artifacts_in_place ARTIFACTS "${GPG_KEY_ID}"
+
+# -----------------------------------------------------------------------------
+# Upload the signed bundle. Matrix params get stored as Artifactory properties.
+# -----------------------------------------------------------------------------
+PROP_MATRIX=""
+if [[ -n ${SOURCE_GIT_SHA} ]]; then
+  PROP_MATRIX=";source.git-sha=${SOURCE_GIT_SHA}"
+fi
+
+clear_destination_if_exists "${STAGING_PATH}"
+
+echo "Uploading to ${STAGING_PATH}"
+upload_artifacts_to_staging ARTIFACTS "${STAGING_URL}" "${STAGING_PATH}" "${PROP_MATRIX}"
+
+# -----------------------------------------------------------------------------
+# Hand resolved coordinates back to the host script.
+# -----------------------------------------------------------------------------
+write_upload_metadata "${OUTPUT_DIR}/upload_metadata.env" \
+  "${GROUP_ID}" "${ARTIFACT_ID}" "${VERSION}"
+
+echo "Upload complete for ${GROUP_ID}:${ARTIFACT_ID}:${VERSION} at ${STAGING_PATH}"

--- a/ci/maven-publish/artifactory_upload_steps.sh
+++ b/ci/maven-publish/artifactory_upload_steps.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Step functions used by artifactory_upload_in_container.sh. Sourced, not executed:
+#   . "${SCRIPT_DIR}/artifactory_upload_steps.sh"
+#
+# Two layers:
+#   * HTTP wrapper (artifactory_put_file) - single-purpose curl call. Accepts
+#     optional trailing `retries` and `retry_delay_sec` args (defaults 3 / 2 s).
+#   * Step functions - workflow-level actions composed on top, plus a couple
+#     of `discover_*` / `read_*` helpers so the main script reads top-to-bottom
+#     as an outline.
+#
+# Both layers rely on globals set by the calling script (ARTIFACTORY_*,
+# GPG_PRIVATE_KEY, GPG_PASSPHRASE) and on `fatal` from maven_utils.sh.
+
+# -----------------------------------------------------------------------------
+# HTTP wrapper
+# -----------------------------------------------------------------------------
+
+# PUT a local file to an Artifactory URL. Response body is discarded.
+#   $1 = local file path
+#   $2 = full remote URL (may include Artifactory ;matrix=params)
+#   $3 = retries (default 3)
+#   $4 = retry_delay_sec (default 2)
+artifactory_put_file() {
+  local local_path=$1
+  local remote_url=$2
+  local retries=${3:-3}
+  local retry_delay_sec=${4:-2}
+  curl -sS -f --retry "${retries}" --retry-delay "${retry_delay_sec}" \
+    --user "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}" \
+    -T "${local_path}" \
+    -X PUT "${remote_url}" \
+    -o /dev/null
+}
+
+# -----------------------------------------------------------------------------
+# Container prep
+# -----------------------------------------------------------------------------
+
+# Base maven image lacks gpg and curl; install both on demand (no-op if already
+# present, e.g. from an image rebuild that includes them).
+install_container_deps() {
+  if command -v gpg >/dev/null && command -v curl >/dev/null; then
+    return 0
+  fi
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update -qq
+  apt-get install -qq -y --no-install-recommends gnupg curl
+}
+
+# -----------------------------------------------------------------------------
+# POM discovery and parsing
+# -----------------------------------------------------------------------------
+
+# Populate <out_pom_var> with the single POM found under <input_dir>. Fatals if
+# 0 or >1 POMs are present.
+discover_single_pom() {
+  local input_dir=$1
+  local -n out_pom_var=$2
+  local -a candidates
+  mapfile -t candidates < <(find "${input_dir}" -type f -name '*.pom' | sort)
+  case ${#candidates[@]} in
+    0) fatal "no *.pom found anywhere under ${input_dir}" ;;
+    1) out_pom_var=${candidates[0]} ;;
+    *)
+      { echo "Error: expected exactly one POM under ${input_dir}, found:"
+        printf '  %s\n' "${candidates[@]}"; } >&2
+      exit 1
+      ;;
+  esac
+}
+
+# Read groupId / artifactId / version from <pom_file> into the three nameref
+# out-vars via `mvn help:evaluate`. Fatals if any resolves empty.
+read_pom_coordinates() {
+  local pom_file=$1
+  local -n out_group_var=$2
+  local -n out_artifact_var=$3
+  local -n out_version_var=$4
+  out_group_var=$(mvn -q -B -f "${pom_file}" help:evaluate -Dexpression=project.groupId -DforceStdout)
+  out_artifact_var=$(mvn -q -B -f "${pom_file}" help:evaluate -Dexpression=project.artifactId -DforceStdout)
+  out_version_var=$(mvn -q -B -f "${pom_file}" help:evaluate -Dexpression=project.version -DforceStdout)
+  if [[ -z ${out_group_var} || -z ${out_artifact_var} || -z ${out_version_var} ]]; then
+    fatal "failed to read groupId/artifactId/version from ${pom_file}"
+  fi
+}
+
+# -----------------------------------------------------------------------------
+# GPG signing
+# -----------------------------------------------------------------------------
+
+# Import GPG_PRIVATE_KEY into a fresh, per-run GNUPGHOME (isolated from any
+# ambient state). Populate <out_key_id> with the imported secret key's long ID.
+import_gpg_signing_key() {
+  local -n out_key_id=$1
+  export GNUPGHOME
+  GNUPGHOME="$(mktemp -d)"
+  chmod 700 "${GNUPGHOME}"
+  echo "${GPG_PRIVATE_KEY}" | gpg --batch --yes --pinentry-mode loopback \
+    --passphrase "${GPG_PASSPHRASE}" --import
+  out_key_id=$(gpg --list-secret-keys --keyid-format=long --with-colons \
+    | awk -F: '$1=="sec" { print $5; exit }')
+  if [[ -z ${out_key_id} ]]; then
+    fatal "no GPG secret key was imported"
+  fi
+}
+
+# Populate <out_files> with every file directly under <artifact_dir> that is
+# NOT itself a signature or checksum (those would be signed-signature / signed-
+# checksum garbage). Fatals if the result would be empty.
+list_artifacts_to_sign() {
+  local artifact_dir=$1
+  local -n out_files=$2
+  mapfile -t out_files < <(find "${artifact_dir}" -maxdepth 1 -type f \
+    ! -name '*.asc' ! -name '*.md5' ! -name '*.sha1' ! -name '*.sha256' \
+    ! -name '*.sha512' | sort)
+  if (( ${#out_files[@]} == 0 )); then
+    fatal "no artifacts found under ${artifact_dir} to sign"
+  fi
+}
+
+# Produce a detached .asc signature next to every file in <files_ref>, using
+# the imported key. The promoter byte-forwards these signatures unmodified.
+sign_artifacts_in_place() {
+  local -n files_ref=$1
+  local key_id=$2
+  local file
+  for file in "${files_ref[@]}"; do
+    gpg --batch --yes --pinentry-mode loopback \
+      --passphrase "${GPG_PASSPHRASE}" \
+      --local-user "${key_id}" \
+      --armor --detach-sign \
+      --output "${file}.asc" \
+      "${file}"
+  done
+}
+
+# -----------------------------------------------------------------------------
+# Upload
+# -----------------------------------------------------------------------------
+
+# DELETE anything already at <path>. Logs "OVERRIDE:" when executed.
+clear_destination_if_exists() {
+  local path=$1
+  local status
+  status=$(curl -sS -o /dev/null -w '%{http_code}' \
+    --user "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}" \
+    "${ARTIFACTORY_URL}/api/storage/${ARTIFACTORY_REPOSITORY}/${path}")
+  case ${status} in
+    200)
+      echo "OVERRIDE: existing content found at ${path}. Deleting before re-upload"
+      curl -sS -f --retry 3 --retry-delay 2 \
+        --user "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}" \
+        -X DELETE "${ARTIFACTORY_URL}/${ARTIFACTORY_REPOSITORY}/${path}" \
+        -o /dev/null
+      ;;
+    404)
+      echo "Destination ${path} is empty. Proceeding with fresh upload"
+      ;;
+    *)
+      fatal "unexpected HTTP ${status} probing ${path}"
+      ;;
+  esac
+}
+
+# Upload every file in <files_ref> plus its .asc sibling to Artifactory under
+# <staging_url>, tacking <prop_matrix> onto each PUT so Artifactory stores the
+# matrix params as queryable properties.
+upload_artifacts_to_staging() {
+  local -n files_ref=$1
+  local staging_url=$2
+  local staging_path=$3
+  local prop_matrix=$4
+  local file candidate remote_name
+  for file in "${files_ref[@]}"; do
+    for candidate in "${file}" "${file}.asc"; do
+      remote_name=$(basename "${candidate}")
+      echo "  PUT ${remote_name} -> ${staging_path}/${remote_name}"
+      artifactory_put_file "${candidate}" "${staging_url}/${remote_name}${prop_matrix}"
+    done
+  done
+}
+
+# -----------------------------------------------------------------------------
+# Handoff to host script
+# -----------------------------------------------------------------------------
+
+# Write resolved coordinates to a env-file for artifactory_upload.sh to source.
+write_upload_metadata() {
+  local out_path=$1
+  local group_id=$2
+  local artifact_id=$3
+  local version=$4
+  {
+    echo "GROUP_ID=${group_id}"
+    echo "ARTIFACT_ID=${artifact_id}"
+    echo "VERSION=${version}"
+  } > "${out_path}"
+}

--- a/ci/maven-publish/maven_central_publish.sh
+++ b/ci/maven-publish/maven_central_publish.sh
@@ -1,0 +1,184 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Uploads a bundle to the Sonatype Publisher Portal and polls until it
+# passes validation. Never calls the /publish endpoint - promoting to
+# Maven Central always requires a human click in the Portal UI.
+#
+# After validation, --auto-drop decides what to do:
+#   true  -> drop the deployment (no PENDING entry left in the Portal)
+#   false -> leave it PENDING for a human to Publish or Drop
+#
+# Runs on the host (no docker) - only needs curl, jq, zip.
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/argparse.sh"
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/maven_utils.sh"
+# shellcheck disable=SC1091
+. "${SCRIPT_DIR}/maven_central_publish_steps.sh"
+
+CENTRAL_PORTAL_URL="https://central.sonatype.com"
+POLL_INTERVAL_SEC=15
+POLL_TIMEOUT_SEC=900
+
+GROUP_ID=""
+ARTIFACT_ID=""
+VERSION=""
+ARTIFACTORY_URL=""
+ARTIFACTORY_REPOSITORY=""
+AUTO_DROP="true"
+
+print_help() {
+  cat << EOF
+
+Usage: maven_central_publish.sh --group-id <g> --artifact-id <a> --version <v> \\
+                                --artifactory-url <url> \\
+                                --artifactory-repository <repo> [OPTIONS]
+
+Byte-forwards the signed bundle currently staged in Artifactory at
+<groupPath>/<artifactId>/<version>/ (whatever the latest upload of that
+coordinate is) to the Sonatype Central Publisher Portal in USER_MANAGED
+mode. .md5 / .sha1 sidecars are generated locally before upload.
+Sonatype requires them per file.
+
+REQUIRED:
+    -g, --group-id                 Maven groupId, e.g. ai.rapids.
+    -a, --artifact-id              Maven artifactId, e.g. cudf.
+    -v, --version                  Release version, e.g. 26.08.0.
+    -u, --artifactory-url          Base URL of the Artifactory server.
+    -r, --artifactory-repository   Artifactory repository to download from.
+
+OPTIONS:
+    --auto-drop <true|false>       Drop after VALIDATED (default: true).
+    -h, --help                     Show this help message.
+
+ENVIRONMENT VARIABLES:
+    ARTIFACTORY_USERNAME           Read-access account on Artifactory (required).
+    ARTIFACTORY_TOKEN              Auth token for ARTIFACTORY_USERNAME (required).
+    MAVEN_DEPLOY_USERNAME          Publisher Portal user token username (required).
+    MAVEN_DEPLOY_TOKEN             Publisher Portal user token password (required).
+
+EOF
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+      -h|--help)
+        print_help
+        exit 0
+        ;;
+      -g|--group-id)
+        require_value "$1" "$2"
+        GROUP_ID=$2
+        shift 2
+        ;;
+      -a|--artifact-id)
+        require_value "$1" "$2"
+        ARTIFACT_ID=$2
+        shift 2
+        ;;
+      -v|--version)
+        require_value "$1" "$2"
+        VERSION=$2
+        shift 2
+        ;;
+      -u|--artifactory-url)
+        require_value "$1" "$2"
+        ARTIFACTORY_URL=$2
+        shift 2
+        ;;
+      -r|--artifactory-repository)
+        require_value "$1" "$2"
+        ARTIFACTORY_REPOSITORY=$2
+        shift 2
+        ;;
+      --auto-drop)
+        require_value "$1" "$2"
+        AUTO_DROP=$2
+        shift 2
+        ;;
+      *)
+        echo "Error: Unknown argument $1"
+        print_help
+        exit 1
+        ;;
+    esac
+  done
+}
+
+parse_args "$@"
+
+require_arg --group-id               "${GROUP_ID}"
+require_arg --artifact-id            "${ARTIFACT_ID}"
+require_arg --version                "${VERSION}"
+require_arg --artifactory-url        "${ARTIFACTORY_URL}"
+require_arg --artifactory-repository "${ARTIFACTORY_REPOSITORY}"
+
+if [[ ${AUTO_DROP} != "true" && ${AUTO_DROP} != "false" ]]; then
+  fatal "--auto-drop must be 'true' or 'false' (got '${AUTO_DROP}')"
+fi
+require_release_version "${VERSION}"
+
+: "${ARTIFACTORY_USERNAME:?must be set}"
+: "${ARTIFACTORY_TOKEN:?must be set}"
+: "${MAVEN_DEPLOY_USERNAME:?must be set}"
+: "${MAVEN_DEPLOY_TOKEN:?must be set}"
+
+require_cmds curl jq zip
+
+STAGING_SUBPATH=$(maven_release_path "${GROUP_ID}" "${ARTIFACT_ID}" "${VERSION}")
+STAGING_URL="${ARTIFACTORY_URL}/${ARTIFACTORY_REPOSITORY}/${STAGING_SUBPATH}"
+
+echo "Maven Central promote"
+echo "  coordinates:   ${GROUP_ID}:${ARTIFACT_ID}:${VERSION}"
+echo "  auto-drop:     ${AUTO_DROP}"
+echo "  source path:   ${STAGING_SUBPATH}"
+echo "  target portal: ${CENTRAL_PORTAL_URL}"
+
+WORK_DIR="$(mktemp -d)"
+trap 'rm -rf "${WORK_DIR}"' EXIT
+
+BUNDLE_DIR="${WORK_DIR}/bundle"
+BUNDLE_ARTIFACT_DIR="${BUNDLE_DIR}/$(maven_group_path "${GROUP_ID}")/${ARTIFACT_ID}/${VERSION}"
+mkdir -p "${BUNDLE_ARTIFACT_DIR}"
+
+# -----------------------------------------------------------------------------
+# Main flow.
+# -----------------------------------------------------------------------------
+
+echo "Listing staged files at ${STAGING_SUBPATH}"
+mapfile -t STAGED_FILES < <(list_staged_files)
+if (( ${#STAGED_FILES[@]} == 0 )); then
+  fatal "no files found at ${STAGING_SUBPATH} to promote"
+fi
+
+require_bundle_contents STAGED_FILES
+download_bundle STAGED_FILES "${BUNDLE_ARTIFACT_DIR}"
+generate_bundle_checksums "${BUNDLE_ARTIFACT_DIR}"
+
+BUNDLE_ZIP="${WORK_DIR}/${ARTIFACT_ID}-${VERSION}.zip"
+create_bundle_zip "${BUNDLE_ZIP}"
+
+DEPLOYMENT_ID=""
+upload_bundle_to_portal "${BUNDLE_ZIP}" "${ARTIFACT_ID}-${VERSION}" DEPLOYMENT_ID
+
+wait_for_validated "${DEPLOYMENT_ID}"
+
+if [[ ${AUTO_DROP} == "true" ]]; then
+  drop_deployment "${DEPLOYMENT_ID}"
+else
+  cat <<EOF
+Deployment left in PENDING state.
+  Deployment id:  ${DEPLOYMENT_ID}
+  Portal UI:      ${CENTRAL_PORTAL_URL}/publishing/deployments
+A human must review the deployment and click Publish to release it to
+Maven Central.
+EOF
+fi

--- a/ci/maven-publish/maven_central_publish_steps.sh
+++ b/ci/maven-publish/maven_central_publish_steps.sh
@@ -1,0 +1,216 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Step functions used by maven_central_publish.sh. Sourced, not executed:
+#   . "${SCRIPT_DIR}/maven_central_publish_steps.sh"
+#
+# Two layers:
+#   * HTTP wrappers (artifactory_* / portal_*) - single-purpose curl calls.
+#     Accept optional trailing `retries` and `retry_delay_sec` args (defaults
+#     3 / 2 seconds).
+#   * Step functions - workflow-level actions composed from the HTTP wrappers,
+#     with logging and validation.
+#
+# Both layers rely on globals set by the calling script (ARTIFACTORY_*,
+# MAVEN_DEPLOY_*, CENTRAL_PORTAL_URL, POLL_*, STAGING_URL, STAGING_SUBPATH,
+# ARTIFACT_ID, VERSION, BUNDLE_DIR) and on `fatal` from maven_utils.sh.
+
+# -----------------------------------------------------------------------------
+# HTTP wrappers
+# -----------------------------------------------------------------------------
+
+# Base64 HTTP Basic value for the Publisher Portal (user token : password).
+_portal_auth() {
+  printf '%s:%s' "${MAVEN_DEPLOY_USERNAME}" "${MAVEN_DEPLOY_TOKEN}" | base64 -w0
+}
+
+# GET a JSON payload from Artifactory. Writes the response body to stdout.
+#   $1 = repo-relative path (e.g. "api/storage/<repo>/<subpath>")
+#   $2 = retries (default 3)
+#   $3 = retry_delay_sec (default 2)
+artifactory_get_json() {
+  local path=$1
+  local retries=${2:-3}
+  local retry_delay_sec=${3:-2}
+  curl -sS -f --retry "${retries}" --retry-delay "${retry_delay_sec}" \
+    --user "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}" \
+    "${ARTIFACTORY_URL}/${path}"
+}
+
+# GET a single file from Artifactory and save it to disk.
+#   $1 = full remote URL
+#   $2 = local destination path
+#   $3 = retries (default 3)
+#   $4 = retry_delay_sec (default 2)
+artifactory_download_file() {
+  local remote_url=$1
+  local local_path=$2
+  local retries=${3:-3}
+  local retry_delay_sec=${4:-2}
+  curl -sS -f --retry "${retries}" --retry-delay "${retry_delay_sec}" \
+    --user "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_TOKEN}" \
+    -o "${local_path}" \
+    "${remote_url}"
+}
+
+# POST a signed bundle zip to the Publisher Portal upload endpoint. Writes the
+# deployment id returned by the Portal to stdout.
+#   $1 = bundle zip path (already assembled locally)
+#   $2 = deployment name (unencoded; URL-encoded by this function)
+#   $3 = retries (default 3)
+#   $4 = retry_delay_sec (default 2)
+portal_upload_bundle() {
+  local bundle_path=$1
+  local deployment_name=$2
+  local retries=${3:-3}
+  local retry_delay_sec=${4:-2}
+  local url
+  url="${CENTRAL_PORTAL_URL}/api/v1/publisher/upload?name=$(printf %s "${deployment_name}" | jq -sRr @uri)&publishingType=USER_MANAGED"
+  curl -sS -f --retry "${retries}" --retry-delay "${retry_delay_sec}" \
+    -H "Authorization: Bearer $(_portal_auth)" \
+    -F "bundle=@${bundle_path}" \
+    -X POST "${url}"
+}
+
+# POST to the Publisher Portal status endpoint. Writes the response body to
+# stdout. On any curl failure, writes '{}' so callers can safely feed the
+# result to `jq` without extra error handling.
+#   $1 = deployment id
+#   $2 = retries (default 3)
+#   $3 = retry_delay_sec (default 2)
+portal_get_status() {
+  local deployment_id=$1
+  local retries=${2:-3}
+  local retry_delay_sec=${3:-2}
+  local url="${CENTRAL_PORTAL_URL}/api/v1/publisher/status?id=${deployment_id}"
+  curl -sS -f --retry "${retries}" --retry-delay "${retry_delay_sec}" \
+    -H "Authorization: Bearer $(_portal_auth)" \
+    -X POST "${url}" || echo '{}'
+}
+
+# DELETE a deployment from the Publisher Portal.
+#   $1 = deployment id
+#   $2 = retries (default 3)
+#   $3 = retry_delay_sec (default 2)
+portal_drop_deployment() {
+  local deployment_id=$1
+  local retries=${2:-3}
+  local retry_delay_sec=${3:-2}
+  curl -sS -f --retry "${retries}" --retry-delay "${retry_delay_sec}" \
+    -H "Authorization: Bearer $(_portal_auth)" \
+    -X DELETE "${CENTRAL_PORTAL_URL}/api/v1/publisher/deployment/${deployment_id}" \
+    -o /dev/null
+}
+
+# -----------------------------------------------------------------------------
+# Workflow step functions
+# -----------------------------------------------------------------------------
+
+list_staged_files() {
+  artifactory_get_json "api/storage/${ARTIFACTORY_REPOSITORY}/${STAGING_SUBPATH}" \
+    | jq -r '.children[] | select(.folder == false) | .uri | ltrimstr("/")'
+}
+
+# Fail early with a clear message rather than an opaque Central VALIDATION_FAILED.
+require_bundle_contents() {
+  local -n files_ref=$1
+  local pattern desc file found entry
+  local expected=(
+    "${ARTIFACT_ID}-${VERSION}.pom|the POM"
+    "${ARTIFACT_ID}-${VERSION}.pom.asc|the POM signature"
+    "${ARTIFACT_ID}-${VERSION}.jar|the unclassified primary jar"
+    "${ARTIFACT_ID}-${VERSION}.jar.asc|the unclassified primary jar signature"
+    "${ARTIFACT_ID}-${VERSION}-sources.jar|the sources jar"
+    "${ARTIFACT_ID}-${VERSION}-javadoc.jar|the javadoc jar"
+  )
+  for entry in "${expected[@]}"; do
+    IFS='|' read -r pattern desc <<< "${entry}"
+    found=0
+    for file in "${files_ref[@]}"; do
+      if [[ ${file} == "${pattern}" ]]; then
+        found=1
+        break
+      fi
+    done
+    if (( ! found )); then
+      fatal "staged bundle is missing ${desc} (${pattern})"
+    fi
+  done
+}
+
+download_bundle() {
+  local -n files_ref=$1
+  local dest=$2
+  local file
+  echo "Downloading ${#files_ref[@]} files from Artifactory"
+  for file in "${files_ref[@]}"; do
+    echo "  GET ${file}"
+    artifactory_download_file "${STAGING_URL}/${file}" "${dest}/${file}"
+  done
+}
+
+# Write .md5 and .sha1 sidecars next to every non-checksum file under
+# <root>. Sonatype Central rejects deployments missing either checksum
+# (https://central.sonatype.org/publish/requirements/); Artifactory doesn't
+# list them as children (it stores client-declared checksums as file
+# metadata) so we generate at promote time.
+generate_bundle_checksums() {
+  local root=$1
+  local file
+  while IFS= read -r file; do
+    md5sum  "${file}" | awk '{ print $1 }' > "${file}.md5"
+    sha1sum "${file}" | awk '{ print $1 }' > "${file}.sha1"
+  done < <(find "${root}" -type f ! -name '*.md5' ! -name '*.sha1' \
+             ! -name '*.sha256' ! -name '*.sha512')
+}
+
+create_bundle_zip() {
+  local zip_path=$1
+  echo "Zipping bundle at ${zip_path}"
+  (cd "${BUNDLE_DIR}" && zip -qr "${zip_path}" .)
+}
+
+# Publisher Portal API: https://central.sonatype.org/publish/publish-portal-api/
+upload_bundle_to_portal() {
+  local zip_path=$1
+  local deployment_name=$2
+  local -n out_deployment_id=$3
+  echo "Uploading bundle to Publisher Portal"
+  out_deployment_id=$(portal_upload_bundle "${zip_path}" "${deployment_name}")
+  if [[ -z ${out_deployment_id} ]]; then
+    fatal "Publisher Portal did not return a deployment id"
+  fi
+  echo "  deployment id: ${out_deployment_id}"
+}
+
+wait_for_validated() {
+  local deployment_id=$1
+  local response state elapsed=0
+  echo "Polling status (interval=${POLL_INTERVAL_SEC}s, timeout=${POLL_TIMEOUT_SEC}s)"
+  while (( elapsed < POLL_TIMEOUT_SEC )); do
+    response=$(portal_get_status "${deployment_id}")
+    state=$(jq -r '.deploymentState // "UNKNOWN"' <<< "${response}")
+    echo "  [${elapsed}s] state=${state}"
+    case "${state}" in
+      VALIDATED) return 0 ;;
+      FAILED|VALIDATION_FAILED)
+        jq . <<< "${response}" >&2 || true
+        fatal "Publisher Portal reported terminal state ${state}"
+        ;;
+      PUBLISHED)
+        fatal "unexpected PUBLISHED state (USER_MANAGED deployments should never auto-publish)"
+        ;;
+    esac
+    sleep "${POLL_INTERVAL_SEC}"
+    elapsed=$((elapsed + POLL_INTERVAL_SEC))
+  done
+  fatal "timed out waiting for VALIDATED, last state was '${state}'"
+}
+
+drop_deployment() {
+  local deployment_id=$1
+  echo "Dropping deployment ${deployment_id} (--auto-drop true)"
+  portal_drop_deployment "${deployment_id}"
+  echo "Deployment dropped. Nothing was published to Maven Central."
+}

--- a/ci/maven-publish/maven_utils.sh
+++ b/ci/maven-publish/maven_utils.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Shared helpers for the ci/maven-publish/ pipeline scripts (host and
+# in-container). Sourced, not executed:
+#   . "${SCRIPT_DIR}/maven_utils.sh"
+
+fatal() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+require_cmds() {
+  local cmd
+  for cmd in "$@"; do
+    if ! command -v "${cmd}" >/dev/null; then
+      fatal "'${cmd}' not on PATH"
+    fi
+  done
+}
+
+require_release_version() {
+  local version=$1
+  if [[ ${version} == *-SNAPSHOT ]]; then
+    fatal "release-shaped version required, got '${version}'"
+  fi
+}
+
+# Maven groupId (a.b.c) -> filesystem path (a/b/c).
+maven_group_path() {
+  echo "${1//./\/}"
+}
+
+# Repo-relative Maven path: <groupPath>/<artifactId>/<version>.
+# Re-uploading the same X.Y.Z overwrites in place. RC iteration is not
+# part of the path. Artifactory lastModified + sha256 give per-file
+# provenance. source.git-sha (matrix property) records the commit.
+maven_release_path() {
+  local group_id=$1 artifact_id=$2 version=$3
+  echo "$(maven_group_path "${group_id}")/${artifact_id}/${version}"
+}


### PR DESCRIPTION
* Add `.github/workflows/maven-publish.yaml`, a reusable workflow that
  publishes release-candidate Maven artifacts (jars, POMs, sources,
  javadoc) to Maven Central via the Sonatype Central Publisher Portal.
  Callers invoke it on tag builds.

* Two-phase pipeline: sign and upload to Artifactory first, then
  forward the same bytes to the Publisher Portal. Artifactory acts as
  the audit layer. Every upload lands at
  `<groupPath>/<artifactId>/<version>/`, overwriting any earlier
  bundle at the same coordinate (the workflow logs when it does so)
  so a later RC always wins. Each file is stamped with a
  `source.git-sha` matrix property linking it back to a commit.

* Upload runs in a container because it needs a Maven client and GPG.
  Promote runs directly on the host runner because it needs only an
  HTTP client. This avoids paying container startup cost twice.

* The workflow never calls the Portal's `/publish` endpoint. The
  `stage-for-maven-central-publish` input picks between two modes: by
  default it validates the bundle and immediately drops it (a safe
  rehearsal), or it can leave the bundle PENDING for a human to
  release from the Portal UI. Either way, promoting to Central
  requires a human click.

* Generate `.md5` and `.sha1` sidecars locally at promote time.
  Sonatype requires them for every file (including `.asc` signatures),
  and Artifactory doesn't preserve them as separately-listable files,
  so the pipeline generates them on the bundle right before
  uploading.

* The workflow resolves its own repository and ref from the caller's
  `uses:` line rather than hardcoding `rapidsai/shared-workflows`, so
  callers testing from a fork automatically pick up their own copy of
  the pipeline scripts.

* Add `RAPIDS_ARTIFACTORY_URL` and `RAPIDS_ARTIFACTORY_REPO` to the
  `config-variables` list in `.github/actionlint.yaml` so actionlint
  recognizes the workflow's references to them.

Closes https://github.com/rapidsai/build-infra/issues/382, https://github.com/rapidsai/build-infra/issues/383