### PR TITLE
release: generate release catalog companions for build artifacts

### DIFF
--- a/.github/workflows/compute-matrix.yaml
+++ b/.github/workflows/compute-matrix.yaml
@@ -2,7 +2,7 @@ on:
   workflow_call:
     inputs:
       build_type:
-        description: "One of: [branch, nightly, pull-request]"
+        description: "One of: [branch, nightly, pull-request, release-candidate]"
         required: true
         type: string
       matrix_name:
@@ -200,8 +200,8 @@ jobs:
         env:
           MATRIX: ${{ steps.prepare-matrix.outputs.matrix }}
         run: |
-          if [[ "$BUILD_TYPE" != "branch" ]] && [[ "$BUILD_TYPE" != "nightly" ]] && [[ "$BUILD_TYPE" != "pull-request" ]]; then
-              echo "Invalid build_type! Must be one of 'branch', 'nightly', or 'pull-request'."
+          if [[ "$BUILD_TYPE" != "branch" ]] && [[ "$BUILD_TYPE" != "nightly" ]] && [[ "$BUILD_TYPE" != "pull-request" ]] && [[ "$BUILD_TYPE" != "release-candidate" ]]; then
+              echo "Invalid build_type! Must be one of 'branch', 'nightly', 'pull-request', or 'release-candidate'."
               exit 1
           fi
           if [[ "$MATRIX_TYPE" != "auto" ]] && [[ "$MATRIX_TYPE" != "nightly" ]] && [[ "$MATRIX_TYPE" != "pull-request" ]]; then
@@ -224,7 +224,7 @@ jobs:
 
           # only overwrite MATRIX_TYPE if it was set to 'auto'
           if [[ "${MATRIX_TYPE}" == "auto" ]]; then
-            if [[ "${BUILD_TYPE}" == "branch" ]]; then
+            if [[ "${BUILD_TYPE}" == "branch" || "${BUILD_TYPE}" == "release-candidate" ]]; then
               # Use the nightly matrix for branch tests
               MATRIX_TYPE="nightly"
             else

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -48,7 +48,10 @@ on:
         type: string
         default: ''
         required: false
-        description: "Override the release-platform unit ID; defaults to conda:<repository-name>"
+        description: >-
+          Release component ID: a string label, not a file or bundle. It is written to each manifest entry and groups
+          files and matrix variants for release assembly. Leave empty to use conda:<repository-name>; override only
+          when one repository's Conda producers must be tracked as distinct components.
       matrix_filter:
         description: |
           jq expression which modifies the matrix.
@@ -234,11 +237,14 @@ jobs:
 
       - name: Create Conda release build-output companion
         if: ${{ inputs.upload-artifacts }}
-        uses: rapidsai/shared-actions/release-build-output-dispatch@3a9568fc2c9bc9fd05e4cf76a73d9ad481f93ac5 # agent/release-build-output-container
+        uses: rapidsai/shared-actions/release-build-output-dispatch@a18a4a7ac572366c09c15641ec274cc6f15bfb5d # agent/release-build-output-container
         with:
-          artifact-type: conda
-          output-directory: ${{ steps.package-name.outputs.CONDA_OUTPUT_DIR }}
-          release-unit: ${{ inputs.release-unit || format('conda:{0}', github.event.repository.name) }}
+          config: >-
+            {
+              "artifact_type": "conda",
+              "component_id": ${{ toJSON(inputs.release-unit || format('conda:{0}', github.event.repository.name)) }},
+              "output_directory": ${{ toJSON(steps.package-name.outputs.CONDA_OUTPUT_DIR) }}
+            }
           source-artifact-name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
           source-sha: ${{ inputs.sha || github.sha }}
       - name: Upload additional artifacts

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -2,7 +2,7 @@ on:
   workflow_call:
     inputs:
       build_type:
-        description: "One of: [branch, nightly, pull-request]"
+        description: "One of: [branch, nightly, pull-request, release-candidate]"
         required: true
         type: string
       branch:
@@ -44,6 +44,10 @@ on:
         default: true
         required: false
         description: "One of [true, false], true if artifacts should be uploaded to GitHub's artifact store"
+      candidate-train-sha256:
+        description: "Canonical SHA-256 of the release train; required for release-candidate builds."
+        type: string
+        default: ""
       matrix_filter:
         description: |
           jq expression which modifies the matrix.
@@ -200,7 +204,7 @@ jobs:
           MAMBA_USE_SHARDED_REPODATA: false
           RATTLER_SHARDED: false
       - name: Get Package Name and Location
-        if: ${{ inputs.upload-artifacts }}
+        if: ${{ inputs.upload-artifacts || inputs.build_type == 'release-candidate' }}
         env:
           # Pass RAPIDS_PACKAGE_NAME from cpp-build step if available
           RAPIDS_PACKAGE_NAME: ${{ steps.cpp-build.outputs.rapids-package-name }}
@@ -214,22 +218,22 @@ jobs:
           echo "CONDA_OUTPUT_DIR=${RAPIDS_CONDA_BLD_OUTPUT_DIR}" >> "${GITHUB_OUTPUT}"
         id: package-name
       - name: Show files to be uploaded
-        if: ${{ inputs.upload-artifacts }}
+        if: ${{ inputs.upload-artifacts || inputs.build_type == 'release-candidate' }}
         env:
           CONDA_OUTPUT_DIR: ${{ steps.package-name.outputs.CONDA_OUTPUT_DIR }}
         run: |
           echo "Contents of directory to be uploaded:"
           ls -R "${CONDA_OUTPUT_DIR}"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: ${{ inputs.upload-artifacts }}
+        if: ${{ inputs.upload-artifacts && inputs.build_type != 'release-candidate' }}
         with:
           if-no-files-found: 'error'
           name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
           path: ${{ steps.package-name.outputs.CONDA_OUTPUT_DIR }}
 
       - name: Create Conda release catalog companion
-        if: ${{ inputs.upload-artifacts }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@32a308ab234f7381dd611056747b4c1ac30d2a34 # shared-actions PR 136 canary head
+        if: ${{ inputs.build_type == 'release-candidate' }}
+        uses: rapidsai/shared-actions/release-catalog-dispatch@8fef990732014851c3d5afcf931c2506f7e175b0 # shared-actions PR 136 candidate-store head
         with:
           config: >-
             {
@@ -237,8 +241,10 @@ jobs:
               "artifact_directory": ${{ toJSON(steps.package-name.outputs.CONDA_OUTPUT_DIR) }}
             }
           source-artifact-name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
+          candidate-train-sha256: ${{ inputs.candidate-train-sha256 }}
+          upload-to-s3: 'true'
       - name: Upload additional artifacts
-        if: "!cancelled()"
+        if: ${{ !cancelled() && inputs.build_type != 'release-candidate' }}
         run: rapids-upload-artifacts-dir "cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)"
       - name: Telemetry upload attributes
         uses: rapidsai/shared-actions/telemetry-dispatch-stash-job-artifacts@main

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -44,6 +44,11 @@ on:
         default: true
         required: false
         description: "One of [true, false], true if artifacts should be uploaded to GitHub's artifact store"
+      release-unit:
+        type: string
+        default: ''
+        required: false
+        description: "Override the release-platform unit ID; defaults to conda:<repository-name>"
       matrix_filter:
         description: |
           jq expression which modifies the matrix.
@@ -226,6 +231,16 @@ jobs:
           if-no-files-found: 'error'
           name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
           path: ${{ steps.package-name.outputs.CONDA_OUTPUT_DIR }}
+
+      - name: Create Conda release build-output companion
+        if: ${{ inputs.upload-artifacts }}
+        uses: rapidsai/shared-actions/release-build-output-dispatch@main
+        with:
+          artifact-type: conda
+          output-directory: ${{ steps.package-name.outputs.CONDA_OUTPUT_DIR }}
+          release-unit: ${{ inputs.release-unit || format('conda:{0}', github.event.repository.name) }}
+          source-artifact-name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
+          source-sha: ${{ inputs.sha || github.sha }}
       - name: Upload additional artifacts
         if: "!cancelled()"
         run: rapids-upload-artifacts-dir "cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)"

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -233,7 +233,7 @@ jobs:
 
       - name: Create Conda release catalog companion
         if: ${{ inputs.build_type == 'release-candidate' }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@d2f44b9e8cd705357c8e12c0b07fea3dd9b893a0 # shared-actions PR 136 candidate-store head
+        uses: rapidsai/shared-actions/release-catalog-dispatch@d2f44b948645ee187102bf586d2ea44596a637c1 # shared-actions PR 136 candidate-store head
         with:
           config: >-
             {

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -240,7 +240,7 @@ jobs:
           role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-rapids-release-candidates
       - name: Create Conda release catalog companion
         if: ${{ inputs.build_type == 'release-candidate' }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@d2f44b948645ee187102bf586d2ea44596a637c1 # shared-actions PR 136 candidate-store head
+        uses: rapidsai/shared-actions/release-catalog-dispatch@f2e2c3621f5fc8b77b3c0dc669d60f817b1d05eb # shared-actions PR 136 candidate-store head
         with:
           config: >-
             {

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -234,7 +234,7 @@ jobs:
 
       - name: Create Conda release build-output companion
         if: ${{ inputs.upload-artifacts }}
-        uses: msarahan/shared-actions/release-build-output-dispatch@76acdd577825aefd04d8ea143449101b707acee6 # agent/release-build-output-container
+        uses: rapidsai/shared-actions/release-build-output-dispatch@3a9568fc2c9bc9fd05e4cf76a73d9ad481f93ac5 # agent/release-build-output-container
         with:
           artifact-type: conda
           output-directory: ${{ steps.package-name.outputs.CONDA_OUTPUT_DIR }}

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -120,6 +120,7 @@ jobs:
         # build helpers use the established nightly dependency behavior.
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type == 'release-candidate' && 'nightly' || inputs.build_type }}
         RAPIDS_RELEASE_CANDIDATE: ${{ inputs.build_type == 'release-candidate' }}
+        GITHUB_REF: ${{ inputs.build_type == 'release-candidate' && format('refs/tags/{0}', inputs.release-candidate-tag) || github.ref }}
         RAPIDS_DATETIME_STRING: ${{ inputs.build-datetime }}
     steps:
       - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -120,7 +120,6 @@ jobs:
         # build helpers use the established nightly dependency behavior.
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type == 'release-candidate' && 'nightly' || inputs.build_type }}
         RAPIDS_RELEASE_CANDIDATE: ${{ inputs.build_type == 'release-candidate' }}
-        GITHUB_REF: ${{ inputs.build_type == 'release-candidate' && format('refs/tags/{0}', inputs.release-candidate-tag) || github.ref }}
         RAPIDS_DATETIME_STRING: ${{ inputs.build-datetime }}
     steps:
       - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
@@ -142,7 +141,15 @@ jobs:
         run: |
           test -n "${RELEASE_CANDIDATE_TAG}"
           git tag --force "${RELEASE_CANDIDATE_TAG}" "${RELEASE_CANDIDATE_SHA}"
+          git remote set-url --push origin no_push
           git show-ref --verify --quiet "refs/tags/${RELEASE_CANDIDATE_TAG}"
+      - name: Force local release-candidate build context
+        if: ${{ inputs.build_type == 'release-candidate' }}
+        run: |
+          mkdir -p "${RUNNER_TEMP}/release-candidate-tools"
+          printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "${RUNNER_TEMP}/release-candidate-tools/rapids-is-release-build"
+          chmod +x "${RUNNER_TEMP}/release-candidate-tools/rapids-is-release-build"
+          echo "${RUNNER_TEMP}/release-candidate-tools" >> "${GITHUB_PATH}"
       - name: Standardize repository information
         env:
           RAPIDS_REPOSITORY: ${{ inputs.repo || github.repository }}

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -237,7 +237,6 @@ jobs:
               "artifact_directory": ${{ toJSON(steps.package-name.outputs.CONDA_OUTPUT_DIR) }}
             }
           source-artifact-name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
-          source-sha: ${{ env.RAPIDS_SHA }}
       - name: Upload additional artifacts
         if: "!cancelled()"
         run: rapids-upload-artifacts-dir "cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)"

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -48,6 +48,10 @@ on:
         description: "Canonical SHA-256 of the release train; required for release-candidate builds."
         type: string
         default: ""
+      release-candidate-tag:
+        description: "Final source tag created locally for a release-candidate build; it is never pushed."
+        type: string
+        default: ""
       matrix_filter:
         description: |
           jq expression which modifies the matrix.
