### PR TITLE
compute-build-details: switch to just producing the datetime

### DIFF
--- a/.github/workflows/compute-build-details.yaml
+++ b/.github/workflows/compute-build-details.yaml
@@ -1,9 +1,9 @@
 on:
   workflow_call:
     outputs:
-      package-version-suffix:
-        description: "Suffix to be appended to conda/sdist/wheel version numbers."
-        value: ${{ jobs.build.outputs.version-suffix }}
+      build-datetime:
+        description: "integer-formatted 'UTC now' datetime"
+        value: ${{ jobs.build.outputs.build-datetime }}
 
 permissions: {}
 
@@ -11,9 +11,10 @@ jobs:
   build:
     runs-on: ubuntu-slim
     outputs:
-      version-suffix: ${{ steps.build-details.outputs.version-suffix }}
+      build-datetime: ${{ steps.build-details.outputs.build-datetime }}
     steps:
       - name: build
         id: build-details
         run: |
-          echo "version-suffix=.post$(date -u +'%y%m%d%H%M%S')" | tee -a "${GITHUB_OUTPUT}"
+          BUILD_DATETIME="$(date -u +'%y%m%d%H%M%S')"
+          echo "build-datetime="${BUILD_DATETIME}" | tee -a "${GITHUB_OUTPUT}"

--- a/.github/workflows/compute-build-details.yaml
+++ b/.github/workflows/compute-build-details.yaml
@@ -17,4 +17,4 @@ jobs:
         id: build-details
         run: |
           BUILD_DATETIME="$(date -u +'%y%m%d%H%M%S')"
-          echo "build-datetime="${BUILD_DATETIME}" | tee -a "${GITHUB_OUTPUT}"
+          echo "build-datetime=${BUILD_DATETIME}" | tee -a "${GITHUB_OUTPUT}"

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -16,11 +16,11 @@ on:
       sha:
         description: "Full git commit SHA to check out"
         type: string
-      version-suffix:
+      build-datetime:
         description: |
-          Optional value to be appended to package versions.
-          Will be appended exactly, so e.g. to add a '.' separator,
-          provide '.post1' not 'post1'.
+          date-time to be used in build strings.
+          Unlike input 'date' (set in the call to the calling workflow), this is computed at runtime
+          by the calling workflow.
         default: null
         required: false
         type: string
@@ -109,7 +109,7 @@ jobs:
       image: rapidsai/ci-conda:26.10-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
-        RAPIDS_VERSION_SUFFIX: ${{ inputs.version-suffix }}
+        RAPIDS_DATETIME_STRING: ${{ inputs.build-datetime }}
     steps:
       - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -16,11 +16,11 @@ on:
       sha:
         description: "Full git commit SHA to check out"
         type: string
-      version-suffix:
+      build-datetime:
         description: |
-          Optional value to be appended to package versions.
-          Will be appended exactly, so e.g. to add a '.' separator,
-          provide '.post1' not 'post1'.
+          date-time to be used in build strings.
+          Unlike input 'date' (set in the call to the calling workflow), this is computed at runtime
+          by the calling workflow.
         default: null
         required: false
         type: string
@@ -119,7 +119,7 @@ jobs:
       image: rapidsai/ci-conda:26.10-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
-        RAPIDS_VERSION_SUFFIX: ${{ inputs.version-suffix }}
+        RAPIDS_DATETIME_STRING: ${{ inputs.build-datetime }}
     steps:
       - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -16,11 +16,11 @@ on:
       sha:
         description: "Full git commit SHA to check out"
         type: string
-      version-suffix:
+      build-datetime:
         description: |
-          Optional value to be appended to package versions.
-          Will be appended exactly, so e.g. to add a '.' separator,
-          provide '.post1' not 'post1'.
+          date-time to be used in build strings.
+          Unlike input 'date' (set in the call to the calling workflow), this is computed at runtime
+          by the calling workflow.
         default: null
         required: false
         type: string
@@ -139,7 +139,7 @@ jobs:
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
-        RAPIDS_VERSION_SUFFIX: ${{ inputs.version-suffix }}
+        RAPIDS_DATETIME_STRING: ${{ inputs.build-datetime }}
     steps:
       - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -14,14 +14,14 @@ on:
       sha:
         description: "Full git commit SHA to check out"
         type: string
-      version-suffix:
+      build-datetime:
         description: |
-          Optional value to be appended to package versions.
-          Will be appended exactly, so e.g. to add a '.' separator,
-          provide '.post1' not 'post1'.
+          date-time to be used in build strings.
+          Unlike input 'date' (set in the call to the calling workflow), this is computed at runtime
+          by the calling workflow.
         default: null
-        type: string
         required: false
+        type: string
       repo:
         description: "Git repo to check out, in '{org}/{repo}' form, e.g. 'rapidsai/cudf'"
         type: string
@@ -149,8 +149,7 @@ jobs:
       image: "rapidsai/ci-wheel:26.10-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
       env:
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
-        RAPIDS_VERSION_SUFFIX: ${{ inputs.version-suffix }}
-
+        RAPIDS_DATETIME_STRING: ${{ inputs.build-datetime }}
     steps:
       - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
         with:


### PR DESCRIPTION
#603 added a `compute-build-details` workflow, to generate a stable version component for nightly packages.

This adjusts that based on feedback in https://github.com/rapidsai/cugraph-gnn/pull/508#discussion_r3678533912 that we'd prefer to handle conda packages and wheels differently.

## Notes for Reviewers

### How I tested this

See "How I tested this" in https://github.com/rapidsai/cugraph-gnn/pull/508