### PR TITLE
Backport pubish-api-docs to release/26.08

### DIFF
--- a/.github/workflows/publish-api-docs.yaml
+++ b/.github/workflows/publish-api-docs.yaml
@@ -1,0 +1,182 @@
+name: Publish API docs
+
+on:
+  workflow_call:
+    inputs:
+      dry-run:
+        default: "false"
+        description: If true, run without making any changes
+        required: false
+        type: boolean
+      source-path:
+        default: docs
+        description: Local path to download docs to
+        required: false
+        type: string
+      source-s3-bucket:
+        default: rapidsai-docs
+        description: The S3 bucket to download files from
+        required: false
+        type: string
+      source-s3-key:
+        description: The S3 key to download files from, e.g. the repo name
+        required: true
+        type: string
+      akamai-emails-to-notify:
+        default: svc-rapids@nvidia.com
+        description: Comma-delimited list of email addresses to notify
+        required: false
+        type: string
+      version-map:
+        default: '{"26.08": "legacy", "26.10": "stable"}'
+        description: JSON map of RAPIDS version to tag (e.g. stable, legacy)
+        required: false
+        type: string
+    secrets:
+      akamai-access-token:
+        description: Akamai EdgeGrid access token
+        required: true
+      akamai-client-token:
+        description: Akamai EdgeGrid client token
+        required: true
+      akamai-client-secret:
+        description: Akamai EdgeGrid client secret
+        required: true
+      akamai-host:
+        description: Akamai API hostname
+        required: true
+      target-aws-access-key-id:
+        description: AWS access key ID
+        required: true
+      target-aws-region:
+        description: AWS region
+        required: true
+      target-aws-role-to-assume:
+        description: AWS role to assume
+        required: true
+      target-aws-secret-access-key:
+        description: AWS secret access key
+        required: true
+      target-s3-bucket:
+        description: The S3 bucket to upload files to
+        required: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  publish-api-docs:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Download gha-tools with git clone
+      run: |
+        git clone https://github.com/rapidsai/gha-tools.git -b main /tmp/gha-tools
+        echo "/tmp/gha-tools/tools" >> "${GITHUB_PATH}"
+
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        path: /tmp/repo
+
+    - name: Read VERSION file
+      id: version
+      working-directory: /tmp/repo
+      run: |
+        echo rapids-version-major-minor="$(rapids-version-major-minor)" >> "${GITHUB_OUTPUT}"
+
+    - name: Resolve VERSION tag
+      id: version-tag
+      env:
+        RAPIDS_VERSION_MAJOR_MINOR: ${{ steps.version.outputs.rapids-version-major-minor }}
+        VERSION_MAP: ${{ inputs.version-map }}
+      run: |
+        tag="$(echo "${VERSION_MAP}" | jq -r --arg v "${RAPIDS_VERSION_MAJOR_MINOR}" '.[$v] // ""')"
+        echo "rapids-version-tag=${tag}" >> "${GITHUB_OUTPUT}"
+
+    - name: Compute Akamai request name
+      id: akamai
+      env:
+        REPO: ${{ github.repository }}
+        RUN_ID: ${{ github.run_id }}
+      run: |
+        name="$(echo "${REPO}" | tr '[:upper:]' '[:lower:]' | tr '/' '-')-${RUN_ID}"
+        echo "request-name=${name}" >> "${GITHUB_OUTPUT}"
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+      with:
+        aws-region: ${{ vars.AWS_REGION }}
+        role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+
+    - name: Download docs
+      env:
+        S3_BUCKET: ${{ inputs.source-s3-bucket }}
+        S3_KEY: ${{ inputs.source-s3-key }}
+        S3_KEY_SUFFIX: ${{ steps.version.outputs.rapids-version-major-minor }}
+        SOURCE_PATH: ${{ inputs.source-path }}
+      run: |
+        aws s3 sync "s3://${S3_BUCKET}/${S3_KEY}/${S3_KEY_SUFFIX}" "${SOURCE_PATH}"
+
+    # publish <project>/<version>
+    - name: Publish version to docs.nvidia.com
+      uses: rapidsai/shared-actions/publish-docs@main
+      with:
+        akamai-access-token: ${{ secrets.akamai-access-token }}
+        akamai-client-secret: ${{ secrets.akamai-client-secret }}
+        akamai-client-token: ${{ secrets.akamai-client-token }}
+        akamai-emails-to-notify: ${{ inputs.akamai-emails-to-notify }}
+        akamai-host: ${{ secrets.akamai-host }}
+        akamai-request-name: ${{ steps.akamai.outputs.request-name }}-${{ steps.version.outputs.rapids-version-major-minor }}
+        dry-run: ${{ inputs.dry-run }}
+        source-path: ${{ inputs.source-path }}
+        target-aws-access-key-id: ${{ secrets.target-aws-access-key-id }}
+        target-aws-region: ${{ secrets.target-aws-region }}
+        target-aws-role-to-assume: ${{ secrets.target-aws-role-to-assume }}
+        target-aws-secret-access-key: ${{ secrets.target-aws-secret-access-key }}
+        target-s3-bucket: ${{ secrets.target-s3-bucket }}
+        target-s3-key-suffix: ${{ steps.version.outputs.rapids-version-major-minor }}
+        target-s3-key: ${{ inputs.source-s3-key }}
+
+    # publish <project>/nightly
+    - name: Publish nightly to docs.nvidia.com
+      if: github.ref_name == 'main'
+      uses: rapidsai/shared-actions/publish-docs@main
+      with:
+        akamai-access-token: ${{ secrets.akamai-access-token }}
+        akamai-client-secret: ${{ secrets.akamai-client-secret }}
+        akamai-client-token: ${{ secrets.akamai-client-token }}
+        akamai-emails-to-notify: ${{ inputs.akamai-emails-to-notify }}
+        akamai-host: ${{ secrets.akamai-host }}
+        akamai-request-name: ${{ steps.akamai.outputs.request-name }}-nightly
+        dry-run: ${{ inputs.dry-run }}
+        source-path: ${{ inputs.source-path }}
+        target-aws-access-key-id: ${{ secrets.target-aws-access-key-id }}
+        target-aws-region: ${{ secrets.target-aws-region }}
+        target-aws-role-to-assume: ${{ secrets.target-aws-role-to-assume }}
+        target-aws-secret-access-key: ${{ secrets.target-aws-secret-access-key }}
+        target-s3-bucket: ${{ secrets.target-s3-bucket }}
+        target-s3-key-suffix: nightly
+        target-s3-key: ${{ inputs.source-s3-key }}
+
+    # publish <project>/<tag> (e.g. stable, legacy)
+    - name: Publish tagged version to docs.nvidia.com
+      if: steps.version-tag.outputs.rapids-version-tag != '' && startsWith(github.ref_name, 'release/')
+      uses: rapidsai/shared-actions/publish-docs@main
+      with:
+        akamai-access-token: ${{ secrets.akamai-access-token }}
+        akamai-client-secret: ${{ secrets.akamai-client-secret }}
+        akamai-client-token: ${{ secrets.akamai-client-token }}
+        akamai-emails-to-notify: ${{ inputs.akamai-emails-to-notify }}
+        akamai-host: ${{ secrets.akamai-host }}
+        akamai-request-name: ${{ steps.akamai.outputs.request-name }}-${{ steps.version-tag.outputs.rapids-version-tag }}
+        dry-run: ${{ inputs.dry-run }}
+        source-path: ${{ inputs.source-path }}
+        target-aws-access-key-id: ${{ secrets.target-aws-access-key-id }}
+        target-aws-region: ${{ secrets.target-aws-region }}
+        target-aws-role-to-assume: ${{ secrets.target-aws-role-to-assume }}
+        target-aws-secret-access-key: ${{ secrets.target-aws-secret-access-key }}
+        target-s3-bucket: ${{ secrets.target-s3-bucket }}
+        target-s3-key-suffix: ${{ steps.version-tag.outputs.rapids-version-tag }}
+        target-s3-key: ${{ inputs.source-s3-key }}

