### PR TITLE
X-ORG-596: Only publish numeric version of docs

### DIFF
--- a/.github/workflows/publish-api-docs.yaml
+++ b/.github/workflows/publish-api-docs.yaml
@@ -110,15 +110,6 @@ jobs:
         run: |
           echo rapids-version-major-minor="$(rapids-version-major-minor)" >> "${GITHUB_OUTPUT}"
 
-      - name: Resolve VERSION tag
-        id: version-tag
-        env:
-          RAPIDS_VERSION_MAJOR_MINOR: ${{ steps.version.outputs.rapids-version-major-minor }}
-          VERSION_MAP: ${{ inputs.version-map }}
-        run: |
-          tag="$(echo "${VERSION_MAP}" | jq -r --arg v "${RAPIDS_VERSION_MAJOR_MINOR}" '.[$v] // ""')"
-          echo "rapids-version-tag=${tag}" >> "${GITHUB_OUTPUT}"
-
       - name: Compute Akamai request name
         id: akamai
         env:
@@ -160,64 +151,4 @@ jobs:
           target-aws-secret-access-key: ${{ secrets.target-aws-secret-access-key }}
           target-s3-bucket: ${{ secrets.target-s3-bucket }}
           target-s3-key-suffix: ${{ steps.version.outputs.rapids-version-major-minor }}
-          target-s3-key: ${{ matrix.project }}
-
-      # publish <project>/<tag> (e.g. stable, legacy) if in version map
-      - name: Publish tagged version to docs.nvidia.com
-        if: steps.version-tag.outputs.rapids-version-tag != '' && startsWith(github.ref_name, 'release/')
-        uses: rapidsai/shared-actions/publish-docs@main
-        with:
-          akamai-access-token: ${{ secrets.akamai-access-token }}
-          akamai-client-secret: ${{ secrets.akamai-client-secret }}
-          akamai-client-token: ${{ secrets.akamai-client-token }}
-          akamai-emails-to-notify: ${{ secrets.akamai-emails-to-notify }}
-          akamai-host: ${{ secrets.akamai-host }}
-          akamai-request-name: ${{ steps.akamai.outputs.request-name }}-${{ steps.version-tag.outputs.rapids-version-tag }}
-          dry-run: ${{ inputs.dry-run }}
-          source-path: ${{ inputs.source-path }}
-          target-aws-access-key-id: ${{ secrets.target-aws-access-key-id }}
-          target-aws-region: ${{ secrets.target-aws-region }}
-          target-aws-secret-access-key: ${{ secrets.target-aws-secret-access-key }}
-          target-s3-bucket: ${{ secrets.target-s3-bucket }}
-          target-s3-key-suffix: ${{ steps.version-tag.outputs.rapids-version-tag }}
-          target-s3-key: ${{ matrix.project }}
-
-      # publish <project>/latest if main, same as nightly
-      - name: Publish "latest" version to docs.nvidia.com
-        if: github.ref_name == 'main'
-        uses: rapidsai/shared-actions/publish-docs@main
-        with:
-          akamai-access-token: ${{ secrets.akamai-access-token }}
-          akamai-client-secret: ${{ secrets.akamai-client-secret }}
-          akamai-client-token: ${{ secrets.akamai-client-token }}
-          akamai-emails-to-notify: ${{ secrets.akamai-emails-to-notify }}
-          akamai-host: ${{ secrets.akamai-host }}
-          akamai-request-name: ${{ steps.akamai.outputs.request-name }}-latest
-          dry-run: ${{ inputs.dry-run }}
-          source-path: ${{ inputs.source-path }}
-          target-aws-access-key-id: ${{ secrets.target-aws-access-key-id }}
-          target-aws-region: ${{ secrets.target-aws-region }}
-          target-aws-secret-access-key: ${{ secrets.target-aws-secret-access-key }}
-          target-s3-bucket: ${{ secrets.target-s3-bucket }}
-          target-s3-key-suffix: latest
-          target-s3-key: ${{ matrix.project }}
-
-      # publish <project>/nightly if main
-      - name: Publish "nightly" version to docs.nvidia.com
-        if: github.ref_name == 'main'
-        uses: rapidsai/shared-actions/publish-docs@main
-        with:
-          akamai-access-token: ${{ secrets.akamai-access-token }}
-          akamai-client-secret: ${{ secrets.akamai-client-secret }}
-          akamai-client-token: ${{ secrets.akamai-client-token }}
-          akamai-emails-to-notify: ${{ secrets.akamai-emails-to-notify }}
-          akamai-host: ${{ secrets.akamai-host }}
-          akamai-request-name: ${{ steps.akamai.outputs.request-name }}-nightly
-          dry-run: ${{ inputs.dry-run }}
-          source-path: ${{ inputs.source-path }}
-          target-aws-access-key-id: ${{ secrets.target-aws-access-key-id }}
-          target-aws-region: ${{ secrets.target-aws-region }}
-          target-aws-secret-access-key: ${{ secrets.target-aws-secret-access-key }}
-          target-s3-bucket: ${{ secrets.target-s3-bucket }}
-          target-s3-key-suffix: nightly
           target-s3-key: ${{ matrix.project }}


### PR DESCRIPTION
Contributes to #596 

For the shared workflow, let's only push the XX.YY versions of the docs to docs.nvidia.com. Pushing the friendly tags ("stable", "legacy", "nightly") is tricky to get correct when performed from a per-repo, per-branch build, so we're going to punt on that technique for this release and let it cook more.

Instead we'll use the deploy workflow (https://github.com/rapidsai/docs/pull/820) to guarantee the correct friendly tags ("stable", "legacy", "nightly") are pushed to docs.nvidia.com in a coordinated way on a daily / on-demand basis, just like for docs.rapidsai.org.

To simplify backwards-compatibility, and to leave the door open to coordinating friendly tags on a per-repo basis, I'm leaving the "version-map" input as-is. We're just going to stop using it for the time being.