### PR TITLE
Change pr-builder runner from ubuntu-latest to ubuntu-slim

### DIFF
--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   run:
-    runs-on: linux-amd64-cpu4
+    runs-on: ubuntu-slim
     steps:
       # This reusable workflow should depend on all other jobs in the calling workflow.
       - name: "Check all dependent jobs"

--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   run:
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     steps:
       # This reusable workflow should depend on all other jobs in the calling workflow.
       - name: "Check all dependent jobs"


### PR DESCRIPTION
GitHub’s `ubuntu-latest` runners are heavily backlogged, and `pr-builder` cannot run, which blocks merges. Switching to use self-hosted CPU runners should help alleviate the problem.