--- a/.github/workflows/publish-api-docs.yaml
+++ b/.github/workflows/publish-api-docs.yaml
@@ -36,7 +36,7 @@ on:
         type: string
       version-map:
         description: |
-          JSON map of tag to RAPIDS version, e.g. '{"stable": "26.08", "nightly": "26.10"}'
+          JSON map of tag to library version, e.g. '{"stable": "26.08", "nightly": "26.10"}'
         required: true
         type: string
     secrets:

--- a/.github/workflows/publish-api-docs.yaml
+++ b/.github/workflows/publish-api-docs.yaml
@@ -36,7 +36,7 @@ on:
         type: string
       version-map:
         description: |
-          JSON map of RAPIDS version to tag, e.g. '{"26.08": "legacy", "26.10": "stable"}'
+          JSON map of tag to RAPIDS version, e.g. '{"stable": "26.08", "nightly": "26.10"}'
         required: true
         type: string
     secrets:
@@ -113,10 +113,11 @@ jobs:
       - name: Compute Akamai request name
         id: akamai
         env:
+          PROJECT: ${{ matrix.project }}
           REPO: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}
         run: |
-          name="$(echo "${REPO}" | tr '[:upper:]' '[:lower:]' | tr '/' '-')-${RUN_ID}"
+          name="$(echo "${REPO}" | tr '[:upper:]' '[:lower:]' | tr '/' '-')-${RUN_ID}-${PROJECT}"
           echo "request-name=${name}" >> "${GITHUB_OUTPUT}"
 
       - name: Configure AWS credentials