@@ -115,6 +119,7 @@ jobs:
         # Candidate orchestration retains its own input mode, while RAPIDS
         # build helpers use the established nightly dependency behavior.
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type == 'release-candidate' && 'nightly' || inputs.build_type }}
+        RAPIDS_RELEASE_CANDIDATE: ${{ inputs.build_type == 'release-candidate' }}
         RAPIDS_DATETIME_STRING: ${{ inputs.build-datetime }}
     steps:
       - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
@@ -128,6 +133,15 @@ jobs:
           ref: ${{ inputs.sha }}
           fetch-depth: 0
           persist-credentials: true
+      - name: Create local release-candidate tag
+        if: ${{ inputs.build_type == 'release-candidate' }}
+        env:
+          RELEASE_CANDIDATE_TAG: ${{ inputs.release-candidate-tag }}
+          RELEASE_CANDIDATE_SHA: ${{ inputs.sha }}
+        run: |
+          test -n "${RELEASE_CANDIDATE_TAG}"
+          git tag --force "${RELEASE_CANDIDATE_TAG}" "${RELEASE_CANDIDATE_SHA}"
+          git show-ref --verify --quiet "refs/tags/${RELEASE_CANDIDATE_TAG}"
       - name: Standardize repository information
         env:
           RAPIDS_REPOSITORY: ${{ inputs.repo || github.repository }}