@@ -151,4 +152,63 @@ jobs:
           target-aws-secret-access-key: ${{ secrets.target-aws-secret-access-key }}
           target-s3-bucket: ${{ secrets.target-s3-bucket }}
           target-s3-key-suffix: ${{ steps.version.outputs.rapids-version-major-minor }}
+          target-s3-key: ${{ matrix.project }}
+
+  publish-versions-json:
+    needs: compute-matrix
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ inputs.container-image }} # zizmor: ignore[unpinned-images]
+      options: ${{ inputs.container-options }}
+    strategy:
+      fail-fast: false
+      matrix:
+        project: ${{ fromJSON(needs.compute-matrix.outputs.matrix) }}
+    steps:
+
+      - name: Generate versions.json
+        env:
+          PROJECT: ${{ matrix.project }}
+          VERSION_MAP: ${{ inputs.version-map }}
+        run: |
+          jq -n -S \
+            --arg project "${PROJECT}" \
+            --argjson map "${VERSION_MAP}" \
+            '
+              $map
+              | to_entries
+              | map({
+                  name: "\(.value) (\(.key))",
+                  url: "https://docs.nvidia.com/\($project)/\(.value)/",
+                  version: .value
+                } + (if .key == "stable" then {preferred: true} else {}end))
+              | sort_by(.version)
+              | reverse
+            ' > versions.json
+
+      - name: Compute Akamai request name
+        id: akamai
+        env:
+          PROJECT: ${{ matrix.project }}
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          name="$(echo "${REPO}" | tr '[:upper:]' '[:lower:]' | tr '/' '-')-${RUN_ID}-${PROJECT}-versions-json"
+          echo "request-name=${name}" >> "${GITHUB_OUTPUT}"
+
+      - name: Publish versions.json
+        uses: rapidsai/shared-actions/publish-one-doc@josephine/x-org-138-publish-one-doc
+        with:
+          akamai-access-token: ${{ secrets.akamai-access-token }}
+          akamai-client-secret: ${{ secrets.akamai-client-secret }}
+          akamai-client-token: ${{ secrets.akamai-client-token }}
+          akamai-emails-to-notify: ${{ secrets.akamai-emails-to-notify }}
+          akamai-host: ${{ secrets.akamai-host }}
+          akamai-request-name: ${{ steps.akamai.outputs.request-name }}-versions
+          dry-run: ${{ inputs.dry-run }}
+          file-path: ./versions.json
+          target-aws-access-key-id: ${{ secrets.target-aws-access-key-id }}
+          target-aws-region: ${{ secrets.target-aws-region }}
+          target-aws-secret-access-key: ${{ secrets.target-aws-secret-access-key }}
+          target-s3-bucket: ${{ secrets.target-s3-bucket }}
           target-s3-key: ${{ matrix.project }}

--- a/.github/workflows/publish-api-docs.yaml
+++ b/.github/workflows/publish-api-docs.yaml
@@ -185,6 +185,7 @@ jobs:
               | sort_by(.version)
               | reverse
             ' > versions.json
+          cat versions.json
 
       - name: Compute Akamai request name
         id: akamai

--- a/.github/workflows/publish-api-docs.yaml
+++ b/.github/workflows/publish-api-docs.yaml
@@ -3,6 +3,11 @@ name: Publish API docs
 on:
   workflow_call:
     inputs:
+      akamai-emails-to-notify:
+        default: svc-rapids@nvidia.com
+        description: Comma-delimited list of email addresses to notify
+        required: false
+        type: string
       dry-run:
         default: "false"
         description: If true, run without making any changes
@@ -21,11 +26,6 @@ on:
       source-s3-key:
         description: The S3 key to download files from, e.g. the repo name
         required: true
-        type: string
-      akamai-emails-to-notify:
-        default: svc-rapids@nvidia.com
-        description: Comma-delimited list of email addresses to notify
-        required: false
         type: string
       version-map:
         default: '{"26.08": "legacy", "26.10": "stable"}'

--- a/.github/workflows/publish-api-docs.yaml
+++ b/.github/workflows/publish-api-docs.yaml
@@ -28,9 +28,9 @@ on:
         required: true
         type: string
       version-map:
-        default: '{"26.08": "legacy", "26.10": "stable"}'
-        description: JSON map of RAPIDS version to tag (e.g. stable, legacy)
-        required: false
+        description: |
+          JSON map of RAPIDS version to tag, e.g. '{"26.08": "legacy", "26.10": "stable"}'
+        required: true
         type: string
     secrets:
       akamai-access-token:

--- a/.github/workflows/publish-api-docs.yaml
+++ b/.github/workflows/publish-api-docs.yaml
@@ -98,126 +98,57 @@ jobs:
         project: ${{ fromJSON(needs.compute-matrix.outputs.matrix) }}
     steps:
 
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        path: repo
-        persist-credentials: false
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          path: repo
+          persist-credentials: false
 
-    - name: Read VERSION file
-      id: version
-      working-directory: repo
-      run: |
-        echo rapids-version-major-minor="$(rapids-version-major-minor)" >> "${GITHUB_OUTPUT}"
+      - name: Read VERSION file
+        id: version
+        working-directory: repo
+        run: |
+          echo rapids-version-major-minor="$(rapids-version-major-minor)" >> "${GITHUB_OUTPUT}"
 
-    - name: Resolve VERSION tag
-      id: version-tag
-      env:
-        RAPIDS_VERSION_MAJOR_MINOR: ${{ steps.version.outputs.rapids-version-major-minor }}
-        VERSION_MAP: ${{ inputs.version-map }}
-      run: |
-        tag="$(echo "${VERSION_MAP}" | jq -r --arg v "${RAPIDS_VERSION_MAJOR_MINOR}" '.[$v] // ""')"
-        echo "rapids-version-tag=${tag}" >> "${GITHUB_OUTPUT}"
+      - name: Compute Akamai request name
+        id: akamai
+        env:
+          REPO: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          name="$(echo "${REPO}" | tr '[:upper:]' '[:lower:]' | tr '/' '-')-${RUN_ID}"
+          echo "request-name=${name}" >> "${GITHUB_OUTPUT}"
 
-    - name: Compute Akamai request name
-      id: akamai
-      env:
-        REPO: ${{ github.repository }}
-        RUN_ID: ${{ github.run_id }}
-      run: |
-        name="$(echo "${REPO}" | tr '[:upper:]' '[:lower:]' | tr '/' '-')-${RUN_ID}"
-        echo "request-name=${name}" >> "${GITHUB_OUTPUT}"
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
+        with:
+          aws-region: ${{ vars.AWS_REGION }}
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
 
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
-      with:
-        aws-region: ${{ vars.AWS_REGION }}
-        role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+      - name: Download docs
+        env:
+          S3_BUCKET: ${{ inputs.source-s3-bucket }}
+          S3_KEY: ${{ matrix.project }}
+          S3_KEY_SUFFIX: ${{ steps.version.outputs.rapids-version-major-minor }}
+          SOURCE_PATH: ${{ inputs.source-path }}
+        run: |
+          aws s3 sync "s3://${S3_BUCKET}/${S3_KEY}/html/${S3_KEY_SUFFIX}" "${SOURCE_PATH}"
 