@@ -242,7 +256,7 @@ jobs:
           role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-rapids-release-candidates
       - name: Create Conda release catalog companion
         if: ${{ inputs.build_type == 'release-candidate' }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@f2e2c3621f5fc8b77b3c0dc669d60f817b1d05eb # shared-actions PR 136 candidate-store head
+        uses: rapidsai/shared-actions/release-catalog-dispatch@079aafb321c9a87d5741a79234d65ad30f1e9bb0 # shared-actions PR 136 candidate-store head
         with:
           config: >-
             {

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -227,9 +227,9 @@ jobs:
           name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
           path: ${{ steps.package-name.outputs.CONDA_OUTPUT_DIR }}
 
-      - name: Create Conda release build-output companion
+      - name: Create Conda release catalog companion
         if: ${{ inputs.upload-artifacts }}
-        uses: rapidsai/shared-actions/release-build-output-dispatch@a18a4a7ac572366c09c15641ec274cc6f15bfb5d # agent/release-build-output-container
+        uses: rapidsai/shared-actions/release-catalog-dispatch@45e84f709fde5e3f1b5960ed0510599c5f388333 # shared-actions PR 136
         with:
           config: >-
             {

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -44,14 +44,6 @@ on:
         default: true
         required: false
         description: "One of [true, false], true if artifacts should be uploaded to GitHub's artifact store"
-      release-unit:
-        type: string
-        default: ''
-        required: false
-        description: >-
-          Release component ID: a string label, not a file or bundle. It is written to each manifest entry and groups
-          files and matrix variants for release assembly. Leave empty to use conda:<repository-name>; override only
-          when one repository's Conda producers must be tracked as distinct components.
       matrix_filter:
         description: |
           jq expression which modifies the matrix.
@@ -242,11 +234,11 @@ jobs:
           config: >-
             {
               "artifact_type": "conda",
-              "component_id": ${{ toJSON(inputs.release-unit || format('conda:{0}', github.event.repository.name)) }},
+              "component_id": ${{ toJSON(format('conda:{0}', github.event.repository.name)) }},
               "output_directory": ${{ toJSON(steps.package-name.outputs.CONDA_OUTPUT_DIR) }}
             }
           source-artifact-name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
-          source-sha: ${{ inputs.sha || github.sha }}
+          source-sha: ${{ env.RAPIDS_SHA }}
       - name: Upload additional artifacts
         if: "!cancelled()"
         run: rapids-upload-artifacts-dir "cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)"

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -229,7 +229,7 @@ jobs:
 
       - name: Create Conda release catalog companion
         if: ${{ inputs.upload-artifacts }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@6cdff151c40c97551fdf2abd5d977580f94ed7e1 # shared-actions PR 136
+        uses: rapidsai/shared-actions/release-catalog-dispatch@32a308ab234f7381dd611056747b4c1ac30d2a34 # shared-actions PR 136 canary head
         with:
           config: >-
             {

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -233,7 +233,7 @@ jobs:
 
       - name: Create Conda release catalog companion
         if: ${{ inputs.build_type == 'release-candidate' }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@8fef990732014851c3d5afcf931c2506f7e175b0 # shared-actions PR 136 candidate-store head
+        uses: rapidsai/shared-actions/release-catalog-dispatch@d2f44b9e8cd705357c8e12c0b07fea3dd9b893a0 # shared-actions PR 136 candidate-store head
         with:
           config: >-
             {

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -229,7 +229,7 @@ jobs:
 
       - name: Create Conda release catalog companion
         if: ${{ inputs.upload-artifacts }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@c4b135aba0b7c5e9fa97f384505efeb17b8c5aa9 # shared-actions PR 136
+        uses: rapidsai/shared-actions/release-catalog-dispatch@6cdff151c40c97551fdf2abd5d977580f94ed7e1 # shared-actions PR 136
         with:
           config: >-
             {

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -112,7 +112,9 @@ jobs:
     container:
       image: rapidsai/ci-conda:26.10-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
       env:
-        RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
+        # Candidate orchestration retains its own input mode, while RAPIDS
+        # build helpers use the established nightly dependency behavior.
+        RAPIDS_BUILD_TYPE: ${{ inputs.build_type == 'release-candidate' && 'nightly' || inputs.build_type }}
         RAPIDS_DATETIME_STRING: ${{ inputs.build-datetime }}
     steps:
       - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -234,7 +234,7 @@ jobs:
           config: >-
             {
               "release_catalog_key": ${{ toJSON(format('conda:{0}', github.event.repository.name)) }},
-              "output_directory": ${{ toJSON(steps.package-name.outputs.CONDA_OUTPUT_DIR) }}
+              "artifact_directory": ${{ toJSON(steps.package-name.outputs.CONDA_OUTPUT_DIR) }}
             }
           source-artifact-name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
           source-sha: ${{ env.RAPIDS_SHA }}

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -234,7 +234,7 @@ jobs:
           config: >-
             {
               "artifact_type": "conda",
-              "component_id": ${{ toJSON(format('conda:{0}', github.event.repository.name)) }},
+              "release_catalog_key": ${{ toJSON(format('conda:{0}', github.event.repository.name)) }},
               "output_directory": ${{ toJSON(steps.package-name.outputs.CONDA_OUTPUT_DIR) }}
             }
           source-artifact-name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -233,7 +233,6 @@ jobs:
         with:
           config: >-
             {
-              "artifact_type": "conda",
               "release_catalog_key": ${{ toJSON(format('conda:{0}', github.event.repository.name)) }},
               "output_directory": ${{ toJSON(steps.package-name.outputs.CONDA_OUTPUT_DIR) }}
             }

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -229,7 +229,7 @@ jobs:
 
       - name: Create Conda release catalog companion
         if: ${{ inputs.upload-artifacts }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@45e84f709fde5e3f1b5960ed0510599c5f388333 # shared-actions PR 136
+        uses: rapidsai/shared-actions/release-catalog-dispatch@c4b135aba0b7c5e9fa97f384505efeb17b8c5aa9 # shared-actions PR 136
         with:
           config: >-
             {

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -231,6 +231,13 @@ jobs:
           name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
           path: ${{ steps.package-name.outputs.CONDA_OUTPUT_DIR }}
 
+      - name: Configure release-candidate store credentials
+        if: ${{ inputs.build_type == 'release-candidate' }}
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
+        with:
+          aws-region: us-east-2
+          role-duration-seconds: 43200 # 12h
+          role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-rapids-release-candidates
       - name: Create Conda release catalog companion
         if: ${{ inputs.build_type == 'release-candidate' }}
         uses: rapidsai/shared-actions/release-catalog-dispatch@d2f44b948645ee187102bf586d2ea44596a637c1 # shared-actions PR 136 candidate-store head

--- a/.github/workflows/conda-cpp-build.yaml
+++ b/.github/workflows/conda-cpp-build.yaml
@@ -234,7 +234,7 @@ jobs:
 
       - name: Create Conda release build-output companion
         if: ${{ inputs.upload-artifacts }}
-        uses: rapidsai/shared-actions/release-build-output-dispatch@main
+        uses: msarahan/shared-actions/release-build-output-dispatch@76acdd577825aefd04d8ea143449101b707acee6 # agent/release-build-output-container
         with:
           artifact-type: conda
           output-directory: ${{ steps.package-name.outputs.CONDA_OUTPUT_DIR }}

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -239,7 +239,7 @@ jobs:
           config: >-
             {
               "release_catalog_key": ${{ toJSON(format('conda:{0}', github.event.repository.name)) }},
-              "output_directory": ${{ toJSON(steps.package-name.outputs.CONDA_OUTPUT_DIR) }}
+              "artifact_directory": ${{ toJSON(steps.package-name.outputs.CONDA_OUTPUT_DIR) }}
             }
           source-artifact-name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
           source-sha: ${{ env.RAPIDS_SHA }}

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -48,7 +48,10 @@ on:
         type: string
         default: ''
         required: false
-        description: "Override the release-platform unit ID; defaults to conda:<repository-name>"
+        description: >-
+          Release component ID: a string label, not a file or bundle. It is written to each manifest entry and groups
+          files and matrix variants for release assembly. Leave empty to use conda:<repository-name>; override only
+          when one repository's Conda producers must be tracked as distinct components.
       matrix_filter:
         description: |
           jq expression which modifies the matrix.
@@ -239,11 +242,14 @@ jobs:
 
       - name: Create Conda release build-output companion
         if: ${{ inputs.upload-artifacts }}
-        uses: rapidsai/shared-actions/release-build-output-dispatch@3a9568fc2c9bc9fd05e4cf76a73d9ad481f93ac5 # agent/release-build-output-container
+        uses: rapidsai/shared-actions/release-build-output-dispatch@a18a4a7ac572366c09c15641ec274cc6f15bfb5d # agent/release-build-output-container
         with:
-          artifact-type: conda
-          output-directory: ${{ steps.package-name.outputs.CONDA_OUTPUT_DIR }}
-          release-unit: ${{ inputs.release-unit || format('conda:{0}', github.event.repository.name) }}
+          config: >-
+            {
+              "artifact_type": "conda",
+              "component_id": ${{ toJSON(inputs.release-unit || format('conda:{0}', github.event.repository.name)) }},
+              "output_directory": ${{ toJSON(steps.package-name.outputs.CONDA_OUTPUT_DIR) }}
+            }
           source-artifact-name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
           source-sha: ${{ inputs.sha || github.sha }}
       - name: Upload additional artifacts

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -245,7 +245,7 @@ jobs:
           role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-rapids-release-candidates
       - name: Create Conda release catalog companion
         if: ${{ inputs.build_type == 'release-candidate' }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@d2f44b948645ee187102bf586d2ea44596a637c1 # shared-actions PR 136 candidate-store head
+        uses: rapidsai/shared-actions/release-catalog-dispatch@f2e2c3621f5fc8b77b3c0dc669d60f817b1d05eb # shared-actions PR 136 candidate-store head
         with:
           config: >-
             {

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -232,9 +232,9 @@ jobs:
           name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
           path: ${{ steps.package-name.outputs.CONDA_OUTPUT_DIR }}
 
-      - name: Create Conda release build-output companion
+      - name: Create Conda release catalog companion
         if: ${{ inputs.upload-artifacts }}
-        uses: rapidsai/shared-actions/release-build-output-dispatch@a18a4a7ac572366c09c15641ec274cc6f15bfb5d # agent/release-build-output-container
+        uses: rapidsai/shared-actions/release-catalog-dispatch@45e84f709fde5e3f1b5960ed0510599c5f388333 # shared-actions PR 136
         with:
           config: >-
             {

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -234,7 +234,7 @@ jobs:
 
       - name: Create Conda release catalog companion
         if: ${{ inputs.upload-artifacts }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@c4b135aba0b7c5e9fa97f384505efeb17b8c5aa9 # shared-actions PR 136
+        uses: rapidsai/shared-actions/release-catalog-dispatch@6cdff151c40c97551fdf2abd5d977580f94ed7e1 # shared-actions PR 136
         with:
           config: >-
             {

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -239,7 +239,7 @@ jobs:
 
       - name: Create Conda release build-output companion
         if: ${{ inputs.upload-artifacts }}
-        uses: msarahan/shared-actions/release-build-output-dispatch@76acdd577825aefd04d8ea143449101b707acee6 # agent/release-build-output-container
+        uses: rapidsai/shared-actions/release-build-output-dispatch@3a9568fc2c9bc9fd05e4cf76a73d9ad481f93ac5 # agent/release-build-output-container
         with:
           artifact-type: conda
           output-directory: ${{ steps.package-name.outputs.CONDA_OUTPUT_DIR }}

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -238,7 +238,7 @@ jobs:
 
       - name: Create Conda release catalog companion
         if: ${{ inputs.build_type == 'release-candidate' }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@d2f44b9e8cd705357c8e12c0b07fea3dd9b893a0 # shared-actions PR 136 candidate-store head
+        uses: rapidsai/shared-actions/release-catalog-dispatch@d2f44b948645ee187102bf586d2ea44596a637c1 # shared-actions PR 136 candidate-store head
         with:
           config: >-
             {

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -239,7 +239,7 @@ jobs:
 
       - name: Create Conda release build-output companion
         if: ${{ inputs.upload-artifacts }}
-        uses: rapidsai/shared-actions/release-build-output-dispatch@main
+        uses: msarahan/shared-actions/release-build-output-dispatch@76acdd577825aefd04d8ea143449101b707acee6 # agent/release-build-output-container
         with:
           artifact-type: conda
           output-directory: ${{ steps.package-name.outputs.CONDA_OUTPUT_DIR }}

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -242,7 +242,6 @@ jobs:
               "artifact_directory": ${{ toJSON(steps.package-name.outputs.CONDA_OUTPUT_DIR) }}
             }
           source-artifact-name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
-          source-sha: ${{ env.RAPIDS_SHA }}
       - name: Upload additional artifacts
         if: "!cancelled()"
         run: rapids-upload-artifacts-dir "cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}"

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -238,7 +238,7 @@ jobs:
 
       - name: Create Conda release catalog companion
         if: ${{ inputs.build_type == 'release-candidate' }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@8fef990732014851c3d5afcf931c2506f7e175b0 # shared-actions PR 136 candidate-store head
+        uses: rapidsai/shared-actions/release-catalog-dispatch@d2f44b9e8cd705357c8e12c0b07fea3dd9b893a0 # shared-actions PR 136 candidate-store head
         with:
           config: >-
             {

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -234,7 +234,7 @@ jobs:
 
       - name: Create Conda release catalog companion
         if: ${{ inputs.upload-artifacts }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@45e84f709fde5e3f1b5960ed0510599c5f388333 # shared-actions PR 136
+        uses: rapidsai/shared-actions/release-catalog-dispatch@c4b135aba0b7c5e9fa97f384505efeb17b8c5aa9 # shared-actions PR 136
         with:
           config: >-
             {

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -122,7 +122,9 @@ jobs:
     container:
       image: rapidsai/ci-conda:26.10-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}
       env:
-        RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
+        # Candidate orchestration retains its own input mode, while RAPIDS
+        # build helpers use the established nightly dependency behavior.
+        RAPIDS_BUILD_TYPE: ${{ inputs.build_type == 'release-candidate' && 'nightly' || inputs.build_type }}
         RAPIDS_DATETIME_STRING: ${{ inputs.build-datetime }}
     steps:
       - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -44,6 +44,11 @@ on:
         default: true
         required: false
         description: "One of [true, false], true if artifacts should be uploaded to GitHub's artifact store"
+      release-unit:
+        type: string
+        default: ''
+        required: false
+        description: "Override the release-platform unit ID; defaults to conda:<repository-name>"
       matrix_filter:
         description: |
           jq expression which modifies the matrix.
@@ -231,6 +236,16 @@ jobs:
           if-no-files-found: 'error'
           name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
           path: ${{ steps.package-name.outputs.CONDA_OUTPUT_DIR }}
+
+      - name: Create Conda release build-output companion
+        if: ${{ inputs.upload-artifacts }}
+        uses: rapidsai/shared-actions/release-build-output-dispatch@main
+        with:
+          artifact-type: conda
+          output-directory: ${{ steps.package-name.outputs.CONDA_OUTPUT_DIR }}
+          release-unit: ${{ inputs.release-unit || format('conda:{0}', github.event.repository.name) }}
+          source-artifact-name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
+          source-sha: ${{ inputs.sha || github.sha }}
       - name: Upload additional artifacts
         if: "!cancelled()"
         run: rapids-upload-artifacts-dir "cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}"

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -239,7 +239,7 @@ jobs:
           config: >-
             {
               "artifact_type": "conda",
-              "component_id": ${{ toJSON(format('conda:{0}', github.event.repository.name)) }},
+              "release_catalog_key": ${{ toJSON(format('conda:{0}', github.event.repository.name)) }},
               "output_directory": ${{ toJSON(steps.package-name.outputs.CONDA_OUTPUT_DIR) }}
             }
           source-artifact-name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -236,6 +236,13 @@ jobs:
           name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
           path: ${{ steps.package-name.outputs.CONDA_OUTPUT_DIR }}
 
+      - name: Configure release-candidate store credentials
+        if: ${{ inputs.build_type == 'release-candidate' }}
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
+        with:
+          aws-region: us-east-2
+          role-duration-seconds: 43200 # 12h
+          role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-rapids-release-candidates
       - name: Create Conda release catalog companion
         if: ${{ inputs.build_type == 'release-candidate' }}
         uses: rapidsai/shared-actions/release-catalog-dispatch@d2f44b948645ee187102bf586d2ea44596a637c1 # shared-actions PR 136 candidate-store head

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -48,6 +48,10 @@ on:
         description: "Canonical SHA-256 of the release train; required for release-candidate builds."
         type: string
         default: ""
+      release-candidate-tag:
+        description: "Final source tag created locally for a release-candidate build; it is never pushed."
+        type: string
+        default: ""
       matrix_filter:
         description: |
           jq expression which modifies the matrix.
@@ -125,6 +129,7 @@ jobs:
         # Candidate orchestration retains its own input mode, while RAPIDS
         # build helpers use the established nightly dependency behavior.
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type == 'release-candidate' && 'nightly' || inputs.build_type }}
+        RAPIDS_RELEASE_CANDIDATE: ${{ inputs.build_type == 'release-candidate' }}
         RAPIDS_DATETIME_STRING: ${{ inputs.build-datetime }}
     steps:
       - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
@@ -138,6 +143,15 @@ jobs:
           ref: ${{ inputs.sha }}
           fetch-depth: 0
           persist-credentials: true
+      - name: Create local release-candidate tag
+        if: ${{ inputs.build_type == 'release-candidate' }}
+        env:
+          RELEASE_CANDIDATE_TAG: ${{ inputs.release-candidate-tag }}
+          RELEASE_CANDIDATE_SHA: ${{ inputs.sha }}
+        run: |
+          test -n "${RELEASE_CANDIDATE_TAG}"
+          git tag --force "${RELEASE_CANDIDATE_TAG}" "${RELEASE_CANDIDATE_SHA}"
+          git show-ref --verify --quiet "refs/tags/${RELEASE_CANDIDATE_TAG}"
       - name: Standardize repository information
         env:
           RAPIDS_REPOSITORY: ${{ inputs.repo || github.repository }}
@@ -247,7 +261,7 @@ jobs:
           role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-rapids-release-candidates
       - name: Create Conda release catalog companion
         if: ${{ inputs.build_type == 'release-candidate' }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@f2e2c3621f5fc8b77b3c0dc669d60f817b1d05eb # shared-actions PR 136 candidate-store head
+        uses: rapidsai/shared-actions/release-catalog-dispatch@079aafb321c9a87d5741a79234d65ad30f1e9bb0 # shared-actions PR 136 candidate-store head
         with:
           config: >-
             {

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -234,7 +234,7 @@ jobs:
 
       - name: Create Conda release catalog companion
         if: ${{ inputs.upload-artifacts }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@6cdff151c40c97551fdf2abd5d977580f94ed7e1 # shared-actions PR 136
+        uses: rapidsai/shared-actions/release-catalog-dispatch@32a308ab234f7381dd611056747b4c1ac30d2a34 # shared-actions PR 136 canary head
         with:
           config: >-
             {

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -130,6 +130,7 @@ jobs:
         # build helpers use the established nightly dependency behavior.
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type == 'release-candidate' && 'nightly' || inputs.build_type }}
         RAPIDS_RELEASE_CANDIDATE: ${{ inputs.build_type == 'release-candidate' }}
+        GITHUB_REF: ${{ inputs.build_type == 'release-candidate' && format('refs/tags/{0}', inputs.release-candidate-tag) || github.ref }}
         RAPIDS_DATETIME_STRING: ${{ inputs.build-datetime }}
     steps:
       - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -130,7 +130,6 @@ jobs:
         # build helpers use the established nightly dependency behavior.
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type == 'release-candidate' && 'nightly' || inputs.build_type }}
         RAPIDS_RELEASE_CANDIDATE: ${{ inputs.build_type == 'release-candidate' }}
-        GITHUB_REF: ${{ inputs.build_type == 'release-candidate' && format('refs/tags/{0}', inputs.release-candidate-tag) || github.ref }}
         RAPIDS_DATETIME_STRING: ${{ inputs.build-datetime }}
     steps:
       - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
@@ -152,7 +151,15 @@ jobs:
         run: |
           test -n "${RELEASE_CANDIDATE_TAG}"
           git tag --force "${RELEASE_CANDIDATE_TAG}" "${RELEASE_CANDIDATE_SHA}"
+          git remote set-url --push origin no_push
           git show-ref --verify --quiet "refs/tags/${RELEASE_CANDIDATE_TAG}"
+      - name: Force local release-candidate build context
+        if: ${{ inputs.build_type == 'release-candidate' }}
+        run: |
+          mkdir -p "${RUNNER_TEMP}/release-candidate-tools"
+          printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "${RUNNER_TEMP}/release-candidate-tools/rapids-is-release-build"
+          chmod +x "${RUNNER_TEMP}/release-candidate-tools/rapids-is-release-build"
+          echo "${RUNNER_TEMP}/release-candidate-tools" >> "${GITHUB_PATH}"
       - name: Standardize repository information
         env:
           RAPIDS_REPOSITORY: ${{ inputs.repo || github.repository }}

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -2,7 +2,7 @@ on:
   workflow_call:
     inputs:
       build_type:
-        description: "One of: [branch, nightly, pull-request]"
+        description: "One of: [branch, nightly, pull-request, release-candidate]"
         required: true
         type: string
       branch:
@@ -44,6 +44,10 @@ on:
         default: true
         required: false
         description: "One of [true, false], true if artifacts should be uploaded to GitHub's artifact store"
+      candidate-train-sha256:
+        description: "Canonical SHA-256 of the release train; required for release-candidate builds."
+        type: string
+        default: ""
       matrix_filter:
         description: |
           jq expression which modifies the matrix.
@@ -205,7 +209,7 @@ jobs:
           MAMBA_USE_SHARDED_REPODATA: false
           RATTLER_SHARDED: false
       - name: Get Package Name and Location
-        if: ${{ inputs.upload-artifacts }}
+        if: ${{ inputs.upload-artifacts || inputs.build_type == 'release-candidate' }}
         env:
           # Pass RAPIDS_PACKAGE_NAME from python-build step if available
           RAPIDS_PACKAGE_NAME: ${{ steps.python-build.outputs.rapids-package-name }}
@@ -219,22 +223,22 @@ jobs:
           echo "CONDA_OUTPUT_DIR=${RAPIDS_CONDA_BLD_OUTPUT_DIR}" >> "${GITHUB_OUTPUT}"
         id: package-name
       - name: Show files to be uploaded
-        if: ${{ inputs.upload-artifacts }}
+        if: ${{ inputs.upload-artifacts || inputs.build_type == 'release-candidate' }}
         env:
           CONDA_OUTPUT_DIR: ${{ steps.package-name.outputs.CONDA_OUTPUT_DIR }}
         run: |
           echo "Contents of directory to be uploaded:"
           ls -R "${CONDA_OUTPUT_DIR}"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: ${{ inputs.upload-artifacts }}
+        if: ${{ inputs.upload-artifacts && inputs.build_type != 'release-candidate' }}
         with:
           if-no-files-found: 'error'
           name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
           path: ${{ steps.package-name.outputs.CONDA_OUTPUT_DIR }}
 
       - name: Create Conda release catalog companion
-        if: ${{ inputs.upload-artifacts }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@32a308ab234f7381dd611056747b4c1ac30d2a34 # shared-actions PR 136 canary head
+        if: ${{ inputs.build_type == 'release-candidate' }}
+        uses: rapidsai/shared-actions/release-catalog-dispatch@8fef990732014851c3d5afcf931c2506f7e175b0 # shared-actions PR 136 candidate-store head
         with:
           config: >-
             {
@@ -242,8 +246,10 @@ jobs:
               "artifact_directory": ${{ toJSON(steps.package-name.outputs.CONDA_OUTPUT_DIR) }}
             }
           source-artifact-name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
+          candidate-train-sha256: ${{ inputs.candidate-train-sha256 }}
+          upload-to-s3: 'true'
       - name: Upload additional artifacts
-        if: "!cancelled()"
+        if: ${{ !cancelled() && inputs.build_type != 'release-candidate' }}
         run: rapids-upload-artifacts-dir "cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}"
       - name: Telemetry upload attributes
         uses: rapidsai/shared-actions/telemetry-dispatch-stash-job-artifacts@main

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -238,7 +238,6 @@ jobs:
         with:
           config: >-
             {
-              "artifact_type": "conda",
               "release_catalog_key": ${{ toJSON(format('conda:{0}', github.event.repository.name)) }},
               "output_directory": ${{ toJSON(steps.package-name.outputs.CONDA_OUTPUT_DIR) }}
             }

--- a/.github/workflows/conda-python-build.yaml
+++ b/.github/workflows/conda-python-build.yaml
@@ -44,14 +44,6 @@ on:
         default: true
         required: false
         description: "One of [true, false], true if artifacts should be uploaded to GitHub's artifact store"
-      release-unit:
-        type: string
-        default: ''
-        required: false
-        description: >-
-          Release component ID: a string label, not a file or bundle. It is written to each manifest entry and groups
-          files and matrix variants for release assembly. Leave empty to use conda:<repository-name>; override only
-          when one repository's Conda producers must be tracked as distinct components.
       matrix_filter:
         description: |
           jq expression which modifies the matrix.
@@ -247,11 +239,11 @@ jobs:
           config: >-
             {
               "artifact_type": "conda",
-              "component_id": ${{ toJSON(inputs.release-unit || format('conda:{0}', github.event.repository.name)) }},
+              "component_id": ${{ toJSON(format('conda:{0}', github.event.repository.name)) }},
               "output_directory": ${{ toJSON(steps.package-name.outputs.CONDA_OUTPUT_DIR) }}
             }
           source-artifact-name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
-          source-sha: ${{ inputs.sha || github.sha }}
+          source-sha: ${{ env.RAPIDS_SHA }}
       - name: Upload additional artifacts
         if: "!cancelled()"
         run: rapids-upload-artifacts-dir "cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}"

--- a/.github/workflows/conda-upload-packages.yaml
+++ b/.github/workflows/conda-upload-packages.yaml
@@ -2,7 +2,7 @@ on:
   workflow_call:
     inputs:
       build_type:
-        description: "One of: [branch, nightly, pull-request]"
+        description: "One of: [branch, nightly, pull-request, release-candidate]"
         required: true
         type: string
       branch:
@@ -71,6 +71,9 @@ permissions:
 
 jobs:
   upload:
+    # Candidate artifacts are staged privately by the build workflow. They must
+    # not enter either public Anaconda.org channel before rollover approval.
+    if: ${{ inputs.build_type != 'release-candidate' }}
     runs-on: linux-amd64-cpu4
     container:
       image: "python:3.14-slim"

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -238,7 +238,7 @@ jobs:
           if-no-files-found: ignore
       - name: Create release catalog companion
         if: ${{ inputs.release-catalog-config != '' }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@45e84f709fde5e3f1b5960ed0510599c5f388333 # shared-actions PR 136
+        uses: rapidsai/shared-actions/release-catalog-dispatch@c4b135aba0b7c5e9fa97f384505efeb17b8c5aa9 # shared-actions PR 136
         with:
           config: ${{ inputs.release-catalog-config }}
           source-artifact-name: ${{ inputs.artifact-name }}

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -243,7 +243,7 @@ jobs:
           if-no-files-found: ignore
       - name: Create release catalog companion
         if: ${{ inputs.build_type == 'release-candidate' && inputs.release-catalog-config != '' }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@8fef990732014851c3d5afcf931c2506f7e175b0 # shared-actions PR 136 candidate-store head
+        uses: rapidsai/shared-actions/release-catalog-dispatch@d2f44b9e8cd705357c8e12c0b07fea3dd9b893a0 # shared-actions PR 136 candidate-store head
         with:
           config: ${{ inputs.release-catalog-config }}
           source-artifact-name: ${{ inputs.artifact-name }}

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -158,6 +158,7 @@ jobs:
         # build helpers use the established nightly dependency behavior.
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type == 'release-candidate' && 'nightly' || inputs.build_type }}
         RAPIDS_RELEASE_CANDIDATE: ${{ inputs.build_type == 'release-candidate' }}
+        GITHUB_REF: ${{ inputs.build_type == 'release-candidate' && format('refs/tags/{0}', inputs.release-candidate-tag) || github.ref }}
         RAPIDS_DATETIME_STRING: ${{ inputs.build-datetime }}
     steps:
       - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -158,7 +158,6 @@ jobs:
         # build helpers use the established nightly dependency behavior.
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type == 'release-candidate' && 'nightly' || inputs.build_type }}
         RAPIDS_RELEASE_CANDIDATE: ${{ inputs.build_type == 'release-candidate' }}
-        GITHUB_REF: ${{ inputs.build_type == 'release-candidate' && format('refs/tags/{0}', inputs.release-candidate-tag) || github.ref }}
         RAPIDS_DATETIME_STRING: ${{ inputs.build-datetime }}
     steps:
       - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
@@ -180,7 +179,15 @@ jobs:
         run: |
           test -n "${RELEASE_CANDIDATE_TAG}"
           git tag --force "${RELEASE_CANDIDATE_TAG}" "${RELEASE_CANDIDATE_SHA}"
+          git remote set-url --push origin no_push
           git show-ref --verify --quiet "refs/tags/${RELEASE_CANDIDATE_TAG}"
+      - name: Force local release-candidate build context
+        if: ${{ inputs.build_type == 'release-candidate' }}
+        run: |
+          mkdir -p "${RUNNER_TEMP}/release-candidate-tools"
+          printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "${RUNNER_TEMP}/release-candidate-tools/rapids-is-release-build"
+          chmod +x "${RUNNER_TEMP}/release-candidate-tools/rapids-is-release-build"
+          echo "${RUNNER_TEMP}/release-candidate-tools" >> "${GITHUB_PATH}"
       - name: Telemetry setup
         uses: rapidsai/shared-actions/telemetry-dispatch-setup@main
         continue-on-error: true

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -107,9 +107,9 @@ on:
         required: false
       release-catalog-config:
         description: >-
-          Optional JSON configuration for the `shared-actions/release-build-output-dispatch` action. When non-empty,
-          this job uploads an additional `release-build-output-<artifact-name>` GitHub Actions artifact. See
-          https://github.com/rapidsai/shared-actions/tree/main/release-build-output for configuration details.
+          Optional JSON configuration for the shared-actions release catalog companion. When non-empty, this job
+          uploads an additional `release-catalog-<artifact-name>` GitHub Actions artifact. See
+          https://github.com/rapidsai/shared-actions/tree/main/release-catalog for configuration details.
         default: ''
         type: string
         required: false
@@ -236,9 +236,9 @@ jobs:
           name: ${{ inputs.artifact-name }}
           path: ${{ inputs.file_to_upload }}
           if-no-files-found: ignore
-      - name: Create release build-output companion
+      - name: Create release catalog companion
         if: ${{ inputs.release-catalog-config != '' }}
-        uses: rapidsai/shared-actions/release-build-output-dispatch@a18a4a7ac572366c09c15641ec274cc6f15bfb5d # agent/release-build-output-container
+        uses: rapidsai/shared-actions/release-catalog-dispatch@45e84f709fde5e3f1b5960ed0510599c5f388333 # shared-actions PR 136
         with:
           config: ${{ inputs.release-catalog-config }}
           source-artifact-name: ${{ inputs.artifact-name }}

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -243,7 +243,7 @@ jobs:
           if-no-files-found: ignore
       - name: Create release catalog companion
         if: ${{ inputs.build_type == 'release-candidate' && inputs.release-catalog-config != '' }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@d2f44b9e8cd705357c8e12c0b07fea3dd9b893a0 # shared-actions PR 136 candidate-store head
+        uses: rapidsai/shared-actions/release-catalog-dispatch@d2f44b948645ee187102bf586d2ea44596a637c1 # shared-actions PR 136 candidate-store head
         with:
           config: ${{ inputs.release-catalog-config }}
           source-artifact-name: ${{ inputs.artifact-name }}

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -238,7 +238,7 @@ jobs:
           if-no-files-found: ignore
       - name: Create release catalog companion
         if: ${{ inputs.release-catalog-config != '' }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@6cdff151c40c97551fdf2abd5d977580f94ed7e1 # shared-actions PR 136
+        uses: rapidsai/shared-actions/release-catalog-dispatch@32a308ab234f7381dd611056747b4c1ac30d2a34 # shared-actions PR 136 canary head
         with:
           config: ${{ inputs.release-catalog-config }}
           source-artifact-name: ${{ inputs.artifact-name }}

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -107,7 +107,9 @@ on:
         required: false
       release-build-config:
         description: >-
-          Optional JSON string with additional configuration for the `shared-actions/release-build-output-dispatch` action. See https://github.com/rapidsai/shared-actions/tree/main/release-build-output for details. If non-empty, creates a release manifest for artifacts produced by this job.
+          Optional JSON configuration for the `shared-actions/release-build-output-dispatch` action. When non-empty,
+          this job uploads an additional `release-build-output-<artifact-name>` GitHub Actions artifact. See
+          https://github.com/rapidsai/shared-actions/tree/main/release-build-output for configuration details.
         default: ''
         type: string
         required: false
@@ -235,12 +237,12 @@ jobs:
           path: ${{ inputs.file_to_upload }}
           if-no-files-found: ignore
       - name: Create release build-output companion
-        if: ${{ inputs.release-build-output != '' }}
+        if: ${{ inputs.release-build-config != '' }}
         uses: rapidsai/shared-actions/release-build-output-dispatch@a18a4a7ac572366c09c15641ec274cc6f15bfb5d # agent/release-build-output-container
         with:
-          config: ${{ inputs.release-build-output }}
+          config: ${{ inputs.release-build-config }}
           source-artifact-name: ${{ inputs.artifact-name }}
-          source-sha: ${{ inputs.sha || github.sha }}
+          source-sha: ${{ env.RAPIDS_SHA }}
       - name: Upload additional artifacts
         if: "!cancelled()"
         run: rapids-upload-artifacts-dir "custom-job-$(arch)"

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -105,12 +105,9 @@ on:
         default: false
         type: boolean
         required: false
-      release-build-output:
+      release-build-config:
         description: >-
-          Optional JSON object describing a custom release package bundle. A non-empty value creates the companion;
-          leave empty for logs, documentation, tests, and other non-release artifacts. Requires artifact_type set to
-          custom, component_id, artifacts, and exactly one of package or package_file; output_directory defaults to
-          '.'. The shared action validates every field before inspecting build outputs.
+          Optional JSON string with additional configuration for the `shared-actions/release-build-output-dispatch` action. See https://github.com/rapidsai/shared-actions/tree/main/release-build-output for details. If non-empty, creates a release manifest for artifacts produced by this job.
         default: ''
         type: string
         required: false

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -105,6 +105,36 @@ on:
         default: false
         type: boolean
         required: false
+      release-build-output:
+        description: "Generate a release-build-output companion for the uploaded artifact bundle"
+        default: false
+        type: boolean
+        required: false
+      release-unit:
+        description: "Stable release-platform unit ID; required when release-build-output is true"
+        default: ''
+        type: string
+        required: false
+      release-package:
+        description: "JSON package identity shared by the bundle; mutually exclusive with release-package-file"
+        default: ''
+        type: string
+        required: false
+      release-package-file:
+        description: "Producer-created package JSON relative to release-output-directory"
+        default: ''
+        type: string
+        required: false
+      release-artifacts:
+        description: "JSON primary-artifact and evidence descriptors relative to release-output-directory"
+        default: ''
+        type: string
+        required: false
+      release-output-directory:
+        description: "Directory containing the primary artifact paths described by release-artifacts"
+        default: '.'
+        type: string
+        required: false
 
 defaults:
   run:
@@ -228,6 +258,18 @@ jobs:
           name: ${{ inputs.artifact-name }}
           path: ${{ inputs.file_to_upload }}
           if-no-files-found: ignore
+      - name: Create release build-output companion
+        if: ${{ inputs.release-build-output }}
+        uses: rapidsai/shared-actions/release-build-output-dispatch@main
+        with:
+          artifact-type: custom
+          output-directory: ${{ inputs.release-output-directory }}
+          release-artifacts: ${{ inputs.release-artifacts }}
+          release-package: ${{ inputs.release-package }}
+          release-package-file: ${{ inputs.release-package-file }}
+          release-unit: ${{ inputs.release-unit }}
+          source-artifact-name: ${{ inputs.artifact-name }}
+          source-sha: ${{ inputs.sha || github.sha }}
       - name: Upload additional artifacts
         if: "!cancelled()"
         run: rapids-upload-artifacts-dir "custom-job-$(arch)"

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -150,7 +150,9 @@ jobs:
       options: ${{ inputs.container-options }}
       env:
         NVIDIA_VISIBLE_DEVICES: ${{ env.NVIDIA_VISIBLE_DEVICES }}
-        RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
+        # Candidate orchestration retains its own input mode, while RAPIDS
+        # build helpers use the established nightly dependency behavior.
+        RAPIDS_BUILD_TYPE: ${{ inputs.build_type == 'release-candidate' && 'nightly' || inputs.build_type }}
         RAPIDS_DATETIME_STRING: ${{ inputs.build-datetime }}
     steps:
       - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -106,33 +106,12 @@ on:
         type: boolean
         required: false
       release-build-output:
-        description: "Generate a release-build-output companion for the uploaded artifact bundle"
-        default: false
-        type: boolean
-        required: false
-      release-unit:
-        description: "Stable release-platform unit ID; required when release-build-output is true"
+        description: >-
+          Optional JSON object describing a custom release package bundle. A non-empty value creates the companion;
+          leave empty for logs, documentation, tests, and other non-release artifacts. Requires artifact_type set to
+          custom, component_id, artifacts, and exactly one of package or package_file; output_directory defaults to
+          '.'. The shared action validates every field before inspecting build outputs.
         default: ''
-        type: string
-        required: false
-      release-package:
-        description: "JSON package identity shared by the bundle; mutually exclusive with release-package-file"
-        default: ''
-        type: string
-        required: false
-      release-package-file:
-        description: "Producer-created package JSON relative to release-output-directory"
-        default: ''
-        type: string
-        required: false
-      release-artifacts:
-        description: "JSON primary-artifact and evidence descriptors relative to release-output-directory"
-        default: ''
-        type: string
-        required: false
-      release-output-directory:
-        description: "Directory containing the primary artifact paths described by release-artifacts"
-        default: '.'
         type: string
         required: false
 
@@ -259,15 +238,10 @@ jobs:
           path: ${{ inputs.file_to_upload }}
           if-no-files-found: ignore
       - name: Create release build-output companion
-        if: ${{ inputs.release-build-output }}
-        uses: rapidsai/shared-actions/release-build-output-dispatch@3a9568fc2c9bc9fd05e4cf76a73d9ad481f93ac5 # agent/release-build-output-container
+        if: ${{ inputs.release-build-output != '' }}
+        uses: rapidsai/shared-actions/release-build-output-dispatch@a18a4a7ac572366c09c15641ec274cc6f15bfb5d # agent/release-build-output-container
         with:
-          artifact-type: custom
-          output-directory: ${{ inputs.release-output-directory }}
-          release-artifacts: ${{ inputs.release-artifacts }}
-          release-package: ${{ inputs.release-package }}
-          release-package-file: ${{ inputs.release-package-file }}
-          release-unit: ${{ inputs.release-unit }}
+          config: ${{ inputs.release-build-output }}
           source-artifact-name: ${{ inputs.artifact-name }}
           source-sha: ${{ inputs.sha || github.sha }}
       - name: Upload additional artifacts

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -238,7 +238,7 @@ jobs:
           if-no-files-found: ignore
       - name: Create release catalog companion
         if: ${{ inputs.release-catalog-config != '' }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@c4b135aba0b7c5e9fa97f384505efeb17b8c5aa9 # shared-actions PR 136
+        uses: rapidsai/shared-actions/release-catalog-dispatch@6cdff151c40c97551fdf2abd5d977580f94ed7e1 # shared-actions PR 136
         with:
           config: ${{ inputs.release-catalog-config }}
           source-artifact-name: ${{ inputs.artifact-name }}

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -2,7 +2,7 @@ on:
   workflow_call:
     inputs:
       build_type:
-        description: "One of: [branch, nightly, pull-request]"
+        description: "One of: [branch, nightly, pull-request, release-candidate]"
         required: true
         type: string
       branch:
@@ -107,12 +107,16 @@ on:
         required: false
       release-catalog-config:
         description: >-
-          Optional JSON configuration for the shared-actions release catalog companion. When non-empty, this job
-          uploads an additional `release-catalog-<artifact-name>` GitHub Actions artifact. See
+          Optional JSON configuration for the shared-actions release catalog action. In release-candidate mode,
+          it writes the declared files and evidence to the private candidate store. See
           https://github.com/rapidsai/shared-actions/tree/main/release-catalog for configuration details.
         default: ''
         type: string
         required: false
+      candidate-train-sha256:
+        description: "Canonical SHA-256 of the release train; required for release-candidate builds."
+        type: string
+        default: ""
 
 defaults:
   run:
@@ -231,19 +235,22 @@ jobs:
           MAMBA_USE_SHARDED_REPODATA: false
           RATTLER_SHARDED: false
       - name: Upload file to GitHub Artifact
+        if: ${{ inputs.build_type != 'release-candidate' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ inputs.artifact-name }}
           path: ${{ inputs.file_to_upload }}
           if-no-files-found: ignore
       - name: Create release catalog companion
-        if: ${{ inputs.release-catalog-config != '' }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@32a308ab234f7381dd611056747b4c1ac30d2a34 # shared-actions PR 136 canary head
+        if: ${{ inputs.build_type == 'release-candidate' && inputs.release-catalog-config != '' }}
+        uses: rapidsai/shared-actions/release-catalog-dispatch@8fef990732014851c3d5afcf931c2506f7e175b0 # shared-actions PR 136 candidate-store head
         with:
           config: ${{ inputs.release-catalog-config }}
           source-artifact-name: ${{ inputs.artifact-name }}
+          candidate-train-sha256: ${{ inputs.candidate-train-sha256 }}
+          upload-to-s3: 'true'
       - name: Upload additional artifacts
-        if: "!cancelled()"
+        if: ${{ !cancelled() && inputs.build_type != 'release-candidate' }}
         run: rapids-upload-artifacts-dir "custom-job-$(arch)"
       - name: Telemetry upload attributes
         uses: rapidsai/shared-actions/telemetry-dispatch-stash-job-artifacts@main

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -105,7 +105,7 @@ on:
         default: false
         type: boolean
         required: false
-      release-build-config:
+      release-catalog-config:
         description: >-
           Optional JSON configuration for the `shared-actions/release-build-output-dispatch` action. When non-empty,
           this job uploads an additional `release-build-output-<artifact-name>` GitHub Actions artifact. See
@@ -237,10 +237,10 @@ jobs:
           path: ${{ inputs.file_to_upload }}
           if-no-files-found: ignore
       - name: Create release build-output companion
-        if: ${{ inputs.release-build-config != '' }}
+        if: ${{ inputs.release-catalog-config != '' }}
         uses: rapidsai/shared-actions/release-build-output-dispatch@a18a4a7ac572366c09c15641ec274cc6f15bfb5d # agent/release-build-output-container
         with:
-          config: ${{ inputs.release-build-config }}
+          config: ${{ inputs.release-catalog-config }}
           source-artifact-name: ${{ inputs.artifact-name }}
           source-sha: ${{ env.RAPIDS_SHA }}
       - name: Upload additional artifacts

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -117,6 +117,10 @@ on:
         description: "Canonical SHA-256 of the release train; required for release-candidate builds."
         type: string
         default: ""
+      release-candidate-tag:
+        description: "Final source tag created locally for a release-candidate build; it is never pushed."
+        type: string
+        default: ""
 
 defaults:
   run:
@@ -153,6 +157,7 @@ jobs:
         # Candidate orchestration retains its own input mode, while RAPIDS
         # build helpers use the established nightly dependency behavior.
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type == 'release-candidate' && 'nightly' || inputs.build_type }}
+        RAPIDS_RELEASE_CANDIDATE: ${{ inputs.build_type == 'release-candidate' }}
         RAPIDS_DATETIME_STRING: ${{ inputs.build-datetime }}
     steps:
       - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
@@ -166,6 +171,15 @@ jobs:
           ref: ${{ inputs.sha }}
           fetch-depth: 0
           persist-credentials: true
+      - name: Create local release-candidate tag
+        if: ${{ inputs.build_type == 'release-candidate' }}
+        env:
+          RELEASE_CANDIDATE_TAG: ${{ inputs.release-candidate-tag }}
+          RELEASE_CANDIDATE_SHA: ${{ inputs.sha }}
+        run: |
+          test -n "${RELEASE_CANDIDATE_TAG}"
+          git tag --force "${RELEASE_CANDIDATE_TAG}" "${RELEASE_CANDIDATE_SHA}"
+          git show-ref --verify --quiet "refs/tags/${RELEASE_CANDIDATE_TAG}"
       - name: Telemetry setup
         uses: rapidsai/shared-actions/telemetry-dispatch-setup@main
         continue-on-error: true
@@ -252,7 +266,7 @@ jobs:
           role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-rapids-release-candidates
       - name: Create release catalog companion
         if: ${{ inputs.build_type == 'release-candidate' && inputs.release-catalog-config != '' }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@f2e2c3621f5fc8b77b3c0dc669d60f817b1d05eb # shared-actions PR 136 candidate-store head
+        uses: rapidsai/shared-actions/release-catalog-dispatch@079aafb321c9a87d5741a79234d65ad30f1e9bb0 # shared-actions PR 136 candidate-store head
         with:
           config: ${{ inputs.release-catalog-config }}
           source-artifact-name: ${{ inputs.artifact-name }}

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -241,6 +241,13 @@ jobs:
           name: ${{ inputs.artifact-name }}
           path: ${{ inputs.file_to_upload }}
           if-no-files-found: ignore
+      - name: Configure release-candidate store credentials
+        if: ${{ inputs.build_type == 'release-candidate' }}
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
+        with:
+          aws-region: us-east-2
+          role-duration-seconds: 43200 # 12h
+          role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-rapids-release-candidates
       - name: Create release catalog companion
         if: ${{ inputs.build_type == 'release-candidate' && inputs.release-catalog-config != '' }}
         uses: rapidsai/shared-actions/release-catalog-dispatch@d2f44b948645ee187102bf586d2ea44596a637c1 # shared-actions PR 136 candidate-store head

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -260,7 +260,7 @@ jobs:
           if-no-files-found: ignore
       - name: Create release build-output companion
         if: ${{ inputs.release-build-output }}
-        uses: msarahan/shared-actions/release-build-output-dispatch@76acdd577825aefd04d8ea143449101b707acee6 # agent/release-build-output-container
+        uses: rapidsai/shared-actions/release-build-output-dispatch@3a9568fc2c9bc9fd05e4cf76a73d9ad481f93ac5 # agent/release-build-output-container
         with:
           artifact-type: custom
           output-directory: ${{ inputs.release-output-directory }}

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -250,7 +250,7 @@ jobs:
           role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-rapids-release-candidates
       - name: Create release catalog companion
         if: ${{ inputs.build_type == 'release-candidate' && inputs.release-catalog-config != '' }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@d2f44b948645ee187102bf586d2ea44596a637c1 # shared-actions PR 136 candidate-store head
+        uses: rapidsai/shared-actions/release-catalog-dispatch@f2e2c3621f5fc8b77b3c0dc669d60f817b1d05eb # shared-actions PR 136 candidate-store head
         with:
           config: ${{ inputs.release-catalog-config }}
           source-artifact-name: ${{ inputs.artifact-name }}

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -260,7 +260,7 @@ jobs:
           if-no-files-found: ignore
       - name: Create release build-output companion
         if: ${{ inputs.release-build-output }}
-        uses: rapidsai/shared-actions/release-build-output-dispatch@main
+        uses: msarahan/shared-actions/release-build-output-dispatch@76acdd577825aefd04d8ea143449101b707acee6 # agent/release-build-output-container
         with:
           artifact-type: custom
           output-directory: ${{ inputs.release-output-directory }}

--- a/.github/workflows/custom-job.yaml
+++ b/.github/workflows/custom-job.yaml
@@ -242,7 +242,6 @@ jobs:
         with:
           config: ${{ inputs.release-catalog-config }}
           source-artifact-name: ${{ inputs.artifact-name }}
-          source-sha: ${{ env.RAPIDS_SHA }}
       - name: Upload additional artifacts
         if: "!cancelled()"
         run: rapids-upload-artifacts-dir "custom-job-$(arch)"

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -305,7 +305,7 @@ jobs:
           config: >-
             {
               "artifact_type": "wheel",
-              "component_id": ${{ toJSON(format('wheel:{0}', github.event.repository.name)) }},
+              "release_catalog_key": ${{ toJSON(format('wheel:{0}', github.event.repository.name)) }},
               "output_directory": ${{ toJSON(steps.package-name.outputs.WHEEL_OUTPUT_DIR) }}
             }
           source-artifact-name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -302,6 +302,13 @@ jobs:
           name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
           path: ${{ steps.package-name.outputs.WHEEL_OUTPUT_DIR }}
 
+      - name: Configure release-candidate store credentials
+        if: ${{ inputs.build_type == 'release-candidate' }}
+        uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
+        with:
+          aws-region: us-east-2
+          role-duration-seconds: 43200 # 12h
+          role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-rapids-release-candidates
       - name: Create wheel release catalog companion
         if: ${{ inputs.build_type == 'release-candidate' }}
         uses: rapidsai/shared-actions/release-catalog-dispatch@d2f44b948645ee187102bf586d2ea44596a637c1 # shared-actions PR 136 candidate-store head

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -75,14 +75,6 @@ on:
         default: true
         required: false
         description: "One of [true, false], true if artifacts should be uploaded to GitHub's artifact store"
-      release-unit:
-        type: string
-        default: ''
-        required: false
-        description: >-
-          Release component ID: a string label, not a file or bundle. It is written to each manifest entry and groups
-          files and matrix variants for release assembly. Leave empty to use wheel:<repository-name>; override only
-          when one repository's wheel producers must be tracked as distinct components.
       extra-repo:
         required: false
         type: string
@@ -313,11 +305,11 @@ jobs:
           config: >-
             {
               "artifact_type": "wheel",
-              "component_id": ${{ toJSON(inputs.release-unit || format('wheel:{0}', github.event.repository.name)) }},
+              "component_id": ${{ toJSON(format('wheel:{0}', github.event.repository.name)) }},
               "output_directory": ${{ toJSON(steps.package-name.outputs.WHEEL_OUTPUT_DIR) }}
             }
           source-artifact-name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
-          source-sha: ${{ inputs.sha || github.sha }}
+          source-sha: ${{ env.RAPIDS_SHA }}
 
       - name: Upload additional artifacts
         if: "!cancelled()"

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -300,7 +300,7 @@ jobs:
 
       - name: Create wheel release catalog companion
         if: ${{ inputs.upload-artifacts }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@c4b135aba0b7c5e9fa97f384505efeb17b8c5aa9 # shared-actions PR 136
+        uses: rapidsai/shared-actions/release-catalog-dispatch@6cdff151c40c97551fdf2abd5d977580f94ed7e1 # shared-actions PR 136
         with:
           config: >-
             {

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -300,7 +300,7 @@ jobs:
 
       - name: Create wheel release catalog companion
         if: ${{ inputs.upload-artifacts }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@6cdff151c40c97551fdf2abd5d977580f94ed7e1 # shared-actions PR 136
+        uses: rapidsai/shared-actions/release-catalog-dispatch@32a308ab234f7381dd611056747b4c1ac30d2a34 # shared-actions PR 136 canary head
         with:
           config: >-
             {

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -79,6 +79,10 @@ on:
         description: "Canonical SHA-256 of the release train; required for release-candidate builds."
         type: string
         default: ""
+      release-candidate-tag:
+        description: "Final source tag created locally for a release-candidate build; it is never pushed."
+        type: string
+        default: ""
       extra-repo:
         required: false
         type: string
@@ -155,6 +159,7 @@ jobs:
         # Candidate orchestration retains its own input mode, while RAPIDS
         # build helpers use the established nightly dependency behavior.
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type == 'release-candidate' && 'nightly' || inputs.build_type }}
+        RAPIDS_RELEASE_CANDIDATE: ${{ inputs.build_type == 'release-candidate' }}
         RAPIDS_DATETIME_STRING: ${{ inputs.build-datetime }}
     steps:
       - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
@@ -170,6 +175,16 @@ jobs:
           ref: ${{ inputs.sha }}
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Create local release-candidate tag
+        if: ${{ inputs.build_type == 'release-candidate' }}
+        env:
+          RELEASE_CANDIDATE_TAG: ${{ inputs.release-candidate-tag }}
+          RELEASE_CANDIDATE_SHA: ${{ inputs.sha }}
+        run: |
+          test -n "${RELEASE_CANDIDATE_TAG}"
+          git tag --force "${RELEASE_CANDIDATE_TAG}" "${RELEASE_CANDIDATE_SHA}"
+          git show-ref --verify --quiet "refs/tags/${RELEASE_CANDIDATE_TAG}"
 
       - name: Standardize repository information
         uses: rapidsai/shared-actions/rapids-github-info@main
@@ -313,7 +328,7 @@ jobs:
           role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-rapids-release-candidates
       - name: Create wheel release catalog companion
         if: ${{ inputs.build_type == 'release-candidate' }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@f2e2c3621f5fc8b77b3c0dc669d60f817b1d05eb # shared-actions PR 136 candidate-store head
+        uses: rapidsai/shared-actions/release-catalog-dispatch@079aafb321c9a87d5741a79234d65ad30f1e9bb0 # shared-actions PR 136 candidate-store head
         with:
           config: >-
             {

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -79,7 +79,10 @@ on:
         type: string
         default: ''
         required: false
-        description: "Override the release-platform unit ID; defaults to wheel:<repository-name>"
+        description: >-
+          Release component ID: a string label, not a file or bundle. It is written to each manifest entry and groups
+          files and matrix variants for release assembly. Leave empty to use wheel:<repository-name>; override only
+          when one repository's wheel producers must be tracked as distinct components.
       extra-repo:
         required: false
         type: string
@@ -305,11 +308,14 @@ jobs:
 
       - name: Create wheel release build-output companion
         if: ${{ inputs.upload-artifacts }}
-        uses: rapidsai/shared-actions/release-build-output-dispatch@3a9568fc2c9bc9fd05e4cf76a73d9ad481f93ac5 # agent/release-build-output-container
+        uses: rapidsai/shared-actions/release-build-output-dispatch@a18a4a7ac572366c09c15641ec274cc6f15bfb5d # agent/release-build-output-container
         with:
-          artifact-type: wheel
-          output-directory: ${{ steps.package-name.outputs.WHEEL_OUTPUT_DIR }}
-          release-unit: ${{ inputs.release-unit || format('wheel:{0}', github.event.repository.name) }}
+          config: >-
+            {
+              "artifact_type": "wheel",
+              "component_id": ${{ toJSON(inputs.release-unit || format('wheel:{0}', github.event.repository.name)) }},
+              "output_directory": ${{ toJSON(steps.package-name.outputs.WHEEL_OUTPUT_DIR) }}
+            }
           source-artifact-name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
           source-sha: ${{ inputs.sha || github.sha }}
 

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -304,7 +304,7 @@ jobs:
 
       - name: Create wheel release catalog companion
         if: ${{ inputs.build_type == 'release-candidate' }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@8fef990732014851c3d5afcf931c2506f7e175b0 # shared-actions PR 136 candidate-store head
+        uses: rapidsai/shared-actions/release-catalog-dispatch@d2f44b9e8cd705357c8e12c0b07fea3dd9b893a0 # shared-actions PR 136 candidate-store head
         with:
           config: >-
             {

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -305,7 +305,7 @@ jobs:
           config: >-
             {
               "release_catalog_key": ${{ toJSON(format('wheel:{0}', github.event.repository.name)) }},
-              "output_directory": ${{ toJSON(steps.package-name.outputs.WHEEL_OUTPUT_DIR) }}
+              "artifact_directory": ${{ toJSON(steps.package-name.outputs.WHEEL_OUTPUT_DIR) }}
             }
           source-artifact-name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
           source-sha: ${{ env.RAPIDS_SHA }}

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -305,7 +305,7 @@ jobs:
 
       - name: Create wheel release build-output companion
         if: ${{ inputs.upload-artifacts }}
-        uses: rapidsai/shared-actions/release-build-output-dispatch@main
+        uses: msarahan/shared-actions/release-build-output-dispatch@76acdd577825aefd04d8ea143449101b707acee6 # agent/release-build-output-container
         with:
           artifact-type: wheel
           output-directory: ${{ steps.package-name.outputs.WHEEL_OUTPUT_DIR }}

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -305,7 +305,7 @@ jobs:
 
       - name: Create wheel release build-output companion
         if: ${{ inputs.upload-artifacts }}
-        uses: msarahan/shared-actions/release-build-output-dispatch@76acdd577825aefd04d8ea143449101b707acee6 # agent/release-build-output-container
+        uses: rapidsai/shared-actions/release-build-output-dispatch@3a9568fc2c9bc9fd05e4cf76a73d9ad481f93ac5 # agent/release-build-output-container
         with:
           artifact-type: wheel
           output-directory: ${{ steps.package-name.outputs.WHEEL_OUTPUT_DIR }}

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -152,7 +152,9 @@ jobs:
     container:
       image: "rapidsai/ci-wheel:26.10-cuda${{ matrix.CUDA_VER }}-${{ matrix.LINUX_VER }}-py${{ matrix.PY_VER }}"
       env:
-        RAPIDS_BUILD_TYPE: ${{ inputs.build_type }}
+        # Candidate orchestration retains its own input mode, while RAPIDS
+        # build helpers use the established nightly dependency behavior.
+        RAPIDS_BUILD_TYPE: ${{ inputs.build_type == 'release-candidate' && 'nightly' || inputs.build_type }}
         RAPIDS_DATETIME_STRING: ${{ inputs.build-datetime }}
     steps:
       - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -304,7 +304,6 @@ jobs:
         with:
           config: >-
             {
-              "artifact_type": "wheel",
               "release_catalog_key": ${{ toJSON(format('wheel:{0}', github.event.repository.name)) }},
               "output_directory": ${{ toJSON(steps.package-name.outputs.WHEEL_OUTPUT_DIR) }}
             }

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -298,9 +298,9 @@ jobs:
           name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
           path: ${{ steps.package-name.outputs.WHEEL_OUTPUT_DIR }}
 
-      - name: Create wheel release build-output companion
+      - name: Create wheel release catalog companion
         if: ${{ inputs.upload-artifacts }}
-        uses: rapidsai/shared-actions/release-build-output-dispatch@a18a4a7ac572366c09c15641ec274cc6f15bfb5d # agent/release-build-output-container
+        uses: rapidsai/shared-actions/release-catalog-dispatch@45e84f709fde5e3f1b5960ed0510599c5f388333 # shared-actions PR 136
         with:
           config: >-
             {

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -300,7 +300,7 @@ jobs:
 
       - name: Create wheel release catalog companion
         if: ${{ inputs.upload-artifacts }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@45e84f709fde5e3f1b5960ed0510599c5f388333 # shared-actions PR 136
+        uses: rapidsai/shared-actions/release-catalog-dispatch@c4b135aba0b7c5e9fa97f384505efeb17b8c5aa9 # shared-actions PR 136
         with:
           config: >-
             {

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -308,7 +308,6 @@ jobs:
               "artifact_directory": ${{ toJSON(steps.package-name.outputs.WHEEL_OUTPUT_DIR) }}
             }
           source-artifact-name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
-          source-sha: ${{ env.RAPIDS_SHA }}
 
       - name: Upload additional artifacts
         if: "!cancelled()"

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -75,6 +75,11 @@ on:
         default: true
         required: false
         description: "One of [true, false], true if artifacts should be uploaded to GitHub's artifact store"
+      release-unit:
+        type: string
+        default: ''
+        required: false
+        description: "Override the release-platform unit ID; defaults to wheel:<repository-name>"
       extra-repo:
         required: false
         type: string
@@ -297,6 +302,16 @@ jobs:
           if-no-files-found: 'error'
           name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
           path: ${{ steps.package-name.outputs.WHEEL_OUTPUT_DIR }}
+
+      - name: Create wheel release build-output companion
+        if: ${{ inputs.upload-artifacts }}
+        uses: rapidsai/shared-actions/release-build-output-dispatch@main
+        with:
+          artifact-type: wheel
+          output-directory: ${{ steps.package-name.outputs.WHEEL_OUTPUT_DIR }}
+          release-unit: ${{ inputs.release-unit || format('wheel:{0}', github.event.repository.name) }}
+          source-artifact-name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
+          source-sha: ${{ inputs.sha || github.sha }}
 
       - name: Upload additional artifacts
         if: "!cancelled()"

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -160,6 +160,7 @@ jobs:
         # build helpers use the established nightly dependency behavior.
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type == 'release-candidate' && 'nightly' || inputs.build_type }}
         RAPIDS_RELEASE_CANDIDATE: ${{ inputs.build_type == 'release-candidate' }}
+        GITHUB_REF: ${{ inputs.build_type == 'release-candidate' && format('refs/tags/{0}', inputs.release-candidate-tag) || github.ref }}
         RAPIDS_DATETIME_STRING: ${{ inputs.build-datetime }}
     steps:
       - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -26,7 +26,7 @@ on:
         description: "Git repo to check out, in '{org}/{repo}' form, e.g. 'rapidsai/cudf'"
         type: string
       build_type:
-        description: "One of: [branch, nightly, pull-request]"
+        description: "One of: [branch, nightly, pull-request, release-candidate]"
         required: true
         type: string
       script:
@@ -75,6 +75,10 @@ on:
         default: true
         required: false
         description: "One of [true, false], true if artifacts should be uploaded to GitHub's artifact store"
+      candidate-train-sha256:
+        description: "Canonical SHA-256 of the release train; required for release-candidate builds."
+        type: string
+        default: ""
       extra-repo:
         required: false
         type: string
@@ -251,7 +255,7 @@ jobs:
         shell: bash -leo pipefail {0}
 
       - name: Get package name
-        if: ${{ inputs.upload-artifacts }}
+        if: ${{ inputs.upload-artifacts || inputs.build_type == 'release-candidate' }}
         env:
           # Pass RAPIDS_PACKAGE_NAME from build-wheel step if available
           RAPIDS_PACKAGE_NAME: ${{ steps.build-wheel.outputs.rapids-package-name }}
@@ -284,7 +288,7 @@ jobs:
         id: package-name
 
       - name: Show files to be uploaded
-        if: ${{ inputs.upload-artifacts }}
+        if: ${{ inputs.upload-artifacts || inputs.build_type == 'release-candidate' }}
         env:
           WHEEL_OUTPUT_DIR: ${{ steps.package-name.outputs.WHEEL_OUTPUT_DIR }}
         run: |
@@ -292,15 +296,15 @@ jobs:
           ls -R "$WHEEL_OUTPUT_DIR"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: ${{ inputs.upload-artifacts }}
+        if: ${{ inputs.upload-artifacts && inputs.build_type != 'release-candidate' }}
         with:
           if-no-files-found: 'error'
           name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
           path: ${{ steps.package-name.outputs.WHEEL_OUTPUT_DIR }}
 
       - name: Create wheel release catalog companion
-        if: ${{ inputs.upload-artifacts }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@32a308ab234f7381dd611056747b4c1ac30d2a34 # shared-actions PR 136 canary head
+        if: ${{ inputs.build_type == 'release-candidate' }}
+        uses: rapidsai/shared-actions/release-catalog-dispatch@8fef990732014851c3d5afcf931c2506f7e175b0 # shared-actions PR 136 candidate-store head
         with:
           config: >-
             {
@@ -308,9 +312,11 @@ jobs:
               "artifact_directory": ${{ toJSON(steps.package-name.outputs.WHEEL_OUTPUT_DIR) }}
             }
           source-artifact-name: ${{ steps.package-name.outputs.RAPIDS_PACKAGE_NAME }}
+          candidate-train-sha256: ${{ inputs.candidate-train-sha256 }}
+          upload-to-s3: 'true'
 
       - name: Upload additional artifacts
-        if: "!cancelled()"
+        if: ${{ !cancelled() && inputs.build_type != 'release-candidate' }}
         run: rapids-upload-artifacts-dir "cuda${RAPIDS_CUDA_VERSION%%.*}_$(arch)_py${RAPIDS_PY_VERSION//.}"
       - name: Telemetry upload attributes
         if: ${{ vars.TELEMETRY_ENABLED == 'true' }}

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -304,7 +304,7 @@ jobs:
 
       - name: Create wheel release catalog companion
         if: ${{ inputs.build_type == 'release-candidate' }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@d2f44b9e8cd705357c8e12c0b07fea3dd9b893a0 # shared-actions PR 136 candidate-store head
+        uses: rapidsai/shared-actions/release-catalog-dispatch@d2f44b948645ee187102bf586d2ea44596a637c1 # shared-actions PR 136 candidate-store head
         with:
           config: >-
             {

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -311,7 +311,7 @@ jobs:
           role-to-assume: arn:aws:iam::279114543810:role/gha-oidc-rapids-release-candidates
       - name: Create wheel release catalog companion
         if: ${{ inputs.build_type == 'release-candidate' }}
-        uses: rapidsai/shared-actions/release-catalog-dispatch@d2f44b948645ee187102bf586d2ea44596a637c1 # shared-actions PR 136 candidate-store head
+        uses: rapidsai/shared-actions/release-catalog-dispatch@f2e2c3621f5fc8b77b3c0dc669d60f817b1d05eb # shared-actions PR 136 candidate-store head
         with:
           config: >-
             {

--- a/.github/workflows/wheels-build.yaml
+++ b/.github/workflows/wheels-build.yaml
@@ -160,7 +160,6 @@ jobs:
         # build helpers use the established nightly dependency behavior.
         RAPIDS_BUILD_TYPE: ${{ inputs.build_type == 'release-candidate' && 'nightly' || inputs.build_type }}
         RAPIDS_RELEASE_CANDIDATE: ${{ inputs.build_type == 'release-candidate' }}
-        GITHUB_REF: ${{ inputs.build_type == 'release-candidate' && format('refs/tags/{0}', inputs.release-candidate-tag) || github.ref }}
         RAPIDS_DATETIME_STRING: ${{ inputs.build-datetime }}
     steps:
       - uses: aws-actions/configure-aws-credentials@517a711dbcd0e402f90c77e7e2f81e849156e31d # v6.2.2
@@ -185,7 +184,15 @@ jobs:
         run: |
           test -n "${RELEASE_CANDIDATE_TAG}"
           git tag --force "${RELEASE_CANDIDATE_TAG}" "${RELEASE_CANDIDATE_SHA}"
+          git remote set-url --push origin no_push
           git show-ref --verify --quiet "refs/tags/${RELEASE_CANDIDATE_TAG}"
+      - name: Force local release-candidate build context
+        if: ${{ inputs.build_type == 'release-candidate' }}
+        run: |
+          mkdir -p "${RUNNER_TEMP}/release-candidate-tools"
+          printf '%s\n' '#!/usr/bin/env bash' 'exit 0' > "${RUNNER_TEMP}/release-candidate-tools/rapids-is-release-build"
+          chmod +x "${RUNNER_TEMP}/release-candidate-tools/rapids-is-release-build"
+          echo "${RUNNER_TEMP}/release-candidate-tools" >> "${GITHUB_PATH}"
 
       - name: Standardize repository information
         uses: rapidsai/shared-actions/rapids-github-info@main

--- a/.github/workflows/wheels-publish.yaml
+++ b/.github/workflows/wheels-publish.yaml
@@ -18,7 +18,7 @@ on:
         description: "Git repo to check out, in '{org}/{repo}' form, e.g. 'rapidsai/cudf'"
         type: string
       build_type:
-        description: "One of: [branch, nightly, pull-request]"
+        description: "One of: [branch, nightly, pull-request, release-candidate]"
         required: true
         type: string
 
@@ -73,6 +73,9 @@ permissions:
 jobs:
   wheel-publish:
     name: wheels publish
+    # Candidate artifacts are staged privately by the build workflow. They must
+    # not enter public Anaconda.org or PyPI channels before rollover approval.
+    if: ${{ inputs.build_type != 'release-candidate' }}
     # Use a self-hosted runner to ensure we have sufficient disk space. Using
     # cpu8 since we shouldn't need much CPU horsepower.
     runs-on: "linux-amd64-cpu8"

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ bundle.
 
 `custom-job.yaml` can be used to produce artifacts, but the generation of extra
 metadata files are opt-in, not automatic. Supplying a non-empty
-`release-build-config` causes the job to upload the additional
+`release-catalog-config` causes the job to upload the additional
 release-build-output artifact; leaving it empty uploads only the original
 artifact.
 

--- a/README.md
+++ b/README.md
@@ -20,23 +20,6 @@ Reusable workflows must be placed in the `.github/workflows` directory as mentio
 
 ## Usage
 
-### Release build outputs
-
-The standard Conda and wheel builders upload an additional
-`release-build-output-<artifact-name>` GitHub Actions artifact for every package
-bundle. It contains build metadata and the available provenance and SBOM
-evidence used during release assembly.
-
-`custom-job.yaml` is opt-in. Supplying a non-empty `release-build-config` causes
-the job to upload the additional release-build-output artifact; leaving it empty
-uploads only the original artifact.
-
-See the
-[`shared-actions` release-build-output documentation](https://github.com/rapidsai/shared-actions/tree/main/release-build-output)
-for the companion layout, configuration schema, examples, and evidence
-semantics. A generated identity-only SPDX record identifies and hashes an
-artifact, but does not provide dependency or source-license coverage.
-
 ### matrix_filter
 
 Several of the workflows in this project have matrices (combinations of workflow inputs) expressed in inline YAML/JSON.
@@ -113,3 +96,23 @@ wheel-tests:
 ```
 
 Values passed through `secrets:` are redacted everywhere in the GitHub UI, including in logs, and in most cases are replaced with `***`.
+
+### Release build outputs
+
+We add additional metadata files to our builds to help track what dependencies
+were present at build time (a Software Bill of Materials, SBoM), as well as
+keeping track of artifacts as we prepare for releases. The standard Conda and
+wheel builders do this automatically and upload an additional
+`release-build-output-<artifact-name>` GitHub Actions artifact for every package
+bundle.
+
+`custom-job.yaml` can be used to produce artifacts, but the generation of extra
+metadata files are opt-in, not automatic. Supplying a non-empty
+`release-build-config` causes the job to upload the additional
+release-build-output artifact; leaving it empty uploads only the original
+artifact.
+
+See the
+[`shared-actions` release-build-output documentation](https://github.com/rapidsai/shared-actions/tree/main/release-build-output)
+for the companion layout, configuration schema, examples, and evidence
+semantics.

--- a/README.md
+++ b/README.md
@@ -29,20 +29,38 @@ source-artifact name, and original files authoritative and avoids a second
 runner and artifact download.
 
 The standard wheel and Conda builders create a companion for every uploaded
-bundle. The release unit defaults to `wheel:<repository-name>` or
+bundle. The release component ID defaults to `wheel:<repository-name>` or
 `conda:<repository-name>` and can be overridden with `release-unit` when the
-release-platform catalog uses a different ID. The shared action reads exact
-package metadata from the built files and uploads
+release catalog needs to track multiple producer families in one repository as
+distinct components. `release-unit` is the API's historical name for this ID.
+It is a string label, not a file, directory, artifact bundle, or list of files.
+The same ID is written on every primary file in the component and is reused
+across its matrix variants, such as CUDA version, Python version, and
+architecture, so release assembly can group those outputs together. Most
+standard Conda and wheel callers should leave `release-unit` unset. The shared
+action reads exact package metadata from the built files and uploads
 `release-build-output-<artifact-name>`. No release-specific caller
 configuration is required for the standard builders.
 
-`custom-job.yaml` remains explicitly opt-in through `release-build-output` and
-also requires `release-unit`, `release-output-directory`, `release-artifacts`,
-and either `release-package` or
-`release-package-file`. Descriptors may name producer-supplied SBOM,
-provenance, and signature sidecars relative to the output directory. Each path
-or glob must resolve to exactly one file; the action never guesses a release
-artifact.
+`custom-job.yaml` remains explicitly opt-in through one `release-build-output`
+JSON object. An empty string disables companion generation. A non-empty object
+requires `artifact_type: custom`, `component_id`, a non-empty `artifacts`
+array, and exactly one of `package` or `package_file`; `output_directory`
+defaults to the job's working directory. Descriptors may name
+producer-supplied SBOM, provenance, and
+signature sidecars relative to the output directory. Each path or glob must
+resolve to exactly one file; the action never guesses a release artifact.
+
+| Custom-job input | Why and when to use it |
+| --- | --- |
+| `release-build-output` | Supply one complete JSON configuration only when the upload is a release package bundle. Its presence enables companion generation; an empty value disables it. The shared action reports malformed JSON, unknown keys, missing fields, conflicting package sources, and invalid artifact descriptors before materialization. |
+
+The canonical schema is
+[`release-build-output/config.schema.json`](https://github.com/rapidsai/shared-actions/blob/a18a4a7ac572366c09c15641ec274cc6f15bfb5d/release-build-output/config.schema.json).
+Pre-commit exercises the schema validator against valid and invalid fixtures.
+The pipeline additionally checks properties that cannot be known before the
+build, including whether package files and artifact/evidence globs resolve to
+exactly one file.
 
 ```yaml
 cuvs-java-build:
@@ -51,11 +69,14 @@ cuvs-java-build:
     # existing build inputs omitted
     artifact-name: cuvs-java-cuda12.9.1
     file_to_upload: java/cuvs-java/target/
-    release-build-output: true
-    release-output-directory: java/cuvs-java/target
-    release-unit: maven:cuvs-java
-    release-package-file: cuvs-java.release-package.json
-    release-artifacts: '[{"path":"cuvs-java-*-x86_64-cuda*.jar"}]'
+    release-build-output: >-
+      {
+        "artifact_type": "custom",
+        "component_id": "maven:cuvs-java",
+        "output_directory": "java/cuvs-java/target",
+        "package_file": "cuvs-java.release-package.json",
+        "artifacts": [{"path": "cuvs-java-*-x86_64-cuda*.jar"}]
+      }
 ```
 
 The release coordinator downloads both artifacts into the same directory, for

--- a/README.md
+++ b/README.md
@@ -20,87 +20,22 @@ Reusable workflows must be placed in the `.github/workflows` directory as mentio
 
 ## Usage
 
-### release-build-output
+### Release build outputs
 
-Release build-output companions are created inside the producer job by the
-[`release-build-output-dispatch`](https://github.com/rapidsai/shared-actions/tree/main/release-build-output-dispatch)
-shared action. Running beside the build keeps the producer's matrix,
-source-artifact name, and original files authoritative and avoids a second
-runner and artifact download.
+The standard Conda and wheel builders upload an additional
+`release-build-output-<artifact-name>` GitHub Actions artifact for every package
+bundle. It contains build metadata and the available provenance and SBOM
+evidence used during release assembly.
 
-The standard wheel and Conda builders create a companion for every uploaded
-bundle. The release component ID defaults to `wheel:<repository-name>` or
-`conda:<repository-name>` and can be overridden with `release-unit` when the
-release catalog needs to track multiple producer families in one repository as
-distinct components. `release-unit` is the API's historical name for this ID.
-It is a string label, not a file, directory, artifact bundle, or list of files.
-The same ID is written on every primary file in the component and is reused
-across its matrix variants, such as CUDA version, Python version, and
-architecture, so release assembly can group those outputs together. Most
-standard Conda and wheel callers should leave `release-unit` unset. The shared
-action reads exact package metadata from the built files and uploads
-`release-build-output-<artifact-name>`. No release-specific caller
-configuration is required for the standard builders.
+`custom-job.yaml` is opt-in. Supplying a non-empty `release-build-config` causes
+the job to upload the additional release-build-output artifact; leaving it empty
+uploads only the original artifact.
 
-`custom-job.yaml` remains explicitly opt-in through one `release-build-output`
-JSON object. An empty string disables companion generation. A non-empty object
-requires `artifact_type: custom`, `component_id`, a non-empty `artifacts`
-array, and exactly one of `package` or `package_file`; `output_directory`
-defaults to the job's working directory. Descriptors may name
-producer-supplied SBOM, provenance, and
-signature sidecars relative to the output directory. Each path or glob must
-resolve to exactly one file; the action never guesses a release artifact.
-
-| Custom-job input | Why and when to use it |
-| --- | --- |
-| `release-build-output` | Supply one complete JSON configuration only when the upload is a release package bundle. Its presence enables companion generation; an empty value disables it. The shared action reports malformed JSON, unknown keys, missing fields, conflicting package sources, and invalid artifact descriptors before materialization. |
-
-The canonical schema is
-[`release-build-output/config.schema.json`](https://github.com/rapidsai/shared-actions/blob/a18a4a7ac572366c09c15641ec274cc6f15bfb5d/release-build-output/config.schema.json).
-Pre-commit exercises the schema validator against valid and invalid fixtures.
-The pipeline additionally checks properties that cannot be known before the
-build, including whether package files and artifact/evidence globs resolve to
-exactly one file.
-
-```yaml
-cuvs-java-build:
-  uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
-  with:
-    # existing build inputs omitted
-    artifact-name: cuvs-java-cuda12.9.1
-    file_to_upload: java/cuvs-java/target/
-    release-build-output: >-
-      {
-        "artifact_type": "custom",
-        "component_id": "maven:cuvs-java",
-        "output_directory": "java/cuvs-java/target",
-        "package_file": "cuvs-java.release-package.json",
-        "artifacts": [{"path": "cuvs-java-*-x86_64-cuda*.jar"}]
-      }
-```
-
-The release coordinator downloads both artifacts into the same directory, for
-example `release-build-outputs/cuvs-java/cuda12.9.1/`. The resulting tree has
-one `release-build-output.json` per producer job and is consumed directly by
-`rapids-release shadow file`. It does not require Artifactory.
-
-The companion artifact also carries `release-build-metadata.json`. It records
-the artifact identity, manifest filename, GitHub build identity, and one
-`metadata.artifacts` entry per primary artifact. Each entry explicitly sets
-`sbom_kind` to `producer-dependency` or `generated-identity`. SBOM and
-provenance paths remain authoritative in `release-build-output.json`; supplied
-sidecars are copied under `release-evidence/` so the companion is independently
-self-contained.
-
-When no SBOM is selected, the action generates an SPDX artifact-identity
-envelope containing package identity and the primary artifact SHA-256. It is
-classified as `generated-identity`, contains no dependency inventory, and must
-not be reported as a producer-supplied dependency SBOM. A descriptor-selected
-producer SBOM is instead classified as `producer-dependency`.
-
-The cross-repository enrollment inventory, blockers, and proposed PR sequence
-are maintained in
-[`rapidsai/build-infra#381`](https://github.com/rapidsai/build-infra/issues/381).
+See the
+[`shared-actions` release-build-output documentation](https://github.com/rapidsai/shared-actions/tree/main/release-build-output)
+for the companion layout, configuration schema, examples, and evidence
+semantics. A generated identity-only SPDX record identifies and hashes an
+artifact, but does not provide dependency or source-license coverage.
 
 ### matrix_filter
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,67 @@ Reusable workflows must be placed in the `.github/workflows` directory as mentio
 
 ## Usage
 
+### release-build-output
+
+Release build-output companions are created inside the producer job by the
+[`release-build-output-dispatch`](https://github.com/rapidsai/shared-actions/tree/main/release-build-output-dispatch)
+shared action. Running beside the build keeps the producer's matrix,
+source-artifact name, and original files authoritative and avoids a second
+runner and artifact download.
+
+The standard wheel and Conda builders create a companion for every uploaded
+bundle. The release unit defaults to `wheel:<repository-name>` or
+`conda:<repository-name>` and can be overridden with `release-unit` when the
+release-platform catalog uses a different ID. The shared action reads exact
+package metadata from the built files and uploads
+`release-build-output-<artifact-name>`. No release-specific caller
+configuration is required for the standard builders.
+
+`custom-job.yaml` remains explicitly opt-in through `release-build-output` and
+also requires `release-unit`, `release-output-directory`, `release-artifacts`,
+and either `release-package` or
+`release-package-file`. Descriptors may name producer-supplied SBOM,
+provenance, and signature sidecars relative to the output directory. Each path
+or glob must resolve to exactly one file; the action never guesses a release
+artifact.
+
+```yaml
+cuvs-java-build:
+  uses: rapidsai/shared-workflows/.github/workflows/custom-job.yaml@main
+  with:
+    # existing build inputs omitted
+    artifact-name: cuvs-java-cuda12.9.1
+    file_to_upload: java/cuvs-java/target/
+    release-build-output: true
+    release-output-directory: java/cuvs-java/target
+    release-unit: maven:cuvs-java
+    release-package-file: cuvs-java.release-package.json
+    release-artifacts: '[{"path":"cuvs-java-*-x86_64-cuda*.jar"}]'
+```
+
+The release coordinator downloads both artifacts into the same directory, for
+example `release-build-outputs/cuvs-java/cuda12.9.1/`. The resulting tree has
+one `release-build-output.json` per producer job and is consumed directly by
+`rapids-release shadow file`. It does not require Artifactory.
+
+The companion artifact also carries `release-build-metadata.json`. It records
+the artifact identity, manifest filename, GitHub build identity, and one
+`metadata.artifacts` entry per primary artifact. Each entry explicitly sets
+`sbom_kind` to `producer-dependency` or `generated-identity`. SBOM and
+provenance paths remain authoritative in `release-build-output.json`; supplied
+sidecars are copied under `release-evidence/` so the companion is independently
+self-contained.
+
+When no SBOM is selected, the action generates an SPDX artifact-identity
+envelope containing package identity and the primary artifact SHA-256. It is
+classified as `generated-identity`, contains no dependency inventory, and must
+not be reported as a producer-supplied dependency SBOM. A descriptor-selected
+producer SBOM is instead classified as `producer-dependency`.
+
+The cross-repository enrollment inventory, blockers, and proposed PR sequence
+are maintained in
+[`rapidsai/build-infra#381`](https://github.com/rapidsai/build-infra/issues/381).
+
 ### matrix_filter
 
 Several of the workflows in this project have matrices (combinations of workflow inputs) expressed in inline YAML/JSON.

--- a/README.md
+++ b/README.md
@@ -97,22 +97,21 @@ wheel-tests:
 
 Values passed through `secrets:` are redacted everywhere in the GitHub UI, including in logs, and in most cases are replaced with `***`.
 
-### Release build outputs
+### Release catalog
 
 We add additional metadata files to our builds to help track what dependencies
 were present at build time (a Software Bill of Materials, SBoM), as well as
 keeping track of artifacts as we prepare for releases. The standard Conda and
 wheel builders do this automatically and upload an additional
-`release-build-output-<artifact-name>` GitHub Actions artifact for every package
+`release-catalog-<artifact-name>` GitHub Actions artifact for every package
 bundle.
 
 `custom-job.yaml` can be used to produce artifacts, but the generation of extra
 metadata files are opt-in, not automatic. Supplying a non-empty
 `release-catalog-config` causes the job to upload the additional
-release-build-output artifact; leaving it empty uploads only the original
-artifact.
+release catalog companion; leaving it empty uploads only the original artifact.
 
 See the
-[`shared-actions` release-build-output documentation](https://github.com/rapidsai/shared-actions/tree/main/release-build-output)
+[`shared-actions` release catalog documentation](https://github.com/rapidsai/shared-actions/tree/main/release-catalog)
 for the companion layout, configuration schema, examples, and evidence
 semantics.


### PR DESCRIPTION
**Posted by Codex (GPT-5) on behalf of [@msarahan](https://github.com/msarahan). This pull request description is LLM-generated; readers should treat its content accordingly.**

## Why

Candidate-first releases need an immutable record of the exact bytes produced by CI, rather than requiring a release coordinator to reconstruct a package list and download artifacts later. This adds a release catalog companion beside each existing build artifact so the release platform can collect the already-built packages, their source revision, and available evidence from the exact workflow run.

## What changes

- Conda C++, Conda Python, and wheel producers upload a `release-catalog-<source-artifact-name>` companion whenever they upload their normal source artifact.
- Standard producers set `release_catalog_key` to `conda:<repository-name>` or `wheel:<repository-name>`, pass their producer output as `artifact_directory`, and let the action discover and parse every built package independently.
- `custom-job.yaml` remains opt-in through the `release-catalog-config` reusable-workflow input. An empty value disables catalog generation; a producer passes one JSON object when its uploaded bundle is a publishable release artifact set.
- Explicit artifact descriptors carry their own identity and evidence references. Parseable Conda and wheel artifacts derive identity from the package itself; other artifacts provide `package_identity_file` on that artifact's descriptor.
- Each companion contains one enveloped `release-catalog-entries.json` and available provenance, signature, and SBOM sidecars without changing the producer's existing artifact bundle.

Configuration is validated against the [`shared-actions` release catalog schema](https://github.com/rapidsai/shared-actions/blob/ed0c8f1fdeeff3348e50ea8fe5032c74b18542a7/release-catalog/config.schema.json) before artifacts are inspected.

The workflows pass `source-sha: ${{ env.RAPIDS_SHA }}` to the action. `RAPIDS_SHA` is populated from the caller-provided checkout SHA when available and otherwise falls back to `git rev-parse HEAD`, so the catalog records the revision actually checked out by the build.

Standard Conda and wheel callers need no release-specific artifact selection. Multiple packages built by the same repository share its repository-level catalog key unless they have independently managed versioning, validation, dependency ordering, publication destination, or promotion strategy.

Tracks [`rapidsai/build-infra#381`](https://github.com/rapidsai/build-infra/issues/381).