-    - name: Download docs
-      env:
-        S3_BUCKET: ${{ inputs.source-s3-bucket }}
-        S3_KEY: ${{ matrix.project }}
-        S3_KEY_SUFFIX: ${{ steps.version.outputs.rapids-version-major-minor }}
-        SOURCE_PATH: ${{ inputs.source-path }}
-      run: |
-        aws s3 sync "s3://${S3_BUCKET}/${S3_KEY}/html/${S3_KEY_SUFFIX}" "${SOURCE_PATH}"
-
-    # publish <project>/<version>
-    - name: Publish numeric version to docs.nvidia.com
-      uses: rapidsai/shared-actions/publish-docs@main
-      with:
-        akamai-access-token: ${{ secrets.akamai-access-token }}
-        akamai-client-secret: ${{ secrets.akamai-client-secret }}
-        akamai-client-token: ${{ secrets.akamai-client-token }}
-        akamai-emails-to-notify: ${{ secrets.akamai-emails-to-notify }}
-        akamai-host: ${{ secrets.akamai-host }}
-        akamai-request-name: ${{ steps.akamai.outputs.request-name }}-${{ steps.version.outputs.rapids-version-major-minor }}
-        dry-run: ${{ inputs.dry-run }}
-        source-path: ${{ inputs.source-path }}
-        target-aws-access-key-id: ${{ secrets.target-aws-access-key-id }}
-        target-aws-region: ${{ secrets.target-aws-region }}
-        target-aws-secret-access-key: ${{ secrets.target-aws-secret-access-key }}
-        target-s3-bucket: ${{ secrets.target-s3-bucket }}
-        target-s3-key-suffix: ${{ steps.version.outputs.rapids-version-major-minor }}
-        target-s3-key: ${{ matrix.project }}
-
-    # publish <project>/<tag> (e.g. stable, legacy) if in version map
-    - name: Publish tagged version to docs.nvidia.com
-      if: steps.version-tag.outputs.rapids-version-tag != '' && startsWith(github.ref_name, 'release/')
-      uses: rapidsai/shared-actions/publish-docs@main
-      with:
-        akamai-access-token: ${{ secrets.akamai-access-token }}
-        akamai-client-secret: ${{ secrets.akamai-client-secret }}
-        akamai-client-token: ${{ secrets.akamai-client-token }}
-        akamai-emails-to-notify: ${{ secrets.akamai-emails-to-notify }}
-        akamai-host: ${{ secrets.akamai-host }}
-        akamai-request-name: ${{ steps.akamai.outputs.request-name }}-${{ steps.version-tag.outputs.rapids-version-tag }}
-        dry-run: ${{ inputs.dry-run }}
-        source-path: ${{ inputs.source-path }}
-        target-aws-access-key-id: ${{ secrets.target-aws-access-key-id }}
-        target-aws-region: ${{ secrets.target-aws-region }}
-        target-aws-secret-access-key: ${{ secrets.target-aws-secret-access-key }}
-        target-s3-bucket: ${{ secrets.target-s3-bucket }}
-        target-s3-key-suffix: ${{ steps.version-tag.outputs.rapids-version-tag }}
-        target-s3-key: ${{ matrix.project }}
-
-    # publish <project>/latest if main, same as nightly
-    - name: Publish "latest" version to docs.nvidia.com
-      if: github.ref_name == 'main'
-      uses: rapidsai/shared-actions/publish-docs@main
-      with:
-        akamai-access-token: ${{ secrets.akamai-access-token }}
-        akamai-client-secret: ${{ secrets.akamai-client-secret }}
-        akamai-client-token: ${{ secrets.akamai-client-token }}
-        akamai-emails-to-notify: ${{ secrets.akamai-emails-to-notify }}
-        akamai-host: ${{ secrets.akamai-host }}
-        akamai-request-name: ${{ steps.akamai.outputs.request-name }}-latest
-        dry-run: ${{ inputs.dry-run }}
-        source-path: ${{ inputs.source-path }}
-        target-aws-access-key-id: ${{ secrets.target-aws-access-key-id }}
-        target-aws-region: ${{ secrets.target-aws-region }}
-        target-aws-secret-access-key: ${{ secrets.target-aws-secret-access-key }}
-        target-s3-bucket: ${{ secrets.target-s3-bucket }}
-        target-s3-key-suffix: latest
-        target-s3-key: ${{ matrix.project }}
-
-    # publish <project>/nightly if main
-    - name: Publish "nightly" version to docs.nvidia.com
-      if: github.ref_name == 'main'
-      uses: rapidsai/shared-actions/publish-docs@main
-      with:
-        akamai-access-token: ${{ secrets.akamai-access-token }}
-        akamai-client-secret: ${{ secrets.akamai-client-secret }}
-        akamai-client-token: ${{ secrets.akamai-client-token }}
-        akamai-emails-to-notify: ${{ secrets.akamai-emails-to-notify }}
-        akamai-host: ${{ secrets.akamai-host }}
-        akamai-request-name: ${{ steps.akamai.outputs.request-name }}-nightly
-        dry-run: ${{ inputs.dry-run }}
-        source-path: ${{ inputs.source-path }}
-        target-aws-access-key-id: ${{ secrets.target-aws-access-key-id }}
-        target-aws-region: ${{ secrets.target-aws-region }}
-        target-aws-secret-access-key: ${{ secrets.target-aws-secret-access-key }}
-        target-s3-bucket: ${{ secrets.target-s3-bucket }}
-        target-s3-key-suffix: nightly
-        target-s3-key: ${{ matrix.project }}
+      # publish <project>/<version>
+      - name: Publish numeric version to docs.nvidia.com
+        uses: rapidsai/shared-actions/publish-docs@main
+        with:
+          akamai-access-token: ${{ secrets.akamai-access-token }}
+          akamai-client-secret: ${{ secrets.akamai-client-secret }}
+          akamai-client-token: ${{ secrets.akamai-client-token }}
+          akamai-emails-to-notify: ${{ secrets.akamai-emails-to-notify }}
+          akamai-host: ${{ secrets.akamai-host }}
+          akamai-request-name: ${{ steps.akamai.outputs.request-name }}-${{ steps.version.outputs.rapids-version-major-minor }}
+          dry-run: ${{ inputs.dry-run }}
+          source-path: ${{ inputs.source-path }}
+          target-aws-access-key-id: ${{ secrets.target-aws-access-key-id }}
+          target-aws-region: ${{ secrets.target-aws-region }}
+          target-aws-secret-access-key: ${{ secrets.target-aws-secret-access-key }}
+          target-s3-bucket: ${{ secrets.target-s3-bucket }}
+          target-s3-key-suffix: ${{ steps.version.outputs.rapids-version-major-minor }}
+          target-s3-key: ${{ matrix.project }}

--- a/.github/workflows/publish-api-docs.yaml
+++ b/.github/workflows/publish-api-docs.yaml
@@ -79,6 +79,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: /tmp/repo
+        persist-credentials: false
 
     - name: Read VERSION file
       id: version

--- a/.github/workflows/publish-api-docs.yaml
+++ b/.github/workflows/publish-api-docs.yaml
@@ -3,13 +3,24 @@ name: Publish API docs
 on:
   workflow_call:
     inputs:
-      akamai-emails-to-notify:
-        default: svc-rapids@nvidia.com
-        description: Comma-delimited list of email addresses to notify
+      container-image:
+        description: Container image URI
+        type: string
+        default: rapidsai/ci-conda:26.10-latest
+      container-options:
+        description: |
+          Command-line arguments passed to 'docker run' when starting the container this workflow runs in.
+          This should be provided as a single string to be inlined into 'docker run', not an array.
+          For example, '--quiet --ulimit nofile=2048'.
         required: false
         type: string
+        default: -e _NOOP
+      docs-projects:
+        description: Comma-delimited list of project names, e.g. "cudf,libcudf"
+        required: true
+        type: string
       dry-run:
-        default: "false"
+        default: false
         description: If true, run without making any changes
         required: false
         type: boolean
@@ -22,10 +33,6 @@ on:
         default: rapidsai-docs
         description: The S3 bucket to download files from
         required: false
-        type: string
-      source-s3-key:
-        description: The S3 key to download files from, e.g. the repo name
-        required: true
         type: string
       version-map:
         description: |
@@ -42,6 +49,9 @@ on:
       akamai-client-secret:
         description: Akamai EdgeGrid client secret
         required: true
+      akamai-emails-to-notify:
+        description: Comma-delimited list of email addresses to notify
+        required: false
       akamai-host:
         description: Akamai API hostname
         required: true
@@ -50,9 +60,6 @@ on:
         required: true
       target-aws-region:
         description: AWS region
-        required: true
-      target-aws-role-to-assume:
-        description: AWS role to assume
         required: true
       target-aws-secret-access-key:
         description: AWS secret access key
@@ -66,24 +73,40 @@ defaults:
     shell: bash
 
 jobs:
-  publish-api-docs:
+  compute-matrix:
     runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
+      - name: Set matrix
+        id: set-matrix
+        env:
+          DOCS_PROJECTS: ${{ inputs.docs-projects }}
+        run: |
+          matrix=$(echo "${DOCS_PROJECTS}" | jq -Rc 'split(",")')
+          echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
 
-    - name: Download gha-tools with git clone
-      run: |
-        git clone https://github.com/rapidsai/gha-tools.git -b main /tmp/gha-tools
-        echo "/tmp/gha-tools/tools" >> "${GITHUB_PATH}"
+  publish-api-docs:
+    needs: compute-matrix
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ inputs.container-image }} # zizmor: ignore[unpinned-images]
+      options: ${{ inputs.container-options }}
+    strategy:
+      fail-fast: false
+      matrix:
+        project: ${{ fromJSON(needs.compute-matrix.outputs.matrix) }}
+    steps:
 
     - name: Checkout
       uses: actions/checkout@v4
       with:
-        path: /tmp/repo
+        path: repo
         persist-credentials: false
 
     - name: Read VERSION file
       id: version
-      working-directory: /tmp/repo
+      working-directory: repo
       run: |
         echo rapids-version-major-minor="$(rapids-version-major-minor)" >> "${GITHUB_OUTPUT}"
 
@@ -114,54 +137,32 @@ jobs:
     - name: Download docs
       env:
         S3_BUCKET: ${{ inputs.source-s3-bucket }}
-        S3_KEY: ${{ inputs.source-s3-key }}
+        S3_KEY: ${{ matrix.project }}
         S3_KEY_SUFFIX: ${{ steps.version.outputs.rapids-version-major-minor }}
         SOURCE_PATH: ${{ inputs.source-path }}
       run: |
-        aws s3 sync "s3://${S3_BUCKET}/${S3_KEY}/${S3_KEY_SUFFIX}" "${SOURCE_PATH}"
+        aws s3 sync "s3://${S3_BUCKET}/${S3_KEY}/html/${S3_KEY_SUFFIX}" "${SOURCE_PATH}"
 
     # publish <project>/<version>
-    - name: Publish version to docs.nvidia.com
+    - name: Publish numeric version to docs.nvidia.com
       uses: rapidsai/shared-actions/publish-docs@main
       with:
         akamai-access-token: ${{ secrets.akamai-access-token }}
         akamai-client-secret: ${{ secrets.akamai-client-secret }}
         akamai-client-token: ${{ secrets.akamai-client-token }}
-        akamai-emails-to-notify: ${{ inputs.akamai-emails-to-notify }}
+        akamai-emails-to-notify: ${{ secrets.akamai-emails-to-notify }}
         akamai-host: ${{ secrets.akamai-host }}
         akamai-request-name: ${{ steps.akamai.outputs.request-name }}-${{ steps.version.outputs.rapids-version-major-minor }}
         dry-run: ${{ inputs.dry-run }}
         source-path: ${{ inputs.source-path }}
         target-aws-access-key-id: ${{ secrets.target-aws-access-key-id }}
         target-aws-region: ${{ secrets.target-aws-region }}
-        target-aws-role-to-assume: ${{ secrets.target-aws-role-to-assume }}
         target-aws-secret-access-key: ${{ secrets.target-aws-secret-access-key }}
         target-s3-bucket: ${{ secrets.target-s3-bucket }}
         target-s3-key-suffix: ${{ steps.version.outputs.rapids-version-major-minor }}
-        target-s3-key: ${{ inputs.source-s3-key }}
+        target-s3-key: ${{ matrix.project }}
 
-    # publish <project>/nightly
-    - name: Publish nightly to docs.nvidia.com
-      if: github.ref_name == 'main'
-      uses: rapidsai/shared-actions/publish-docs@main
-      with:
-        akamai-access-token: ${{ secrets.akamai-access-token }}
-        akamai-client-secret: ${{ secrets.akamai-client-secret }}
-        akamai-client-token: ${{ secrets.akamai-client-token }}
-        akamai-emails-to-notify: ${{ inputs.akamai-emails-to-notify }}
-        akamai-host: ${{ secrets.akamai-host }}
-        akamai-request-name: ${{ steps.akamai.outputs.request-name }}-nightly
-        dry-run: ${{ inputs.dry-run }}
-        source-path: ${{ inputs.source-path }}
-        target-aws-access-key-id: ${{ secrets.target-aws-access-key-id }}
-        target-aws-region: ${{ secrets.target-aws-region }}
-        target-aws-role-to-assume: ${{ secrets.target-aws-role-to-assume }}
-        target-aws-secret-access-key: ${{ secrets.target-aws-secret-access-key }}
-        target-s3-bucket: ${{ secrets.target-s3-bucket }}
-        target-s3-key-suffix: nightly
-        target-s3-key: ${{ inputs.source-s3-key }}
-
-    # publish <project>/<tag> (e.g. stable, legacy)
+    # publish <project>/<tag> (e.g. stable, legacy) if in version map
     - name: Publish tagged version to docs.nvidia.com
       if: steps.version-tag.outputs.rapids-version-tag != '' && startsWith(github.ref_name, 'release/')
       uses: rapidsai/shared-actions/publish-docs@main
@@ -169,15 +170,54 @@ jobs:
         akamai-access-token: ${{ secrets.akamai-access-token }}
         akamai-client-secret: ${{ secrets.akamai-client-secret }}
         akamai-client-token: ${{ secrets.akamai-client-token }}
-        akamai-emails-to-notify: ${{ inputs.akamai-emails-to-notify }}
+        akamai-emails-to-notify: ${{ secrets.akamai-emails-to-notify }}
         akamai-host: ${{ secrets.akamai-host }}
         akamai-request-name: ${{ steps.akamai.outputs.request-name }}-${{ steps.version-tag.outputs.rapids-version-tag }}
         dry-run: ${{ inputs.dry-run }}
         source-path: ${{ inputs.source-path }}
         target-aws-access-key-id: ${{ secrets.target-aws-access-key-id }}
         target-aws-region: ${{ secrets.target-aws-region }}
-        target-aws-role-to-assume: ${{ secrets.target-aws-role-to-assume }}
         target-aws-secret-access-key: ${{ secrets.target-aws-secret-access-key }}
         target-s3-bucket: ${{ secrets.target-s3-bucket }}
         target-s3-key-suffix: ${{ steps.version-tag.outputs.rapids-version-tag }}
-        target-s3-key: ${{ inputs.source-s3-key }}
+        target-s3-key: ${{ matrix.project }}
+
+    # publish <project>/latest if main, same as nightly
+    - name: Publish "latest" version to docs.nvidia.com
+      if: github.ref_name == 'main'
+      uses: rapidsai/shared-actions/publish-docs@main
+      with:
+        akamai-access-token: ${{ secrets.akamai-access-token }}
+        akamai-client-secret: ${{ secrets.akamai-client-secret }}
+        akamai-client-token: ${{ secrets.akamai-client-token }}
+        akamai-emails-to-notify: ${{ secrets.akamai-emails-to-notify }}
+        akamai-host: ${{ secrets.akamai-host }}
+        akamai-request-name: ${{ steps.akamai.outputs.request-name }}-latest
+        dry-run: ${{ inputs.dry-run }}
+        source-path: ${{ inputs.source-path }}
+        target-aws-access-key-id: ${{ secrets.target-aws-access-key-id }}
+        target-aws-region: ${{ secrets.target-aws-region }}
+        target-aws-secret-access-key: ${{ secrets.target-aws-secret-access-key }}
+        target-s3-bucket: ${{ secrets.target-s3-bucket }}
+        target-s3-key-suffix: latest
+        target-s3-key: ${{ matrix.project }}
+
+    # publish <project>/nightly if main
+    - name: Publish "nightly" version to docs.nvidia.com
+      if: github.ref_name == 'main'
+      uses: rapidsai/shared-actions/publish-docs@main
+      with:
+        akamai-access-token: ${{ secrets.akamai-access-token }}
+        akamai-client-secret: ${{ secrets.akamai-client-secret }}
+        akamai-client-token: ${{ secrets.akamai-client-token }}
+        akamai-emails-to-notify: ${{ secrets.akamai-emails-to-notify }}
+        akamai-host: ${{ secrets.akamai-host }}
+        akamai-request-name: ${{ steps.akamai.outputs.request-name }}-nightly
+        dry-run: ${{ inputs.dry-run }}
+        source-path: ${{ inputs.source-path }}
+        target-aws-access-key-id: ${{ secrets.target-aws-access-key-id }}
+        target-aws-region: ${{ secrets.target-aws-region }}
+        target-aws-secret-access-key: ${{ secrets.target-aws-secret-access-key }}
+        target-s3-bucket: ${{ secrets.target-s3-bucket }}
+        target-s3-key-suffix: nightly
+        target-s3-key: ${{ matrix.project }}

--- a/.github/workflows/publish-api-docs.yaml
+++ b/.github/workflows/publish-api-docs.yaml
@@ -198,7 +198,7 @@ jobs:
           echo "request-name=${name}" >> "${GITHUB_OUTPUT}"
 
       - name: Publish versions.json
-        uses: rapidsai/shared-actions/publish-one-doc@josephine/x-org-138-publish-one-doc
+        uses: rapidsai/shared-actions/publish-one-doc@main
         with:
           akamai-access-token: ${{ secrets.akamai-access-token }}
           akamai-client-secret: ${{ secrets.akamai-client-secret }}

--- a/.github/workflows/publish-api-docs.yaml
+++ b/.github/workflows/publish-api-docs.yaml
@@ -99,7 +99,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: repo
           persist-credentials: false


### PR DESCRIPTION
Let's backport the publish-api-docs workflow to release/26.08 so it can be pinned in backport PRs going out to other release/26.08 branches.

No changes in this file relative to `main`:

```
❯ git diff josephine/backport-publish-api-docs main .github/workflows/publish-api-docs.yaml
❯ echo $?
0
```